### PR TITLE
chore: scaffold monorepo as dt-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,279 @@
-# :tada: :tada: Welcome to your new Project on GitHub :tada: :tada:
+# dt-eval
 
 > **Note**
-> This product is not officially supported by Dynatrace!
+> This project is not officially supported by Dynatrace.
 
-Congratulations, your project on GitHub was successfully created and you can start your Open Source Adventure!
+Open-source evaluation toolkit for LLM observability on Dynatrace.
+Fetch GenAI traces instrumented through Dynatrace, score them with any AI judge,
+and feed structured results back into Dynatrace — with zero manual wiring.
 
-As each adventure starts with good preparations, we also have something we would like you to do upe front.
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![npm](https://img.shields.io/npm/v/dt-eval-cli)](https://www.npmjs.com/package/dt-eval-cli)
+[![Node](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-- [ ] Read this ReadMe carefully, to get an overview of the files within your project.
-- [ ] Write your own ReadMe which reflects your project
-- [ ] Check if the [default community files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)(CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md, ..) within the organization `.github`[-project](https://github.com/dynatrace-oss/.github/) match your project's needs. If not, you can always provide your own, but we kindly ask you, that you also update those from time to time.
-- [ ] Check if there is a `LICENSE` file within your project. If not, please create one containing the `Apache License 2.0`.
-- [ ] Explicitly state that this project is not officially supported by Dynatrace in your ReadMe, eg. by using following lines on top of your ReadMe:
+---
 
-    > **Note**
-    > This product is not officially supported by Dynatrace!
+## Quickstart
 
-## How can I make my project public?
+Install the CLI, run the setup wizard, then evaluate your last hour of GenAI traces:
 
-At first, the project will be private, as we (OSPO) want to ensure that you followed the guidelines and that everything is in place.
+```bash
+npm install -g dt-eval-cli
+dt-eval-cli configure
+dt-eval-cli run
+```
 
-As soon as you are done with your initial commits, you can inform OSPO and we will take a close look at the project, and set it to public if we do think all guidelines are followed.
+`configure` walks you through connecting to your Dynatrace tenant and choosing an
+AI provider (OpenAI, Anthropic, AWS Bedrock, or Google Gemini). After that, `run`
+fetches spans from Grail, scores them, and writes results back as Dynatrace
+business events — visible immediately in the AI Observability Evals tab.
 
-There is also some automation running, which will set projects, which do not follow the guidelines, to private.
+---
 
-## Provided Tools
+## Table of Contents
 
-### Markdownlint
+- [How it works](#how-it-works)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Running evals](#running-evals)
+- [Built-in eval metrics](#built-in-eval-metrics)
+- [Scheduling](#scheduling)
+- [Alerting](#alerting)
+- [Serverless deployment](#serverless-deployment)
+- [CI/CD integration](#cicd-integration)
+- [Eval result schema](#eval-result-schema)
+- [Packages](#packages)
+- [Contributing](#contributing)
 
-To make it easier for the project to keep the Markdown files in a good shape, we added `markdownlint-cli` to the project.
+---
 
-1. with a `makefile` for easier execution locally, based on docker images, so it can be used in every environment as long as `docker` and `make` are available.
-1. with a workflow for pull request verification based on the `makefile`.
+## How it works
 
-The following files are part of this integration:
+dt-eval is a pure pass-through pipeline — no prompt or response data is stored anywhere.
 
-- `makefile`: as it contains the targets for execution
-- `.markdownlint.yml`: as it contains the configuration for `markdownlint-cli`
-- `.github/workflows/makefile.yml`: as it contains the GitHub Action configuration
+```
+Dynatrace Grail (DQL)
+        │
+        ▼  fetch gen_ai.* spans
+  Trace extraction
+  + PII masking
+        │
+        ▼  build judge prompt per metric
+  AI provider
+  (OpenAI / Anthropic / Bedrock / Gemini)
+        │
+        ▼  normalized score + label + explanation
+  Dynatrace BizEvents  ──►  AI Observability Evals tab
+  Dynatrace Metrics    ──►  Davis AI alerting
+```
 
-## Licensing
+Every eval result is correlated to its source span via `trace.id` and written using
+the [OTEL GenAI evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
 
-We are using Apache License 2.0 as our default.
+---
 
-### Source Code Headers
+## Requirements
 
-Every file containing source code must include copyright and license
-information. This includes any JS/CSS files that you might be serving out to
-browsers. (This is to help well-intentioned people avoid accidental copying that
-doesn't comply with the license.)
+- Dynatrace Platform SaaS (DPS) with Grail enabled — DQL is required for trace fetching
+- Node.js >= 20 LTS
+- At least one AI provider credential: OpenAI, Anthropic, AWS Bedrock, or Google Gemini
 
-Apache header:
+---
 
-    Copyright 2022 Dynatrace LLC
+## Installation
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+```bash
+npm install -g dt-eval-cli
+```
 
-        https://www.apache.org/licenses/LICENSE-2.0
+Or run without installing:
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
+```bash
+npx dt-eval-cli configure
+```
 
-## Additional Questions/Remarks
+---
 
-If you do have additional questions/remarks, feel free to reach out to OSPO, either via slack or email.
+## Configuration
 
-If you think this template did not solve all your problems, please also let us know, either with a message or a pull request.
-Together we can improve this template to make it easier for our future projects.
+```bash
+dt-eval-cli configure
+```
+
+The wizard sets up:
+
+- Dynatrace tenant URL and API token
+- AI provider and credentials
+- OpenPipeline ingest rules for `gen_ai.*` and `gen_ai.evaluation.*` OTEL attributes (via dtctl)
+
+Configuration is stored in `~/.dt-eval/config.yaml`. A project-level `.dt-eval.yaml`
+at repo root is merged on top and takes precedence.
+
+```bash
+dt-eval-cli configure --show   # print fully resolved config with secrets redacted
+dt-eval-cli migrate            # auto-upgrade config to the current schema version
+```
+
+---
+
+## Running evals
+
+```bash
+# evaluate the last hour of traces (default)
+dt-eval-cli run
+
+# customize the time window and sampling rate
+dt-eval-cli run --since 6h --sample 10
+
+# run a single metric
+dt-eval-cli run --metric toxicity
+
+# override the judge model for this run
+dt-eval-cli run --model gpt-4o
+
+# preview what would be sent — fetches and transforms traces, sends nothing
+dt-eval-cli run --dry-run
+
+# estimate token usage and cost per provider before committing
+dt-eval-cli run --estimate
+```
+
+---
+
+## Built-in eval metrics
+
+dt-eval ships with five LLM-as-judge metrics out of the box. Each uses a
+configurable judge prompt template with sensible defaults.
+
+| Metric | What it measures | Score labels |
+|--------|-----------------|--------------|
+| `toxicity` | Harmful, offensive, or abusive language | `none` `low` `medium` `high` |
+| `hallucination` | Unsupported claims relative to retrieved context | `none` `minor` `major` |
+| `relevance` | Whether the response addresses the input | `high` `medium` `low` |
+| `faithfulness` | Alignment with source/context provided | `faithful` `partially_faithful` `unfaithful` |
+| `coherence` | Logical consistency and readability | `coherent` `incoherent` |
+
+### Custom eval plugins
+
+Install any `dt-eval-plugin-*` npm package and it is auto-discovered at runtime:
+
+```bash
+dt-eval-cli plugins add dt-eval-plugin-pii-score
+dt-eval-cli plugins list
+```
+
+---
+
+## Scheduling
+
+Run evals on a cron schedule without keeping a process alive — deploy the runner as
+a serverless function and configure the schedule from the CLI:
+
+```bash
+dt-eval-cli schedule set        # configure cron expression, sampling %, time window
+dt-eval-cli schedule list       # list active schedules
+dt-eval-cli schedule disable <id>
+```
+
+---
+
+## Alerting
+
+Define per-metric thresholds. When a score breaches a threshold, dt-eval fires
+a webhook and publishes a metric time-series to Dynatrace Metrics API v2 for
+Davis AI alerting.
+
+```bash
+dt-eval-cli alerts set          # define threshold rules per metric
+dt-eval-cli alerts list         # show current rules and recent alert history
+dt-eval-cli alerts test         # fire a synthetic alert to validate webhook delivery
+```
+
+Supported notification channels: Slack, PagerDuty, generic HTTP POST.
+
+---
+
+## Serverless deployment
+
+Package and deploy the eval runner as a serverless function with a single command:
+
+```bash
+dt-eval-cli deploy --provider aws      # AWS Lambda
+dt-eval-cli deploy --provider gcp      # Google Cloud Run
+dt-eval-cli deploy --provider azure    # Azure Functions
+dt-eval-cli deploy --teardown          # destroy deployed resources
+```
+
+Terraform modules are included in `dt-eval-deploy/terraform/{aws,gcp,azure}/`.
+The deployed function instruments itself with OpenTelemetry and exports to your
+configured Dynatrace endpoint.
+
+---
+
+## CI/CD integration
+
+Use `--ci` for non-interactive pipelines. The command exits `0` if all scores are
+within thresholds and `1` if any threshold is breached.
+
+```bash
+dt-eval-cli run --ci --since 24h --sample 5
+```
+
+Output is structured JSON on stdout when `--ci` is set, making it easy to parse
+in downstream pipeline steps.
+
+---
+
+## Eval result schema
+
+Every eval result is written as a Dynatrace business event following the
+[OTEL GenAI evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/):
+
+```jsonc
+{
+  // Dynatrace bizevent envelope
+  "event.type": "dt-eval.result",
+  "event.provider": "dt-eval-cli",
+  "timestamp": "2026-03-11T10:00:00Z",
+
+  // Correlation to source GenAI span
+  "trace.id": "abc123...",
+  "dt.eval.run_id": "run-20260311-abc",
+
+  // OTEL GenAI Evaluation attributes
+  "gen_ai.evaluation.name": "toxicity",
+  "gen_ai.evaluation.score.value": 0.12,
+  "gen_ai.evaluation.score.label": "low",
+  "gen_ai.evaluation.explanation": "No harmful content detected.",
+
+  // Judge metadata
+  "gen_ai.evaluation.judge.provider": "openai",
+  "gen_ai.evaluation.judge.model": "gpt-4o-2024-11-20",
+
+  // Source span metadata
+  "gen_ai.system": "openai",
+  "gen_ai.request.model": "gpt-4o-mini"
+}
+```
+
+---
+
+## Packages
+
+This is a monorepo. All packages are under Apache-2.0.
+
+| Package | Description |
+|---------|-------------|
+| [`dt-eval-cli`](dt-eval-cli/) | CLI — `configure`, `run`, `schedule`, `alerts`, `deploy` commands |
+| [`dt-eval-lib`](dt-eval-lib/) | Shared types, judge prompt templates, score normalization, plugin hooks |
+| [`dt-eval-instrument`](dt-eval-instrument/) | OTEL self-monitoring — emits traces and metrics for eval runs themselves |
+| [`dt-eval-deploy`](dt-eval-deploy/) | Serverless packaging and Terraform modules (Lambda / Cloud Run / Azure Functions) |
+
+---
+
+## Contributing
+
+Contributions are welcome. Please open an issue before submitting a large PR.
+
+Released under [Apache 2.0](LICENSE) in the [Dynatrace OSS](https://github.com/dynatrace-oss) GitHub organization.

--- a/dt-eval-cli/.gitignore
+++ b/dt-eval-cli/.gitignore
@@ -1,0 +1,16 @@
+# Claude Code project memory (local only)
+.claude/
+
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Environment variables
+.env
+.env.*
+
+# Project-specific eval configs (contain credentials — use example.dt-eval.yaml as a template)
+*.dt-eval.yaml
+!example.dt-eval.yaml

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -6,6 +6,9 @@
 
 ---
 
+<img width="686" height="512" alt="image" src="https://github.com/user-attachments/assets/45ed1f81-2d07-4b4a-bfc3-c673e88bac2d" />
+
+
 ## Why this exists
 
 Dynatrace captures GenAI spans (inputs, outputs, latency, token usage) automatically via OpenTelemetry. What it does not do out of the box is tell you whether your LLM responses were actually *good*. `dt-eval-cli` closes that gap:

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -1,0 +1,380 @@
+# dt-eval-cli
+
+**LLM evaluation for Dynatrace GenAI observability.**
+
+`dt-eval-cli` fetches GenAI traces from your Dynatrace environment, evaluates them using an LLM-as-evaluator (OpenAI or Anthropic), and writes structured evaluation results back as Dynatrace business events — giving you quality metrics directly inside your existing observability stack.
+
+---
+
+## Why this exists
+
+Dynatrace captures GenAI spans (inputs, outputs, latency, token usage) automatically via OpenTelemetry. What it does not do out of the box is tell you whether your LLM responses were actually *good*. `dt-eval-cli` closes that gap:
+
+- No extra infrastructure — runs from your terminal or CI pipeline
+- Results land in Dynatrace as business events, queryable via DQL alongside your traces
+- PII is masked before anything leaves your environment
+- Works with whatever LLM provider you already have access to
+
+---
+
+## Features
+
+- **14 built-in evaluators** — toxicity, faithfulness, hallucination, PII leakage, relevance, factual accuracy, coherence, context relevance, answer completeness, prompt injection, bias, summarization quality, conciseness, JSON correctness
+- **Custom evaluators** — add your own domain-specific evaluators backed by the same engine
+- **Flexible sampling** — random percentage, latest-N traces, or errors-only
+- **CI mode** — structured JSON output, non-zero exit on threshold breach, drop straight into GitHub Actions / Jenkins
+- **Scheduled runs** — define cron-based evaluation jobs stored locally, run on demand or as a daemon
+- **Evaluation history** — browse, filter, and export past runs as JSON or CSV
+- **Interactive setup wizard** — guided first-time configuration with `dt-eval-cli configure`
+- **Pre-flight validation** — check config schema, Dynatrace connectivity, and evaluator provider keys before running
+
+---
+
+## Requirements
+
+- Node.js >= 20
+- A Dynatrace environment with GenAI span ingestion (OpenTelemetry, `gen_ai.*` semantic conventions)
+- An OpenAI or Anthropic API key
+
+---
+
+## Installation
+
+```bash
+npm install -g dt-eval-cli
+```
+
+Or run without installing:
+
+```bash
+npx dt-eval-cli configure
+```
+
+---
+
+## Quick start
+
+**1. Configure**
+
+```bash
+dt-eval-cli configure
+```
+
+This launches an interactive wizard that sets your Dynatrace environment URL, API token, evaluator provider, and default evaluators. Config is saved to `.dt-eval.yaml` in the current directory (project-level) and `~/.dt-eval/config.yaml` (global fallback).
+
+**2. Validate**
+
+```bash
+dt-eval-cli validate
+```
+
+Runs pre-flight checks on your config schema, Dynatrace API connectivity, and evaluator provider reachability before you run anything.
+
+**3. Run evaluations**
+
+```bash
+dt-eval-cli run
+```
+
+Fetches GenAI traces from the last hour, runs them through your configured evaluators, and writes evaluation results back to Dynatrace as business events.
+
+---
+
+## Command reference
+
+### `configure`
+
+```
+dt-eval-cli configure [options]
+
+Options:
+  --env-url <url>      Dynatrace environment URL
+  --api-token <token>  Dynatrace API token
+  --provider <name>    Evaluator provider: openai | anthropic
+  --api-key <key>      Evaluator provider API key
+  --model <model>      Evaluator model override
+  --since <duration>   Default time window (e.g. 1h, 6h, 24h)
+  --show               Print current config (secrets redacted)
+  --output <path>      Config file path (default: .dt-eval.yaml)
+```
+
+Run with no flags to launch the interactive wizard.
+
+---
+
+### `run`
+
+```
+dt-eval-cli run [options]
+
+Options:
+  --since <duration>    Time window for trace fetch (default: 1h)
+  --sample <percent>    Percentage of traces to evaluate (default: 100)
+  --metric <name>       Run a specific evaluator only
+  --dry-run             Fetch and show payloads without sending to Dynatrace
+  --ci                  JSON stdout + exit 1 on threshold breach
+  --concurrency <n>     Parallel evaluation workers (default: 5)
+```
+
+**CI example:**
+
+```bash
+dt-eval-cli run --since 6h --metric faithfulness --ci
+```
+
+Exit code 0 = all scores above threshold. Exit code 1 = at least one breach.
+
+---
+
+### `validate`
+
+```
+dt-eval-cli validate
+```
+
+Runs four pre-flight checks in sequence:
+
+1. Config schema is valid
+2. Dynatrace environment is reachable and API token is accepted
+3. Evaluator provider API key is valid
+4. All configured evaluator IDs exist in the catalog
+
+---
+
+### `evaluators`
+
+Manage evaluator definitions — browse the built-in catalog or add custom domain-specific evaluators.
+
+```
+dt-eval-cli evaluators list            # show all built-in + custom evaluators
+dt-eval-cli evaluators show <name>     # print the full evaluator definition
+dt-eval-cli evaluators add             # interactive wizard to create a custom evaluator
+dt-eval-cli evaluators delete <name>   # delete a custom evaluator
+dt-eval-cli evaluators test <name>     # run a single evaluator against sample input
+```
+
+Custom evaluators are stored at `~/.dt-eval/custom-prompts.json`.
+
+---
+
+### `runs`
+
+Browse and export past evaluation run history from `~/.dt-eval/runs.json` (last 100 runs).
+
+```
+dt-eval-cli runs list
+dt-eval-cli runs show <runId>
+dt-eval-cli runs export --format json   # or --format csv
+dt-eval-cli runs export --output out.csv
+```
+
+---
+
+### `schedule`
+
+Manage recurring evaluation runs stored in `~/.dt-eval/schedules.json`.
+
+```
+dt-eval-cli schedule add --cron "0 * * * *" --since 1h --name hourly
+dt-eval-cli schedule list
+dt-eval-cli schedule enable <id>
+dt-eval-cli schedule disable <id>
+dt-eval-cli schedule run <id>       # trigger immediately
+dt-eval-cli schedule delete <id>
+```
+
+---
+
+### `status`
+
+```
+dt-eval-cli status
+```
+
+Prints a summary of the resolved config (environment URL, evaluator provider, enabled evaluators, last evaluation run).
+
+---
+
+## Configuration
+
+Config is resolved in this order (highest precedence first):
+
+| Source | Location |
+|--------|----------|
+| Environment variables | `DT_ENV_URL`, `DT_API_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` |
+| Project config | `.dt-eval.yaml` in current directory |
+| Global config | `~/.dt-eval/config.yaml` |
+| Defaults | Built-in |
+
+**Example `.dt-eval.yaml`:**
+
+```yaml
+schemaVersion: 1
+
+dynatrace:
+  environmentUrl: https://your-env.live.dynatrace.com
+  apiToken: dt0c01.xxxx   # or set DT_API_TOKEN
+
+judge:
+  provider: anthropic
+  model: claude-sonnet-4-6   # optional override
+  timeout: 30000
+  maxRetries: 2
+
+scope:
+  since: 1h
+  sampling:
+    strategy: random
+    percent: 100
+
+metrics:
+  enabled:
+    - toxicity
+    - faithfulness
+    - hallucination
+    - relevance
+
+alerts:
+  thresholds:
+    faithfulness: 0.7
+    toxicity: 1.0
+```
+
+**Supported sampling strategies:**
+
+| Strategy | Config |
+|----------|--------|
+| Random percentage | `strategy: random`, `percent: 50` |
+| Latest N traces | `strategy: latest`, `count: 200` |
+| Errors only | `strategy: errors-only` |
+
+---
+
+## Results in Dynatrace
+
+Evaluation results are written back as Dynatrace business events with the following attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `gen_ai.evaluation.metric` | Evaluator name (e.g. `faithfulness`) |
+| `gen_ai.evaluation.score.value` | Numeric score (0–1 or 0–5 depending on scale) |
+| `gen_ai.evaluation.score.label` | `pass` or `fail` |
+| `gen_ai.evaluation.explanation` | LLM-generated explanation of the score |
+| `gen_ai.evaluation.run_id` | Run identifier for grouping |
+| `gen_ai.span.trace_id` | Links back to the original trace |
+
+Query them in Dynatrace with DQL:
+
+```dql
+fetch bizevents
+| filter event.type == "gen_ai.evaluation"
+| summarize avg(gen_ai.evaluation.score.value), by: gen_ai.evaluation.metric
+```
+
+---
+
+## Global flags
+
+```
+--verbose    Enable debug-level logging
+--json       Structured JSON output (for CI/scripts)
+```
+
+---
+
+## PII protection
+
+Before any trace content is sent to an external evaluator provider for evaluation, the following patterns are masked:
+
+- Email addresses
+- Phone numbers
+- Credit card numbers
+- Social Security numbers
+
+Masking is applied in-memory and the original data is never written anywhere.
+
+---
+
+## Built-in evaluators
+
+| Evaluator | What it measures |
+|-----------|-----------------|
+| `toxicity` | Harmful, offensive, or unsafe content |
+| `faithfulness` | Whether the answer is grounded in provided context |
+| `hallucination` | Fabricated facts not supported by context |
+| `pii-leakage` | PII exposed in the model's response |
+| `relevance` | How well the response addresses the question |
+| `factual-accuracy` | Factual correctness of claims made |
+| `coherence` | Logical consistency and readability |
+| `context-relevance` | Whether retrieved context was actually useful |
+| `answer-completeness` | Whether the response fully answers the question |
+| `prompt-injection` | Attempts to hijack the system prompt |
+| `bias` | Demographic or ideological bias in the response |
+| `summarization-quality` | Quality of summaries |
+| `conciseness` | Unnecessary verbosity |
+| `json-correctness` | Whether the output is valid, schema-conforming JSON |
+
+---
+
+## Local development
+
+**Prerequisites:** Node.js >= 20, npm.
+
+The repo contains two packages. `dt-eval-cli` depends on `dt-eval-lib` via a local `file:` reference, so build the library first.
+
+```bash
+# 1. Install and build the eval engine
+cd dt-eval-lib
+npm install
+npm run build
+
+# 2. Install and build the CLI
+cd ../dt-eval-cli
+npm install
+npm run build
+```
+
+**Running commands without installing globally:**
+
+Use `npm run dev` — it runs the source directly through `tsx` with no build step required:
+
+```bash
+npm run dev -- configure
+npm run dev -- run --dry-run --since 6h
+npm run dev -- validate
+```
+
+Or build once and link the binary:
+
+```bash
+npm run build
+npm link          # registers dt-eval-cli on your PATH from dist/
+dt-eval-cli run --dry-run
+```
+
+**Tests:**
+
+```bash
+npm test                  # run all tests once
+npm test -- --watch       # watch mode
+npm test -- tests/runner  # single suite
+```
+
+**Project structure:**
+
+```
+src/
+  cli/commands/   # one file per command (configure, run, evaluators, runs, …)
+  config/         # YAML config load/save/merge/validation
+  dt/             # Dynatrace client, DQL query builder, bizevent writer
+  masker/         # PII masking applied before evaluation dispatch
+  runner/         # orchestration: sampling, batch concurrency, checkpointing
+  ui/             # banner, spinner, table renderer, formatters
+  logger/         # picocolors logger, --verbose / --json flags
+```
+
+---
+
+## License
+
+Apache-2.0

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -1,383 +1,553 @@
-# dt-eval-cli
+# dt-eval-cli - Dynatrace Evaluation CLI tool
 
-**LLM evaluation for Dynatrace GenAI observability.**
+**Open source continuous evals for LLM applications, with production prompt traces as the dataset.**
 
-`dt-eval-cli` fetches GenAI traces from your Dynatrace environment, evaluates them using an LLM-as-evaluator (OpenAI or Anthropic), and writes structured evaluation results back as Dynatrace business events — giving you quality metrics directly inside your existing observability stack.
+[![npm version](https://img.shields.io/npm/v/dt-eval-cli)](https://www.npmjs.com/package/dt-eval-cli)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![CI](https://github.com/dynatrace-oss/dt-eval-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/dynatrace-oss/dt-eval-cli/actions)
 
----
+`dt-eval-cli` is for teams shipping chat, RAG, copilots, and agent workflows who want evals to run on real traffic, not just curated test sets.
 
-<img width="686" height="512" alt="image" src="https://github.com/user-attachments/assets/45ed1f81-2d07-4b4a-bfc3-c673e88bac2d" />
+<img width="686" height="512" alt="image" src="https://github.com/user-attachments/assets/0e09197f-2ebc-4ecb-9e3a-dcd9ab1cb22f" />
+
+Today, the CLI uses Dynatrace as both the trace source and the evaluation result store. It pulls gen_ai.* spans from your live environment, masks sensitive data in memory, scores real production interactions with an LLM judge, detects score drift over time, and writes structured evaluation results back to Dynatrace as business events. 
+
+That means when a score drops or an outlier appears, you do not just see that quality regressed, you can trace it back through the full AI execution path: prompts, retrieval context, model calls, tool usage, latency, failures, and service dependencies. 
+
+In practice, this gives AI engineers a closed loop for evaluation, observability, alerting, anomaly detection, and remediation on the same production telemetry they already use to operate their systems.
+
+The repository also includes `dt-eval-lib`, a reusable TypeScript evaluation engine for running the same judge-based metrics directly in code, using either the built-in evaluator catalog or your own custom prompt definitions. It also fits cleanly into broader evaluation workflows and observability stacks such as Ragas, MLflow, or Langfuse when you want to orchestrate or track evals in those systems alongside this library.
+
+```bash
+npx dt-eval-cli configure
+npx dt-eval-cli validate
+npx dt-eval-cli run --since 1h --sample 10
+npx dt-eval-cli deploy aws
+```
+
+## Why Teams Use It
+- Run evals on real production traces, not static test sets
+- Keep eval results in Dynatrace with traces, logs, metrics, dashboards, and alerts
+- Catch common LLM and agent failure modes with built-in judge metrics
+- Detect regressions, drift, and outlier score changes early
+- Go from low score to root cause with end-to-end AI observability
+- Correlate failures with prompts, retrieval, tool calls, latency, and dependencies
+- Reuse the same evaluator catalog in CI, app code, and local workflows with dt-eval-lib
+- Deploy the runner to AWS Lambda, Google Cloud Run, Azure Functions or Docker for continuous evals
+- Trigger alerts and optional remediation from the same evaluation pipeline
+
+## Packages
+
+| Package | What it is for |
+|---------|-----------------|
+| `dt-eval-cli` | Continuous evaluation runs against production GenAI traces in Dynatrace |
+| `dt-eval-lib` | TypeScript library for judge-based evals inside tests, scripts, and app code |
+| `dt-eval-engine` | Core Go runtime for deployed eval workers and serverless runners, including AWS Lambda, Google Cloud Run, Azure Funtions or Docker |
 
 
-## Why this exists
+## What It Does
 
-Dynatrace captures GenAI spans (inputs, outputs, latency, token usage) automatically via OpenTelemetry. What it does not do out of the box is tell you whether your LLM responses were actually *good*. `dt-eval-cli` closes that gap:
+- **13 built-in judge metrics** for safety, grounding, relevance, quality, and retrieval quality
+- **Statistical drift detection** against a 7 day baseline of prior evaluation scores
+- **Flexible sampling** with random percentage, latest `N`, or `errors-only`
+- **PII masking before judge calls** for emails, phone numbers, credit cards, and SSNs
+- **OpenAI and Anthropic support** with optional custom base URLs for gateways and proxies
+- **CI friendly runs** with JSON output and non-zero exit codes on threshold breaches
+- **Local run history** with list, inspect, and export flows
+- **Scheduled runs** stored locally and triggerable on demand
+- **Evaluator inspection and testing** from the CLI
+- **TypeScript API** for running the evaluator catalog directly in code
 
-- No extra infrastructure — runs from your terminal or CI pipeline
-- Results land in Dynatrace as business events, queryable via DQL alongside your traces
-- PII is masked before anything leaves your environment
-- Works with whatever LLM provider you already have access to
+## How It Works
 
----
+```text
+Dynatrace spans (gen_ai.*)
+        |
+        v
+sample traces -> mask sensitive data -> score with LLM judge -> write business events
+                                                                    |
+                                                                    v
+                                             query in DQL, dashboard, alert, export
+```
 
-## Features
-
-- **14 built-in evaluators** — toxicity, faithfulness, hallucination, PII leakage, relevance, factual accuracy, coherence, context relevance, answer completeness, prompt injection, bias, summarization quality, conciseness, JSON correctness
-- **Custom evaluators** — add your own domain-specific evaluators backed by the same engine
-- **Flexible sampling** — random percentage, latest-N traces, or errors-only
-- **CI mode** — structured JSON output, non-zero exit on threshold breach, drop straight into GitHub Actions / Jenkins
-- **Scheduled runs** — define cron-based evaluation jobs stored locally, run on demand or as a daemon
-- **Evaluation history** — browse, filter, and export past runs as JSON or CSV
-- **Interactive setup wizard** — guided first-time configuration with `dt-eval-cli configure`
-- **Pre-flight validation** — check config schema, Dynatrace connectivity, and evaluator provider keys before running
-
----
+The current CLI path is Dynatrace specific. The product positioning is broader: continuous evals for AI-native engineering teams, using your live LLM traffic as the source of truth.
 
 ## Requirements
 
-- Node.js >= 20
-- A Dynatrace environment with GenAI span ingestion (OpenTelemetry, `gen_ai.*` semantic conventions)
-- An OpenAI or Anthropic API key
+- Node.js `>=20`
+- A Dynatrace environment with GenAI spans or OpenTelemetry-style `gen_ai.*` fields
+- An OpenAI or Anthropic API key for the judge model
 
----
-
-## Installation
+## Install
 
 ```bash
 npm install -g dt-eval-cli
 ```
 
-Or run without installing:
+Or run it without installing:
 
 ```bash
-npx dt-eval-cli configure
+npx dt-eval-cli <command>
 ```
 
----
+The CLI also auto-loads a local `.env` file from the current working directory.
 
-## Quick start
+## Quick Start
 
-**1. Configure**
+### 1. Create config
+
+Interactive setup:
 
 ```bash
 dt-eval-cli configure
 ```
 
-This launches an interactive wizard that sets your Dynatrace environment URL, API token, evaluator provider, and default evaluators. Config is saved to `.dt-eval.yaml` in the current directory (project-level) and `~/.dt-eval/config.yaml` (global fallback).
+Non-interactive setup:
 
-**2. Validate**
+```bash
+dt-eval-cli configure \
+  --env-url https://your-env.live.dynatrace.com \
+  --api-token "$DT_API_TOKEN" \
+  --provider openai \
+  --api-key "$OPENAI_API_KEY" \
+  --model gpt-4o \
+  --since 1h \
+  --output .dt-eval.yaml
+```
+
+### 2. Validate the setup
 
 ```bash
 dt-eval-cli validate
 ```
 
-Runs pre-flight checks on your config schema, Dynatrace API connectivity, and evaluator provider reachability before you run anything.
+This checks:
 
-**3. Run evaluations**
+- config schema
+- Dynatrace connectivity
+- judge provider reachability
+- evaluator catalog availability
 
-```bash
-dt-eval-cli run
-```
-
-Fetches GenAI traces from the last hour, runs them through your configured evaluators, and writes evaluation results back to Dynatrace as business events.
-
----
-
-## Command reference
-
-### `configure`
-
-```
-dt-eval-cli configure [options]
-
-Options:
-  --env-url <url>      Dynatrace environment URL
-  --api-token <token>  Dynatrace API token
-  --provider <name>    Evaluator provider: openai | anthropic
-  --api-key <key>      Evaluator provider API key
-  --model <model>      Evaluator model override
-  --since <duration>   Default time window (e.g. 1h, 6h, 24h)
-  --show               Print current config (secrets redacted)
-  --output <path>      Config file path (default: .dt-eval.yaml)
-```
-
-Run with no flags to launch the interactive wizard.
-
----
-
-### `run`
-
-```
-dt-eval-cli run [options]
-
-Options:
-  --since <duration>    Time window for trace fetch (default: 1h)
-  --sample <percent>    Percentage of traces to evaluate (default: 100)
-  --metric <name>       Run a specific evaluator only
-  --dry-run             Fetch and show payloads without sending to Dynatrace
-  --ci                  JSON stdout + exit 1 on threshold breach
-  --concurrency <n>     Parallel evaluation workers (default: 5)
-```
-
-**CI example:**
+### 3. Run evals on recent traces
 
 ```bash
-dt-eval-cli run --since 6h --metric faithfulness --ci
+dt-eval-cli run --since 1h --sample 10 --concurrency 5
 ```
 
-Exit code 0 = all scores above threshold. Exit code 1 = at least one breach.
+Run only one evaluator:
 
----
-
-### `validate`
-
-```
-dt-eval-cli validate
+```bash
+dt-eval-cli run --since 6h --metric faithfulness
 ```
 
-Runs four pre-flight checks in sequence:
+Preview the work without calling the judge or writing results:
 
-1. Config schema is valid
-2. Dynatrace environment is reachable and API token is accepted
-3. Evaluator provider API key is valid
-4. All configured evaluator IDs exist in the catalog
-
----
-
-### `evaluators`
-
-Manage evaluator definitions — browse the built-in catalog or add custom domain-specific evaluators.
-
-```
-dt-eval-cli evaluators list            # show all built-in + custom evaluators
-dt-eval-cli evaluators show <name>     # print the full evaluator definition
-dt-eval-cli evaluators add             # interactive wizard to create a custom evaluator
-dt-eval-cli evaluators delete <name>   # delete a custom evaluator
-dt-eval-cli evaluators test <name>     # run a single evaluator against sample input
+```bash
+dt-eval-cli run --since 1h --sample 5 --dry-run
 ```
 
-Custom evaluators are stored at `~/.dt-eval/custom-prompts.json`.
+## CLI Workflows
 
----
+### Production eval run
 
-### `runs`
-
-Browse and export past evaluation run history from `~/.dt-eval/runs.json` (last 100 runs).
-
-```
-dt-eval-cli runs list
-dt-eval-cli runs show <runId>
-dt-eval-cli runs export --format json   # or --format csv
-dt-eval-cli runs export --output out.csv
+```bash
+dt-eval-cli run \
+  --since 2h \
+  --sample 20 \
+  --concurrency 8 \
+  --debug
 ```
 
----
+### CI gate on quality regressions
 
-### `schedule`
-
-Manage recurring evaluation runs stored in `~/.dt-eval/schedules.json`.
-
+```bash
+dt-eval-cli run --since 6h --metric relevance --ci
 ```
-dt-eval-cli schedule add --cron "0 * * * *" --since 1h --name hourly
+
+- exit code `0`: no threshold breaches
+- exit code `1`: one or more threshold breaches
+
+Example GitHub Actions step:
+
+```yaml
+- name: Run LLM eval gate
+  run: npx dt-eval-cli run --since 6h --metric faithfulness --ci
+  env:
+    DT_ENV_URL: ${{ secrets.DT_ENV_URL }}
+    DT_API_TOKEN: ${{ secrets.DT_API_TOKEN }}
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+```
+
+### Run drift detection only
+
+```bash
+dt-eval-cli run --metric drift --since 24h
+```
+
+This uses prior evaluation results already written to Dynatrace and compares the recent window against a 7 day baseline.
+
+### Inspect available evaluators
+
+```bash
+dt-eval-cli evaluators list
+dt-eval-cli evaluators show faithfulness
+dt-eval-cli evaluators test relevance
+```
+
+Create or remove a custom evaluator:
+
+```bash
+dt-eval-cli evaluators add
+dt-eval-cli evaluators delete my-custom-eval
+```
+
+### Manage run history
+
+```bash
+dt-eval-cli runs list --limit 20
+dt-eval-cli runs show run-2026-04-10T12-00-00-ab12cd34
+dt-eval-cli runs export --format csv --output runs.csv
+```
+
+Run records are stored locally in `~/.dt-eval/runs.json`.
+
+### Schedule recurring runs
+
+```bash
+dt-eval-cli schedule add --name hourly-rag --cron "0 * * * *" --since 1h --sample 10
 dt-eval-cli schedule list
-dt-eval-cli schedule enable <id>
-dt-eval-cli schedule disable <id>
-dt-eval-cli schedule run <id>       # trigger immediately
-dt-eval-cli schedule delete <id>
+dt-eval-cli schedule run <schedule-id>
+dt-eval-cli schedule disable <schedule-id>
+dt-eval-cli schedule enable <schedule-id>
+dt-eval-cli schedule delete <schedule-id>
 ```
 
----
+Schedules are stored locally in `~/.dt-eval/schedules.json`.
 
-### `status`
+### Check current status
 
-```
+```bash
 dt-eval-cli status
+dt-eval-cli configure --show
 ```
 
-Prints a summary of the resolved config (environment URL, evaluator provider, enabled evaluators, last evaluation run).
+## Commands
 
----
+| Command | Description |
+|---------|-------------|
+| `configure` | Create or update config interactively or via flags |
+| `validate` | Check config, Dynatrace connectivity, and judge provider availability |
+| `run` | Evaluate recent GenAI traces |
+| `status` | Show resolved config, connectivity, and last run summary |
+| `evaluators` | List, inspect, test, and manage evaluators |
+| `runs` | View and export historical run records |
+| `schedule` | Create and trigger recurring runs |
+
+Global flags:
+
+```text
+--verbose    Enable verbose logs
+--json       Emit structured JSON logs
+```
+
+`run` flags:
+
+```text
+--config <path>        Path to config file
+--since <duration>     Trace lookback window, for example 1h or 24h
+--sample <percent>     Percentage of traces to evaluate
+--metric <name>        Run only one evaluator
+--dry-run              Do not call the judge or write results
+--ci                   JSON result output and exit 1 on threshold breach
+--concurrency <n>      Number of parallel evaluation workers
+--debug                Per-step timing logs
+```
 
 ## Configuration
 
-Config is resolved in this order (highest precedence first):
+Config is resolved in this order:
 
-| Source | Location |
-|--------|----------|
-| Environment variables | `DT_ENV_URL`, `DT_API_TOKEN`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` |
-| Project config | `.dt-eval.yaml` in current directory |
-| Global config | `~/.dt-eval/config.yaml` |
-| Defaults | Built-in |
+| Priority | Source |
+|----------|--------|
+| 1 | Environment variables |
+| 2 | Project config, usually `.dt-eval.yaml` |
+| 3 | Global config, `~/.dt-eval/config.yaml` |
+| 4 | Built-in defaults |
 
-**Example `.dt-eval.yaml`:**
+### Example config
 
 ```yaml
 schemaVersion: 1
+name: travel-assistant-prod
 
 dynatrace:
   environmentUrl: https://your-env.live.dynatrace.com
-  apiToken: dt0c01.xxxx   # or set DT_API_TOKEN
+  apiToken: dt0c01.xxxxx
+  dtctlContext: my-prod-context
 
 judge:
-  provider: anthropic
-  model: claude-sonnet-4-6   # optional override
+  provider: openai
+  model: gpt-4o
   timeout: 30000
   maxRetries: 2
 
 scope:
+  service: travel-assistant
   since: 1h
   sampling:
     strategy: random
-    percent: 100
+    percent: 10
 
 metrics:
   enabled:
-    - toxicity
     - faithfulness
     - hallucination
     - relevance
+    - answer-completeness
+    - drift
 
 alerts:
   thresholds:
     faithfulness: 0.7
-    toxicity: 1.0
+    relevance: 0.7
+    answer-completeness: 0.8
 ```
 
-**Supported sampling strategies:**
+Sampling strategies:
 
-| Strategy | Config |
-|----------|--------|
-| Random percentage | `strategy: random`, `percent: 50` |
-| Latest N traces | `strategy: latest`, `count: 200` |
-| Errors only | `strategy: errors-only` |
+| Strategy | Example |
+|----------|---------|
+| Random percentage | `strategy: random`, `percent: 10` |
+| Most recent traces | `strategy: latest`, `count: 200` |
+| Error traces only | `strategy: errors-only` |
 
----
+Useful environment variables:
+
+```bash
+DT_ENV_URL=https://your-env.live.dynatrace.com
+DT_API_TOKEN=dt0c01.xxxxx
+DT_DTCTL_CONTEXT=my-prod-context
+
+JUDGE_PROVIDER=openai
+JUDGE_MODEL=gpt-4o
+
+OPENAI_API_KEY=sk-...
+OPENAI_BASE_URL=https://your-gateway.example.com/v1
+
+AZURE_OPENAI_KEY=...
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_BASE_URL=https://your-proxy.example.com
+```
 
 ## Results in Dynatrace
 
-Evaluation results are written back as Dynatrace business events with the following attributes:
+Evaluation results are written as business events with `event.type == "gen_ai.evaluation.result"`.
 
-| Attribute | Description |
-|-----------|-------------|
-| `gen_ai.evaluation.metric` | Evaluator name (e.g. `faithfulness`) |
-| `gen_ai.evaluation.score.value` | Numeric score (0–1 or 0–5 depending on scale) |
+Important fields include:
+
+| Field | Meaning |
+|-------|---------|
+| `gen_ai.evaluation.name` | Evaluator name, for example `faithfulness` |
+| `gen_ai.evaluation.score.value` | Numeric score |
 | `gen_ai.evaluation.score.label` | `pass` or `fail` |
-| `gen_ai.evaluation.explanation` | LLM-generated explanation of the score |
-| `gen_ai.evaluation.run_id` | Run identifier for grouping |
-| `gen_ai.span.trace_id` | Links back to the original trace |
+| `gen_ai.evaluation.score.explanation` | Short summary from the judge |
+| `dt.eval.run_id` | Evaluation run identifier |
+| `trace_id` | Source trace ID |
+| `dt.service.name` | Service filter when configured |
 
-Query them in Dynatrace with DQL:
+Example DQL:
 
 ```dql
 fetch bizevents
-| filter event.type == "gen_ai.evaluation"
-| summarize avg(gen_ai.evaluation.score.value), by: gen_ai.evaluation.metric
+| filter event.type == "gen_ai.evaluation.result"
+| summarize avg_score = avg(gen_ai.evaluation.score.value), by: { gen_ai.evaluation.name }
+| sort avg_score asc
 ```
 
----
+Drift results are written back as the same event type with `gen_ai.evaluation.type == "drift"`.
 
-## Global flags
+## Built-in Evaluators
 
+`dt-eval-cli` ships with 13 built-in LLM judge evaluators, plus drift detection as a separate statistical metric.
+
+| Evaluator | Measures | Required fields |
+|-----------|----------|-----------------|
+| `toxicity` | Harmful, offensive, or unsafe output | `input`, `output` |
+| `faithfulness` | Whether the answer is grounded in provided context | `input`, `output`, `context` |
+| `hallucination` | Unsupported or fabricated claims | `input`, `output`, `context` |
+| `pii-leakage` | Personally identifiable information in the answer | `input`, `output` |
+| `relevance` | Whether the answer addresses the user request | `input`, `output` |
+| `factual-accuracy` | Accuracy against a reference answer | `input`, `output`, `expectedOutput` |
+| `coherence` | Structure, clarity, and logical flow | `input`, `output` |
+| `context-relevance` | Retrieval quality for supplied context | `input`, `context` |
+| `answer-completeness` | Whether all parts of the request were answered | `input`, `output` |
+| `prompt-injection` | Prompt injection attempts in the input | `input`, `output` |
+| `bias` | Harmful bias or unfair framing | `input`, `output` |
+| `summarization-quality` | Summary faithfulness, coverage, and conciseness | `input`, `output` |
+| `conciseness` | Whether the answer avoids filler and unnecessary padding | `input`, `output` |
+
+### Drift detection
+
+`drift` compares current score distributions against a 7 day baseline of prior evaluation events.
+
+Use it when you care about regressions that show up gradually, not just single-run threshold breaches.
+
+## TypeScript Library
+
+The repository includes `dt-eval-lib` for programmatic usage.
+
+### Basic example
+
+```ts
+import { evaluate, BuiltInMetric } from "dt-eval-lib";
+
+const result = await evaluate(
+  BuiltInMetric.Faithfulness,
+  {
+    input: "Can I cancel my booking after check-in?",
+    output: "Yes, you can cancel any time and get a full refund.",
+    context: "Bookings can be canceled up to 24 hours before check-in. Refunds are not available after check-in.",
+  },
+  {
+    provider: {
+      provider: "openai",
+      apiKey: process.env.OPENAI_API_KEY,
+      model: "gpt-5.1",
+      timeout: 30000,
+      maxRetries: 2,
+    },
+  },
+);
+
+console.log(result.score);
+console.log(result.explanation.summary);
+console.log(result.explanation.reasoning);
 ```
---verbose    Enable debug-level logging
---json       Structured JSON output (for CI/scripts)
+
+### Inspect the evaluator catalog
+
+```ts
+import { listPrompts, getPrompt, BuiltInMetric } from "dt-eval-lib";
+
+const prompts = listPrompts();
+const relevance = getPrompt(BuiltInMetric.Relevance);
+
+console.log(prompts.map((prompt) => prompt.id));
+console.log(relevance.requiredFields);
 ```
 
----
+### Override thresholds in code
 
-## PII protection
+```ts
+import { evaluate, BuiltInMetric } from "dt-eval-lib";
 
-Before any trace content is sent to an external evaluator provider for evaluation, the following patterns are masked:
+const result = await evaluate(
+  BuiltInMetric.Relevance,
+  {
+    input: "What are your support hours?",
+    output: "Our support team is available on weekdays.",
+  },
+  {
+    provider: {
+      provider: "anthropic",
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    },
+    scoring: {
+      thresholdOverride: 0.8,
+    },
+  },
+);
 
-- Email addresses
-- Phone numbers
-- Credit card numbers
-- Social Security numbers
+console.log(result.score.label);
+```
 
-Masking is applied in-memory and the original data is never written anywhere.
+### Use a custom gateway or proxy
 
----
+```ts
+import { evaluate, BuiltInMetric } from "dt-eval-lib";
 
-## Built-in evaluators
+await evaluate(
+  BuiltInMetric.Toxicity,
+  {
+    input: "Write a release note",
+    output: "The release fixes several issues.",
+  },
+  {
+    provider: {
+      provider: "openai",
+      apiKey: process.env.OPENAI_API_KEY,
+      baseUrl: process.env.OPENAI_BASE_URL,
+    },
+  },
+);
+```
 
-| Evaluator | What it measures |
-|-----------|-----------------|
-| `toxicity` | Harmful, offensive, or unsafe content |
-| `faithfulness` | Whether the answer is grounded in provided context |
-| `hallucination` | Fabricated facts not supported by context |
-| `pii-leakage` | PII exposed in the model's response |
-| `relevance` | How well the response addresses the question |
-| `factual-accuracy` | Factual correctness of claims made |
-| `coherence` | Logical consistency and readability |
-| `context-relevance` | Whether retrieved context was actually useful |
-| `answer-completeness` | Whether the response fully answers the question |
-| `prompt-injection` | Attempts to hijack the system prompt |
-| `bias` | Demographic or ideological bias in the response |
-| `summarization-quality` | Quality of summaries |
-| `conciseness` | Unnecessary verbosity |
-| `json-correctness` | Whether the output is valid, schema-conforming JSON |
+Library features:
 
----
+- OpenAI and Anthropic providers
+- Structured judge responses with score, summary, and reasoning
+- Built-in prompt catalog via `BuiltInMetric`, `listPrompts()`, and `getPrompt()`
+- Custom evaluator support by passing your own `PromptDefinition`
+- Binary, continuous, and Likert scoring scales
+- Threshold overrides per evaluation call
+- Retry handling for transient provider failures
+- Composable API that can be embedded in external eval and observability workflows
 
-## Local development
+## PII Handling
 
-**Prerequisites:** Node.js >= 20, npm.
+For CLI trace evaluation runs, the following are masked in memory before content is sent to an external judge model:
 
-The repo contains two packages. `dt-eval-cli` depends on `dt-eval-lib` via a local `file:` reference, so build the library first.
+- email addresses
+- phone numbers
+- credit card numbers
+- social security numbers
+
+The original values are not sent to the judge by the CLI path.
+
+## Data Expectations
+
+The CLI currently expects chat-style GenAI spans that include fields such as:
+
+- `gen_ai.provider.name`
+- `gen_ai.request.model`
+- `gen_ai.prompt.<n>.content`
+- `gen_ai.prompt.<n>.role`
+- `gen_ai.completion.0.content`
+- `service.name` or `dt.entity.service` for service scoping
+
+This makes it a good fit for apps instrumented with OpenTelemetry GenAI conventions or OpenLLMetry-style span attributes.
+
+## Local Development
 
 ```bash
-# 1. Install and build the eval engine
-cd dt-eval-lib
-npm install
-npm run build
+# build the library first
+cd dt-eval-lib && npm install && npm run build
 
-# 2. Install and build the CLI
-cd ../dt-eval-cli
-npm install
-npm run build
+# then build the CLI
+cd .. && npm install && npm run build
 ```
 
-**Running commands without installing globally:**
-
-Use `npm run dev` — it runs the source directly through `tsx` with no build step required:
+Run locally without a build:
 
 ```bash
 npm run dev -- configure
-npm run dev -- run --dry-run --since 6h
-npm run dev -- validate
+npm run dev -- run --since 1h --dry-run
 ```
 
-Or build once and link the binary:
+Run tests:
 
 ```bash
-npm run build
-npm link          # registers dt-eval-cli on your PATH from dist/
-dt-eval-cli run --dry-run
+npm test
 ```
 
-**Tests:**
+## Contributing
 
-```bash
-npm test                  # run all tests once
-npm test -- --watch       # watch mode
-npm test -- tests/runner  # single suite
-```
+Issues and pull requests are welcome.
 
-**Project structure:**
-
-```
-src/
-  cli/commands/   # one file per command (configure, run, evaluators, runs, …)
-  config/         # YAML config load/save/merge/validation
-  dt/             # Dynatrace client, DQL query builder, bizevent writer
-  masker/         # PII masking applied before evaluation dispatch
-  runner/         # orchestration: sampling, batch concurrency, checkpointing
-  ui/             # banner, spinner, table renderer, formatters
-  logger/         # picocolors logger, --verbose / --json flags
-```
-
----
+If you want to work on a larger change, open an issue first so the direction is clear before implementation starts.
 
 ## License
 
-Apache-2.0
+[Apache 2.0](LICENSE)

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -42,8 +42,7 @@ npx dt-eval-cli deploy aws
 |---------|-----------------|
 | `dt-eval-cli` | Continuous evaluation runs against production GenAI traces in Dynatrace |
 | `dt-eval-lib` | TypeScript library for judge-based evals inside tests, scripts, and app code |
-| `dt-eval-engine` | Core Go runtime for deployed eval workers and serverless runners, including AWS Lambda, Google Cloud Run, Azure Funtions or Docker |
-
+| `dt-eval-engine` | Core runtime for deployed eval workers and serverless runners |
 
 ## What It Does
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -8,11 +8,9 @@
 
 `dt-eval-cli` is for teams shipping chat, RAG, copilots, and agent workflows who want evals to run on real traffic, not just curated test sets.
 
-<img width="686" height="512" alt="image" src="https://github.com/user-attachments/assets/0e09197f-2ebc-4ecb-9e3a-dcd9ab1cb22f" />
+Today, the CLI uses Dynatrace as both the trace source and the evaluation result store. It pulls gen_ai.* spans from your live environment, masks sensitive data in memory, scores real production interactions with an LLM judge, detects score drift over time, and writes structured evaluation results back to Dynatrace as business events.
 
-Today, the CLI uses Dynatrace as both the trace source and the evaluation result store. It pulls gen_ai.* spans from your live environment, masks sensitive data in memory, scores real production interactions with an LLM judge, detects score drift over time, and writes structured evaluation results back to Dynatrace as business events. 
-
-That means when a score drops or an outlier appears, you do not just see that quality regressed, you can trace it back through the full AI execution path: prompts, retrieval context, model calls, tool usage, latency, failures, and service dependencies. 
+That means when a score drops or an outlier appears, you do not just see that quality regressed, you can trace it back through the full AI execution path: prompts, retrieval context, model calls, tool usage, latency, failures, and service dependencies.
 
 In practice, this gives AI engineers a closed loop for evaluation, observability, alerting, anomaly detection, and remediation on the same production telemetry they already use to operate their systems.
 
@@ -26,6 +24,7 @@ npx dt-eval-cli deploy aws
 ```
 
 ## Why Teams Use It
+
 - Run evals on real production traces, not static test sets
 - Keep eval results in Dynatrace with traces, logs, metrics, dashboards, and alerts
 - Catch common LLM and agent failure modes with built-in judge metrics

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -1,0 +1,113 @@
+# dt-eval-cli configuration example
+# Copy this file to <your-service>.dt-eval.yaml and fill in your values.
+# Run: dt-eval run --config <your-service>.dt-eval.yaml
+
+schemaVersion: 1
+
+# Human-readable name shown in run output and stored in Dynatrace bizevents.
+name: my-ai-service-prod
+
+# ---------------------------------------------------------------------------
+# Dynatrace connection
+# ---------------------------------------------------------------------------
+dynatrace:
+  # Your Dynatrace environment URL (SaaS or Managed).
+  environmentUrl: https://<your-env-id>.apps.dynatracelabs.com
+
+  # API token with the following scopes: bizevents.ingest, storage.read
+  # Tip: use the DYNATRACE_API_TOKEN env var instead of hardcoding the token.
+  apiToken: dt0c01.REPLACE_ME
+
+  # (Optional) dtctl context name to use OAuth for DQL queries instead of the
+  # API token. Requires dtctl to be installed and authenticated.
+  # dtctlContext: my-env
+
+# ---------------------------------------------------------------------------
+# Judge (LLM-as-a-judge) provider
+# ---------------------------------------------------------------------------
+judge:
+  # Supported providers: openai, anthropic
+  provider: openai
+
+  # API key for the judge provider.
+  # Tip: use OPENAI_API_KEY / ANTHROPIC_API_KEY env vars instead.
+  apiKey: sk-REPLACE_ME
+
+  # (Optional) Override the model. Defaults: openai → gpt-4o, anthropic → claude-sonnet-4-6
+  model: gpt-4o
+
+  # (Optional) Custom base URL — useful for Azure OpenAI or local proxies.
+  # baseUrl: https://my-azure-resource.openai.azure.com/
+
+  # Request timeout in milliseconds (default: 30000).
+  timeout: 30000
+
+  # Number of retries on transient failures (default: 2).
+  maxRetries: 2
+
+# ---------------------------------------------------------------------------
+# Scope — which spans to evaluate
+# ---------------------------------------------------------------------------
+scope:
+  # service.name of the AI service to evaluate as it appears in Dynatrace.
+  service: my-ai-service-prod
+
+  # Look-back window for span collection. Accepts: Nh (hours), Nd (days).
+  since: 1h
+
+  sampling:
+    # Sampling strategy: random | latest | errors-only
+    #   random      — random % of spans in the window (set `percent`)
+    #   latest      — most recent N spans (set `count`)
+    #   errors-only — spans that ended in an error state
+    strategy: random
+    percent: 10   # used with strategy: random  (0–100)
+    # count: 50   # used with strategy: latest
+
+# ---------------------------------------------------------------------------
+# Metrics — which evaluations to run
+# ---------------------------------------------------------------------------
+metrics:
+  enabled:
+    # LLM-as-judge metrics (require a judge provider):
+    - toxicity              # Detect harmful or offensive content
+    - faithfulness          # Response grounded in retrieved context
+    - hallucination         # Fabricated facts not in context
+    - pii-leakage           # Personally identifiable information in output
+    - relevance             # Response answers the user's question
+    - factual-accuracy      # Factual correctness vs. provided context
+    - coherence             # Logical flow and readability
+    - context-relevance     # Retrieved context relevant to the question
+    - answer-completeness   # All aspects of the question addressed
+    - prompt-injection      # Adversarial prompt injection attempts
+    - bias                  # Demographic or ideological bias
+    - summarization-quality # Quality of summaries vs. source document
+    - conciseness           # Avoids unnecessary verbosity
+
+    # Statistical drift detection (no LLM call — compares current vs. baseline scores in DT):
+    - drift
+
+# ---------------------------------------------------------------------------
+# Alerts — thresholds that trigger a non-zero exit code
+# ---------------------------------------------------------------------------
+alerts:
+  # Metric score thresholds. A run fails if any enabled metric's average score
+  # falls below (for 0–1 metrics) or above (for toxicity/prompt-injection) the threshold.
+  thresholds:
+    toxicity: 1           # fail if any span scores above 1 (out of 5)
+    hallucination: 0      # fail if any hallucination detected
+    pii-leakage: 0        # fail if any PII leakage detected
+    prompt-injection: 0   # fail if any injection detected
+    relevance: 0.6        # fail if average relevance drops below 0.6
+    coherence: 3          # fail if average coherence drops below 3 (out of 5)
+    answer-completeness: 0.7
+    conciseness: 0.6
+    faithfulness: 0.7
+    factual-accuracy: 0.7
+
+  # (Optional) Webhook notifications on threshold breach.
+  webhooks:
+    - url: https://hooks.slack.com/services/REPLACE_ME
+      type: slack
+    # - url: https://my-webhook-endpoint.example.com/alerts
+    #   type: generic

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -34,7 +34,7 @@ judge:
   apiKey: sk-REPLACE_ME
 
   # (Optional) Override the model. Defaults: openai → gpt-4o, anthropic → claude-sonnet-4-6
-  model: gpt-4o
+  model: gpt-5.3
 
   # (Optional) Custom base URL — useful for Azure OpenAI or local proxies.
   # baseUrl: https://my-azure-resource.openai.azure.com/

--- a/dt-eval-cli/package-lock.json
+++ b/dt-eval-cli/package-lock.json
@@ -1,0 +1,3069 @@
+{
+  "name": "dt-eval-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dt-eval-cli",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^7.10.1",
+        "@types/figlet": "^1.7.0",
+        "commander": "^12.0.0",
+        "dt-eval-lib": "file:../dt-eval-lib",
+        "figlet": "^1.11.0",
+        "picocolors": "^1.1.1",
+        "yaml": "^2.4.0"
+      },
+      "bin": {
+        "dt-eval-cli": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.0",
+        "tsup": "^8.3.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "../dt-eval-lib": {
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.32.0",
+        "openai": "^4.73.0"
+      },
+      "devDependencies": {
+        "tsup": "^8.3.0",
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/figlet": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/figlet/-/figlet-1.7.0.tgz",
+      "integrity": "sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dt-eval-lib": {
+      "resolved": "../dt-eval-lib",
+      "link": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/figlet": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/figlet/-/figlet-1.11.0.tgz",
+      "integrity": "sha512-EEx3OS/l2bFqcUNN2NM9FPJp8vAMrgbCxsbl2hbcJNNxOEwVe3mEzrhan7TbJQViZa8mMqhihlbCaqD+LyYKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "figlet": "bin/index.js"
+      },
+      "engines": {
+        "node": ">= 17.0.0"
+      }
+    },
+    "node_modules/figlet/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "dt-eval-cli",
+  "version": "0.1.0",
+  "description": "Evaluation CLI for LLM observability on Dynatrace",
+  "type": "module",
+  "bin": {
+    "dt-eval-cli": "./dist/index.js"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "dev": "tsx src/index.ts"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@inquirer/prompts": "^7.10.1",
+    "@types/figlet": "^1.7.0",
+    "commander": "^12.0.0",
+    "dt-eval-lib": "file:../dt-eval-lib",
+    "figlet": "^1.11.0",
+    "picocolors": "^1.1.1",
+    "yaml": "^2.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsup": "^8.3.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -1,0 +1,352 @@
+import { Command } from 'commander';
+import { join } from 'node:path';
+import { loadConfig, saveConfig, validateConfig } from '../../config/index.js';
+import type { DtEvalConfig } from '../../config/schema.js';
+import { stringify as stringifyYaml } from 'yaml';
+import { redactSecrets } from '../../ui/format.js';
+import { logger } from '../../logger/index.js';
+import { printBanner } from '../../ui/banner.js';
+import { listPrompts, DRIFT_METRIC_ID } from 'dt-eval-lib';
+import { DynatraceClient } from '../../dt/client.js';
+
+// Per-million-token pricing [input, output] in USD
+const MODEL_PRICING: Record<string, [number, number]> = {
+  'gpt-4o':              [2.50,  10.00],
+  'gpt-4o-mini':         [0.15,   0.60],
+  'gpt-4.1':             [2.00,   8.00],
+  'gpt-4.1-mini':        [0.40,   1.60],
+  'o3':                  [10.00,  40.00],
+  'o4-mini':             [1.10,   4.40],
+  'claude-opus-4-6':     [15.00,  75.00],
+  'claude-sonnet-4-6':   [3.00,  15.00],
+  'claude-haiku-4-5':    [0.80,   4.00],
+};
+const FALLBACK_PRICING: [number, number] = [2.50, 10.00];
+
+function estimateCost(
+  estimatedSpans: number,
+  samplePercent: number,
+  metricCount: number,
+  model: string,
+): { sampledSpans: number; evalCalls: number; inferenceUsd: number; dtIngestUsd: number; totalUsd: number } {
+  const [inputPricePer1M, outputPricePer1M] =
+    MODEL_PRICING[model] ?? MODEL_PRICING[model.split('-').slice(0, 2).join('-')] ?? FALLBACK_PRICING;
+
+  const sampledSpans = Math.max(1, Math.round(estimatedSpans * samplePercent / 100));
+  const evalCalls = sampledSpans * metricCount;
+
+  const inferenceUsd =
+    (evalCalls * 900  / 1_000_000) * inputPricePer1M +
+    (evalCalls * 200  / 1_000_000) * outputPricePer1M;
+
+  const dtIngestUsd = (evalCalls * 1500 / (1024 ** 3)) * 0.20;
+
+  return { sampledSpans, evalCalls, inferenceUsd, dtIngestUsd, totalUsd: inferenceUsd + dtIngestUsd };
+}
+
+function printCostEstimate(
+  estimatedSpans: number | null,
+  samplePercent: number,
+  metrics: string[],
+  model: string,
+): void {
+  const spansFallback = estimatedSpans ?? 500;
+  const { sampledSpans, evalCalls, inferenceUsd, dtIngestUsd, totalUsd } =
+    estimateCost(spansFallback, samplePercent, metrics.length, model);
+
+  const pricingNote = MODEL_PRICING[model] ? model : `${model} (using GPT-4o pricing as baseline)`;
+  const spansLabel = estimatedSpans != null ? `~${spansFallback}` : `~${spansFallback} (estimated)`;
+
+  console.log('\n  ─── Cost estimate ───────────────────────────────');
+  console.log(`  Spans in window:     ${spansLabel} → ~${sampledSpans} sampled (${samplePercent}%)`);
+  console.log(`  Evaluation calls:    ~${evalCalls}  (${sampledSpans} spans × ${metrics.length} evaluators)`);
+  console.log(`  LLM inference:       ~$${inferenceUsd.toFixed(4)}  (model: ${pricingNote})`);
+  console.log(`  DT bizevent ingest:  ~$${dtIngestUsd.toFixed(5)}`);
+  console.log(`  Total per run:       ~$${totalUsd.toFixed(4)}`);
+  console.log('\n  ⚠  Ballpark only — token counts vary by span length and metric.');
+  console.log('  Always monitor your actual inference costs in your provider dashboard.\n');
+}
+
+async function testServiceSpans(
+  environmentUrl: string,
+  apiToken: string,
+  dtctlContext: string | undefined,
+  serviceName: string,
+): Promise<number | null> {
+  try {
+    const client = new DynatraceClient({ environmentUrl, apiToken, dtctlContext });
+    const query = `fetch spans
+| filter service.name == "${serviceName}" or dt.entity.service == "${serviceName}"
+| filter isNotNull(gen_ai.provider.name)
+| limit 1000
+| summarize count = count()`;
+    const records = await client.executeDql(query) as Array<Record<string, unknown>>;
+    const count = records?.[0]?.['count'];
+    return typeof count === 'number' ? count : null;
+  } catch {
+    return null;
+  }
+}
+
+export function createConfigureCommand(): Command {
+  const cmd = new Command('configure');
+  cmd.description('Configure evaluation settings (interactive wizard or flags)');
+
+  cmd.option('--env-url <url>', 'Dynatrace environment URL');
+  cmd.option('--api-token <token>', 'Dynatrace API token');
+  cmd.option('--provider <provider>', 'Judge provider (openai|anthropic)');
+  cmd.option('--api-key <key>', 'Judge provider API key');
+  cmd.option('--model <model>', 'Judge model override');
+  cmd.option('--since <duration>', 'Default time window (e.g. 1h, 6h, 24h)');
+  cmd.option('--show', 'Print current resolved config with secrets redacted');
+  cmd.option('--output <path>', 'Output config file path (default: <name>.dt-eval.yaml or .dt-eval.yaml)');
+
+  cmd.action(async (options: {
+    envUrl?: string;
+    apiToken?: string;
+    provider?: string;
+    apiKey?: string;
+    model?: string;
+    since?: string;
+    show?: boolean;
+    output?: string;
+  }) => {
+    if (options.show) {
+      try {
+        const config = loadConfig();
+        const redacted = redactSecrets(config);
+        console.log(stringifyYaml(redacted, { indent: 2 }));
+      } catch (err) {
+        logger.error(`Failed to load config: ${(err as Error).message}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    const hasFlags = !!(
+      options.envUrl ||
+      options.apiToken ||
+      options.provider ||
+      options.apiKey ||
+      options.model ||
+      options.since
+    );
+
+    if (!hasFlags) printBanner();
+
+    let existing: Partial<DtEvalConfig> = {};
+    try {
+      existing = loadConfig();
+    } catch {
+      // No existing config, start fresh
+    }
+
+    const availablePrompts = await listPrompts();
+    // LLM-as-judge metrics from the lib + drift as a special population-level metric
+    const allMetricIds = [...availablePrompts.map(p => p.id), DRIFT_METRIC_ID];
+
+    if (!hasFlags) {
+      let inquirer: typeof import('@inquirer/prompts');
+      try {
+        inquirer = await import('@inquirer/prompts');
+      } catch {
+        logger.error('@inquirer/prompts is required for interactive mode');
+        process.exit(1);
+      }
+
+      const { input, password, select, checkbox } = inquirer;
+
+      console.log('\n  dt-eval-cli setup wizard');
+      console.log('  ' + '─'.repeat(30) + '\n');
+
+      // ── Evaluation identity ──────────────────────────────
+      const evalName = await input({
+        message: 'Evaluation name  (e.g. "travel-advisor-prod", "chat-service-staging")',
+        default: existing.name ?? '',
+        validate: (v) => v.trim().length > 0 ? true : 'Name is required',
+      });
+
+      const outputPath = options.output ?? join(process.cwd(), `${evalName.trim()}.dt-eval.yaml`);
+
+      // ── Dynatrace ────────────────────────────────────────
+      const envUrl = await input({
+        message: 'Dynatrace environment URL',
+        default: existing.dynatrace?.environmentUrl ?? '',
+      });
+
+      const apiToken = await password({
+        message: 'Dynatrace API token',
+      });
+
+      const dtctlContext = await input({
+        message: 'dtctl context name for OAuth DQL  (leave blank to use API token)',
+        default: existing.dynatrace?.dtctlContext ?? '',
+      });
+
+      // ── Service ──────────────────────────────────────────
+      const serviceName = await input({
+        message: 'Name of your AI app and service  (service.name in Dynatrace spans)',
+        default: existing.scope?.service ?? '',
+        validate: (v) => v.trim().length > 0 ? true : 'Service name is required',
+      });
+
+      process.stdout.write(`\n  Testing service "${serviceName}" — checking for LLM spans...`);
+      const spanCount = await testServiceSpans(
+        envUrl,
+        apiToken || (existing.dynatrace?.apiToken ?? ''),
+        dtctlContext || undefined,
+        serviceName,
+      );
+
+      if (spanCount === null) {
+        process.stdout.write(' ⚠  Could not query (check token / connectivity)\n');
+      } else if (spanCount === 0) {
+        process.stdout.write(` ⚠  No LLM spans found for "${serviceName}" in the last hour\n`);
+        console.log('  (The service may have no recent activity, or span fields may differ)\n');
+      } else {
+        process.stdout.write(` ✓  Found ~${spanCount} LLM spans\n\n`);
+      }
+
+      // ── Evaluator provider ───────────────────────────────
+      const provider = await select({
+        message: 'Evaluator provider',
+        choices: [
+          { name: 'openai', value: 'openai' as const },
+          { name: 'anthropic', value: 'anthropic' as const },
+        ],
+        default: existing.judge?.provider ?? 'openai',
+      });
+
+      const apiKey = await password({
+        message: provider === 'openai' ? 'OpenAI API key' : 'Anthropic API key',
+      });
+
+      const model = await input({
+        message: 'Evaluator model  (leave blank for provider default)',
+        default: existing.judge?.model ?? '',
+      });
+
+      // ── Evaluators ───────────────────────────────────────
+      const enabledMetrics = existing.metrics?.enabled ?? allMetricIds;
+      const selectedMetrics = await checkbox({
+        message: `Evaluators to run  (${allMetricIds.length - 1} built-in + drift detection)`,
+        choices: [
+          ...availablePrompts.map(p => ({ name: p.id, value: p.id, checked: enabledMetrics.includes(p.id) })),
+          { name: `${DRIFT_METRIC_ID}  (population-level, compares score distributions vs 7d baseline)`, value: DRIFT_METRIC_ID, checked: enabledMetrics.includes(DRIFT_METRIC_ID) },
+        ],
+      });
+
+      // ── Sampling ─────────────────────────────────────────
+      const sampleStr = await input({
+        message: 'Sampling — % of traces to evaluate per run  (range: 1–100, default 5 recommended to control costs)',
+        default: String(existing.scope?.sampling?.percent ?? 5),
+        validate: (v) => {
+          const n = parseInt(v, 10);
+          return (n >= 1 && n <= 100) ? true : 'Enter a number between 1 and 100';
+        },
+      });
+
+      const since = await input({
+        message: 'Default time window',
+        default: existing.scope?.since ?? '1h',
+      });
+
+      const updated: DtEvalConfig = {
+        schemaVersion: existing.schemaVersion ?? 1,
+        name: evalName.trim(),
+        dynatrace: {
+          environmentUrl: envUrl,
+          apiToken: apiToken || existing.dynatrace?.apiToken,
+          ...(dtctlContext ? { dtctlContext } : {}),
+        },
+        judge: {
+          provider,
+          apiKey: apiKey || existing.judge?.apiKey,
+          model: model || existing.judge?.model,
+          timeout: existing.judge?.timeout ?? 30000,
+          maxRetries: existing.judge?.maxRetries ?? 2,
+        },
+        scope: {
+          service: serviceName.trim(),
+          since,
+          sampling: {
+            strategy: 'random',
+            percent: parseInt(sampleStr, 10),
+          },
+        },
+        metrics: {
+          enabled: selectedMetrics.length > 0 ? selectedMetrics : enabledMetrics,
+        },
+        alerts: existing.alerts,
+      };
+
+      try {
+        validateConfig(updated);
+      } catch (err) {
+        logger.warn(`Config has validation issues — ${(err as Error).message}`);
+        logger.warn('Config saved anyway. Run "dt-eval-cli validate" to check.');
+      }
+
+      try {
+        saveConfig(updated, outputPath);
+        logger.success(`Config saved to ${outputPath}`);
+      } catch (err) {
+        logger.error(`Failed to save config: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      printCostEstimate(
+        spanCount != null && spanCount > 0 ? spanCount : null,
+        parseInt(sampleStr, 10),
+        updated.metrics.enabled,
+        updated.judge.model ?? (updated.judge.provider === 'openai' ? 'gpt-4o' : 'claude-sonnet-4-6'),
+      );
+
+      return;
+    }
+
+    // ── Flag-only mode ────────────────────────────────────
+    const updated: DtEvalConfig = {
+      schemaVersion: existing.schemaVersion ?? 1,
+      name: existing.name,
+      dynatrace: {
+        environmentUrl: options.envUrl ?? existing.dynatrace?.environmentUrl ?? '',
+        apiToken: options.apiToken ?? existing.dynatrace?.apiToken,
+      },
+      judge: {
+        provider: (options.provider as 'openai' | 'anthropic') ?? existing.judge?.provider ?? 'openai',
+        apiKey: options.apiKey ?? existing.judge?.apiKey,
+        model: options.model ?? existing.judge?.model,
+        timeout: existing.judge?.timeout ?? 30000,
+        maxRetries: existing.judge?.maxRetries ?? 2,
+      },
+      scope: existing.scope ?? {
+        since: options.since ?? '1h',
+        sampling: { strategy: 'random', percent: 5 },
+      },
+      metrics: existing.metrics ?? { enabled: allMetricIds },
+      alerts: existing.alerts,
+    };
+
+    if (options.since) updated.scope.since = options.since;
+
+    const outputPath = options.output ?? join(process.cwd(), updated.name ? `${updated.name}.dt-eval.yaml` : '.dt-eval.yaml');
+
+    try {
+      validateConfig(updated);
+    } catch (err) {
+      console.warn(`Warning: config has validation issues — ${(err as Error).message}`);
+      console.warn('Config saved anyway. Run "dt-eval-cli validate" to check.');
+    }
+
+    try {
+      saveConfig(updated, outputPath);
+      console.log(`Config saved to ${outputPath}`);
+    } catch (err) {
+      console.error(`Failed to save config: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { join } from 'node:path';
 import { loadConfig, saveConfig, validateConfig } from '../../config/index.js';
 import type { DtEvalConfig } from '../../config/schema.js';
+import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
 import { stringify as stringifyYaml } from 'yaml';
 import { redactSecrets } from '../../ui/format.js';
 import { logger } from '../../logger/index.js';
@@ -20,6 +21,15 @@ const MODEL_PRICING: Record<string, [number, number]> = {
   'claude-opus-4-6':     [15.00,  75.00],
   'claude-sonnet-4-6':   [3.00,  15.00],
   'claude-haiku-4-5':    [0.80,   4.00],
+  // Azure OpenAI — same as upstream OpenAI pricing
+  'gpt-4o (azure)':      [2.50,  10.00],
+  // Gemini
+  'gemini-2.0-flash':    [0.10,   0.40],
+  'gemini-1.5-pro':      [3.50,  10.50],
+  'gemini-1.5-flash':    [0.075,  0.30],
+  // Bedrock (Claude via Bedrock)
+  'anthropic.claude-sonnet-4-5-20251001-v1:0': [3.00, 15.00],
+  'anthropic.claude-haiku-3-5-20241022-v1:0':  [0.80,  4.00],
 };
 const FALLBACK_PRICING: [number, number] = [2.50, 10.00];
 
@@ -142,7 +152,7 @@ export function createConfigureCommand(): Command {
     }
 
     const availablePrompts = await listPrompts();
-    // LLM-as-judge metrics from the lib + drift as a special population-level metric
+    // Built-in evaluators from the lib + drift as a special population-level evaluator
     const allMetricIds = [...availablePrompts.map(p => p.id), DRIFT_METRIC_ID];
 
     if (!hasFlags) {
@@ -211,15 +221,34 @@ export function createConfigureCommand(): Command {
       const provider = await select({
         message: 'Evaluator provider',
         choices: [
-          { name: 'openai', value: 'openai' as const },
-          { name: 'anthropic', value: 'anthropic' as const },
+          { name: 'openai       — OpenAI API (GPT models)', value: 'openai' as const },
+          { name: 'anthropic    — Anthropic API (Claude models)', value: 'anthropic' as const },
+          { name: 'azure-openai — Azure OpenAI deployment', value: 'azure-openai' as const },
+          { name: 'gemini       — Google Gemini API', value: 'gemini' as const },
+          { name: 'bedrock      — AWS Bedrock (uses AWS credential chain)', value: 'bedrock' as const },
         ],
         default: existing.judge?.provider ?? 'openai',
       });
 
-      const apiKey = await password({
-        message: provider === 'openai' ? 'OpenAI API key' : 'Anthropic API key',
-      });
+      const providerApiKeyLabel: Record<string, string> = {
+        openai: 'OpenAI API key',
+        anthropic: 'Anthropic API key',
+        'azure-openai': 'Azure OpenAI API key (AZURE_OPENAI_API_KEY)',
+        gemini: 'Gemini API key (GEMINI_API_KEY or GOOGLE_API_KEY)',
+        bedrock: 'AWS region for Bedrock (e.g. us-east-1) — leave blank to use AWS_REGION env var',
+      };
+
+      let apiKey: string;
+      if (provider === 'bedrock') {
+        apiKey = await input({
+          message: providerApiKeyLabel[provider],
+          default: existing.judge?.region ?? process.env['AWS_REGION'] ?? 'us-east-1',
+        });
+      } else {
+        apiKey = await password({
+          message: providerApiKeyLabel[provider] ?? `${provider} API key`,
+        });
+      }
 
       const model = await input({
         message: 'Evaluator model  (leave blank for provider default)',
@@ -261,7 +290,9 @@ export function createConfigureCommand(): Command {
         },
         judge: {
           provider,
-          apiKey: apiKey || existing.judge?.apiKey,
+          ...(provider === 'bedrock'
+            ? { region: apiKey || existing.judge?.region }
+            : { apiKey: apiKey || existing.judge?.apiKey }),
           model: model || existing.judge?.model,
           timeout: existing.judge?.timeout ?? 30000,
           maxRetries: existing.judge?.maxRetries ?? 2,
@@ -299,7 +330,7 @@ export function createConfigureCommand(): Command {
         spanCount != null && spanCount > 0 ? spanCount : null,
         parseInt(sampleStr, 10),
         updated.metrics.enabled,
-        updated.judge.model ?? (updated.judge.provider === 'openai' ? 'gpt-4o' : 'claude-sonnet-4-6'),
+        updated.judge.model ?? DEFAULT_JUDGE_MODELS[updated.judge.provider] ?? 'gpt-4o',
       );
 
       return;
@@ -314,7 +345,7 @@ export function createConfigureCommand(): Command {
         apiToken: options.apiToken ?? existing.dynatrace?.apiToken,
       },
       judge: {
-        provider: (options.provider as 'openai' | 'anthropic') ?? existing.judge?.provider ?? 'openai',
+        provider: (options.provider as DtEvalConfig['judge']['provider']) ?? existing.judge?.provider ?? 'openai',
         apiKey: options.apiKey ?? existing.judge?.apiKey,
         model: options.model ?? existing.judge?.model,
         timeout: existing.judge?.timeout ?? 30000,

--- a/dt-eval-cli/src/cli/commands/evaluators.ts
+++ b/dt-eval-cli/src/cli/commands/evaluators.ts
@@ -1,0 +1,229 @@
+import { Command } from 'commander';
+import { listPrompts, getPrompt, createCustomPrompt, deleteCustomPrompt, evaluate } from 'dt-eval-lib';
+import type { EvalConfig } from 'dt-eval-lib';
+import { loadConfig } from '../../config/index.js';
+import { renderTable } from '../../ui/table.js';
+import { Spinner } from '../../ui/spinner.js';
+import { logger } from '../../logger/index.js';
+
+export function createEvaluatorsCommand(): Command {
+  const cmd = new Command('evaluators');
+  cmd.description('Manage evaluator definitions (built-in and custom)');
+
+  // evaluators list
+  const listCmd = new Command('list');
+  listCmd.description('List all available evaluators');
+
+  listCmd.action(async () => {
+    const prompts = await listPrompts();
+    if (prompts.length === 0) {
+      logger.info('No evaluators available.');
+      return;
+    }
+
+    const headers = ['ID', 'Name', 'Type', 'Scale', 'Required Fields'];
+    const rows = prompts.map(p => {
+      const isBuiltIn = !('custom' in p) || !(p as Record<string, unknown>)['custom'];
+      return [
+        p.id,
+        p.name,
+        isBuiltIn ? 'built-in' : 'custom',
+        p.scoring.type,
+        p.requiredFields.join(', '),
+      ];
+    });
+
+    console.log(renderTable(headers, rows));
+  });
+
+  // evaluators show <id>
+  const showCmd = new Command('show');
+  showCmd.description('Show an evaluator definition');
+  showCmd.argument('<id>', 'Evaluator ID');
+
+  showCmd.action(async (id: string) => {
+    try {
+      const prompt = await getPrompt(id);
+      console.log(`ID: ${prompt.id}`);
+      console.log(`Name: ${prompt.name}`);
+      console.log(`Version: ${prompt.version}`);
+      console.log(`Description: ${prompt.description}`);
+      console.log(`Required Fields: ${prompt.requiredFields.join(', ')}`);
+      console.log(`Scoring Scale: ${prompt.scoring.type}`);
+      if ('threshold' in prompt.scoring) {
+        console.log(`Pass Threshold: ${(prompt.scoring as Record<string, unknown>)['threshold']}`);
+      }
+      console.log(`\nPrompt Template:\n${prompt.prompt}`);
+    } catch (err) {
+      logger.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+  // evaluators add
+  const addCmd = new Command('add');
+  addCmd.description('Add a custom evaluator (interactive wizard)');
+
+  addCmd.action(async () => {
+    let input: typeof import('@inquirer/prompts');
+    try {
+      input = await import('@inquirer/prompts');
+    } catch {
+      logger.error('@inquirer/prompts is required for interactive mode');
+      process.exit(1);
+    }
+
+    const { input: promptInput, password: _password, select, checkbox } = input;
+
+    const name = await promptInput({ message: 'Evaluator name' });
+    const template = await promptInput({ message: 'Prompt template ({{input}} and {{output}} are required placeholders)' });
+
+    const requiredFieldChoices = [
+      { name: 'input', value: 'input' as const, checked: true },
+      { name: 'output', value: 'output' as const, checked: true },
+      { name: 'context', value: 'context' as const, checked: false },
+      { name: 'expected_output', value: 'expected_output' as const, checked: false },
+    ];
+
+    const requiredFields = await checkbox({
+      message: 'Required fields',
+      choices: requiredFieldChoices,
+    });
+
+    const scoringType = await select({
+      message: 'Scoring scale',
+      choices: [
+        { name: 'continuous', value: 'continuous' },
+        { name: 'binary', value: 'binary' },
+        { name: 'likert', value: 'likert' },
+      ],
+    });
+
+    const thresholdStr = await promptInput({ message: 'Pass threshold', default: '0.7' });
+    const threshold = parseFloat(thresholdStr);
+
+    const description = await promptInput({ message: 'Description (optional)', default: '' });
+
+    const id = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+    try {
+      await createCustomPrompt({
+        id,
+        name,
+        description: description || name,
+        prompt: template,
+        requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expected_output')[],
+        scoring: {
+          type: scoringType as 'continuous' | 'binary' | 'likert',
+          threshold,
+        } as Parameters<typeof createCustomPrompt>[0]['scoring'],
+      });
+      logger.success(`Custom evaluator "${id}" created`);
+    } catch (err) {
+      logger.error(`Failed to create evaluator: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+  // evaluators delete <id>
+  const deleteCmd = new Command('delete');
+  deleteCmd.description('Delete a custom evaluator');
+  deleteCmd.argument('<id>', 'Evaluator ID');
+
+  deleteCmd.action(async (id: string) => {
+    let inquirer: typeof import('@inquirer/prompts');
+    try {
+      inquirer = await import('@inquirer/prompts');
+    } catch {
+      logger.error('@inquirer/prompts is required for interactive mode');
+      process.exit(1);
+    }
+
+    const { confirm } = inquirer;
+    const confirmed = await confirm({ message: `Delete evaluator "${id}"? This cannot be undone.` });
+    if (!confirmed) {
+      logger.info('Aborted.');
+      return;
+    }
+
+    try {
+      await deleteCustomPrompt(id);
+      logger.success(`Evaluator "${id}" deleted`);
+    } catch (err) {
+      logger.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+  // evaluators test <id>
+  const testCmd = new Command('test');
+  testCmd.description('Test an evaluator with sample input interactively');
+  testCmd.argument('<id>', 'Evaluator ID');
+
+  testCmd.action(async (id: string) => {
+    try {
+      await getPrompt(id);
+    } catch (err) {
+      logger.error((err as Error).message);
+      process.exit(1);
+    }
+
+    let inquirer: typeof import('@inquirer/prompts');
+    try {
+      inquirer = await import('@inquirer/prompts');
+    } catch {
+      logger.error('@inquirer/prompts is required for interactive mode');
+      process.exit(1);
+    }
+
+    const { input: promptInput } = inquirer;
+
+    const inputText = await promptInput({ message: 'Input (user question)' });
+    const outputText = await promptInput({ message: 'Output (LLM response)' });
+    const contextText = await promptInput({ message: 'Context (optional, enter to skip)', default: '' });
+
+    let config;
+    try {
+      config = loadConfig();
+    } catch (err) {
+      logger.error(`Config error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    const libConfig: EvalConfig = {
+      provider: config.judge.provider,
+      apiKey: config.judge.apiKey,
+      model: config.judge.model,
+      timeout: config.judge.timeout,
+      maxRetries: config.judge.maxRetries,
+    };
+
+    const spinner = new Spinner(`Running evaluation with ${config.judge.provider}/${config.judge.model ?? 'default'}...`);
+    spinner.start();
+
+    try {
+      const result = await evaluate(id, {
+        input: inputText,
+        output: outputText,
+        context: contextText || undefined,
+      }, libConfig);
+
+      spinner.succeed(`Score: ${result.score.value.toFixed(2)} (${result.score.label})`);
+      console.log(`  Summary: ${result.explanation.summary}`);
+      if ('reasoning' in result.explanation) {
+        console.log(`  Reasoning: ${result.explanation['reasoning']}`);
+      }
+    } catch (err) {
+      spinner.fail(`Evaluation failed: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+  cmd.addCommand(listCmd);
+  cmd.addCommand(showCmd);
+  cmd.addCommand(addCmd);
+  cmd.addCommand(deleteCmd);
+  cmd.addCommand(testCmd);
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/prompts.ts
+++ b/dt-eval-cli/src/cli/commands/prompts.ts
@@ -1,0 +1,230 @@
+import { Command } from 'commander';
+import { listPrompts, getPrompt, createCustomPrompt, deleteCustomPrompt, evaluate } from 'dt-eval-lib';
+import type { EvalConfig } from 'dt-eval-lib';
+import { loadConfig } from '../../config/index.js';
+import { renderTable } from '../../ui/table.js';
+import { Spinner } from '../../ui/spinner.js';
+import { logger } from '../../logger/index.js';
+
+export function createPromptsCommand(): Command {
+  const cmd = new Command('prompts');
+  cmd.description('Manage evaluation prompt definitions');
+
+  // prompts list
+  const listCmd = new Command('list');
+  listCmd.description('List all available prompts');
+
+  listCmd.action(async () => {
+    const prompts = await listPrompts();
+    if (prompts.length === 0) {
+      logger.info('No prompts available.');
+      return;
+    }
+
+    const headers = ['ID', 'Name', 'Type', 'Scale', 'Required Fields'];
+    const rows = prompts.map(p => {
+      const isBuiltIn = !('custom' in p) || !(p as Record<string, unknown>)['custom'];
+      return [
+        p.id,
+        p.name,
+        isBuiltIn ? 'built-in' : 'custom',
+        p.scoring.type,
+        p.requiredFields.join(', '),
+      ];
+    });
+
+    console.log(renderTable(headers, rows));
+  });
+
+  // prompts show <id>
+  const showCmd = new Command('show');
+  showCmd.description('Show a prompt definition');
+  showCmd.argument('<id>', 'Prompt ID');
+
+  showCmd.action(async (id: string) => {
+    try {
+      const prompt = await getPrompt(id);
+      console.log(`ID: ${prompt.id}`);
+      console.log(`Name: ${prompt.name}`);
+      console.log(`Version: ${prompt.version}`);
+      console.log(`Description: ${prompt.description}`);
+      console.log(`Required Fields: ${prompt.requiredFields.join(', ')}`);
+      console.log(`Scoring Scale: ${prompt.scoring.type}`);
+      if ('threshold' in prompt.scoring) {
+        console.log(`Pass Threshold: ${(prompt.scoring as Record<string, unknown>)['threshold']}`);
+      }
+      console.log(`\nPrompt Template:\n${prompt.prompt}`);
+    } catch (err) {
+      logger.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+  // prompts add
+  const addCmd = new Command('add');
+  addCmd.description('Add a custom prompt (interactive wizard)');
+
+  addCmd.action(async () => {
+    let input: typeof import('@inquirer/prompts');
+    try {
+      input = await import('@inquirer/prompts');
+    } catch {
+      logger.error('@inquirer/prompts is required for interactive mode');
+      process.exit(1);
+    }
+
+    const { input: promptInput, password: _password, select, checkbox } = input;
+
+    const name = await promptInput({ message: 'Prompt name' });
+    const template = await promptInput({ message: 'Prompt template ({{input}} and {{output}} are required placeholders)' });
+
+    const requiredFieldChoices = [
+      { name: 'input', value: 'input' as const, checked: true },
+      { name: 'output', value: 'output' as const, checked: true },
+      { name: 'context', value: 'context' as const, checked: false },
+      { name: 'expected_output', value: 'expected_output' as const, checked: false },
+    ];
+
+    const requiredFields = await checkbox({
+      message: 'Required fields',
+      choices: requiredFieldChoices,
+    });
+
+    const scoringType = await select({
+      message: 'Scoring scale',
+      choices: [
+        { name: 'continuous', value: 'continuous' },
+        { name: 'binary', value: 'binary' },
+        { name: 'likert', value: 'likert' },
+      ],
+    });
+
+    const thresholdStr = await promptInput({ message: 'Pass threshold', default: '0.7' });
+    const threshold = parseFloat(thresholdStr);
+
+    const description = await promptInput({ message: 'Description (optional)', default: '' });
+
+    const id = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+
+    try {
+      await createCustomPrompt({
+        id,
+        name,
+        description: description || name,
+        prompt: template,
+        requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expected_output')[],
+        scoring: {
+          type: scoringType as 'continuous' | 'binary' | 'likert',
+          threshold,
+        } as Parameters<typeof createCustomPrompt>[0]['scoring'],
+      });
+      logger.success(`Custom prompt "${id}" created`);
+    } catch (err) {
+      logger.error(`Failed to create prompt: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+  // prompts remove <id>
+  const removeCmd = new Command('remove');
+  removeCmd.description('Remove a custom prompt');
+  removeCmd.argument('<id>', 'Prompt ID');
+
+  removeCmd.action(async (id: string) => {
+    let inquirer: typeof import('@inquirer/prompts');
+    try {
+      inquirer = await import('@inquirer/prompts');
+    } catch {
+      logger.error('@inquirer/prompts is required for interactive mode');
+      process.exit(1);
+    }
+
+    const { confirm } = inquirer;
+    const confirmed = await confirm({ message: `Delete prompt "${id}"? This cannot be undone.` });
+    if (!confirmed) {
+      logger.info('Aborted.');
+      return;
+    }
+
+    try {
+      await deleteCustomPrompt(id);
+      logger.success(`Prompt "${id}" deleted`);
+    } catch (err) {
+      logger.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+  // prompts test <id>
+  const testCmd = new Command('test');
+  testCmd.description('Test a prompt with sample input interactively');
+  testCmd.argument('<id>', 'Prompt ID');
+
+  testCmd.action(async (id: string) => {
+    // Verify prompt exists
+    try {
+      await getPrompt(id);
+    } catch (err) {
+      logger.error((err as Error).message);
+      process.exit(1);
+    }
+
+    let inquirer: typeof import('@inquirer/prompts');
+    try {
+      inquirer = await import('@inquirer/prompts');
+    } catch {
+      logger.error('@inquirer/prompts is required for interactive mode');
+      process.exit(1);
+    }
+
+    const { input: promptInput } = inquirer;
+
+    const inputText = await promptInput({ message: 'Input (user question)' });
+    const outputText = await promptInput({ message: 'Output (LLM response)' });
+    const contextText = await promptInput({ message: 'Context (optional, enter to skip)', default: '' });
+
+    let config;
+    try {
+      config = loadConfig();
+    } catch (err) {
+      logger.error(`Config error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    const libConfig: EvalConfig = {
+      provider: config.judge.provider,
+      apiKey: config.judge.apiKey,
+      model: config.judge.model,
+      timeout: config.judge.timeout,
+      maxRetries: config.judge.maxRetries,
+    };
+
+    const spinner = new Spinner(`Evaluating with ${config.judge.provider}/${config.judge.model ?? 'default'}...`);
+    spinner.start();
+
+    try {
+      const result = await evaluate(id, {
+        input: inputText,
+        output: outputText,
+        context: contextText || undefined,
+      }, libConfig);
+
+      spinner.succeed(`Score: ${result.score.value.toFixed(2)} (${result.score.label})`);
+      console.log(`  Summary: ${result.explanation.summary}`);
+      if ('reasoning' in result.explanation) {
+        console.log(`  Reasoning: ${result.explanation['reasoning']}`);
+      }
+    } catch (err) {
+      spinner.fail(`Evaluation failed: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+  cmd.addCommand(listCmd);
+  cmd.addCommand(showCmd);
+  cmd.addCommand(addCmd);
+  cmd.addCommand(removeCmd);
+  cmd.addCommand(testCmd);
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/results.ts
+++ b/dt-eval-cli/src/cli/commands/results.ts
@@ -1,0 +1,110 @@
+import { Command } from 'commander';
+import { writeFileSync } from 'node:fs';
+import { readRunRecords } from '../../runner/checkpoint.js';
+import type { RunRecord } from '../../runner/checkpoint.js';
+import { renderTable } from '../../ui/table.js';
+import { formatDuration } from '../../ui/format.js';
+import { logger } from '../../logger/index.js';
+
+function formatCsv(records: RunRecord[]): string {
+  const headers = ['runId', 'timestamp', 'spansEvaluated', 'resultsWritten', 'errors', 'thresholdBreaches', 'durationMs', 'metrics', 'since'];
+  const rows = records.map(r => [
+    r.runId,
+    r.timestamp,
+    String(r.spansEvaluated),
+    String(r.resultsWritten),
+    String(r.errors),
+    String(r.thresholdBreaches),
+    String(r.durationMs),
+    r.metrics.join(';'),
+    r.since,
+  ].map(v => `"${v}"`).join(','));
+  return [headers.join(','), ...rows].join('\n');
+}
+
+export function createResultsCommand(): Command {
+  const cmd = new Command('results');
+  cmd.description('View and export evaluation run results');
+
+  // results list
+  const listCmd = new Command('list');
+  listCmd.description('List recent evaluation runs');
+  listCmd.option('--limit <n>', 'Number of runs to show', parseInt, 10);
+
+  listCmd.action(async (options: { limit: number }) => {
+    const records = await readRunRecords();
+    if (records.length === 0) {
+      logger.info('No run records found.');
+      return;
+    }
+
+    const recent = records.slice(-options.limit);
+    const headers = ['Run ID', 'Timestamp', 'Spans', 'Results', 'Errors', 'Breaches', 'Duration'];
+    const rows = recent.map(r => [
+      r.runId,
+      new Date(r.timestamp).toLocaleString(),
+      String(r.spansEvaluated),
+      String(r.resultsWritten),
+      String(r.errors),
+      String(r.thresholdBreaches),
+      formatDuration(r.durationMs),
+    ]);
+
+    console.log(renderTable(headers, rows));
+  });
+
+  // results show <runId>
+  const showCmd = new Command('show');
+  showCmd.description('Show details of a specific run');
+  showCmd.argument('<runId>', 'Run ID');
+
+  showCmd.action(async (runId: string) => {
+    const records = await readRunRecords();
+    const record = records.find(r => r.runId === runId || r.runId.startsWith(runId));
+
+    if (!record) {
+      logger.error(`Run not found: ${runId}`);
+      process.exit(1);
+    }
+
+    console.log(`Run ID: ${record.runId}`);
+    console.log(`Timestamp: ${record.timestamp}`);
+    console.log(`Since: ${record.since}`);
+    console.log(`Metrics: ${record.metrics.join(', ')}`);
+    console.log(`Spans Evaluated: ${record.spansEvaluated}`);
+    console.log(`Results Written: ${record.resultsWritten}`);
+    console.log(`Errors: ${record.errors}`);
+    console.log(`Threshold Breaches: ${record.thresholdBreaches}`);
+    console.log(`Duration: ${formatDuration(record.durationMs)}`);
+  });
+
+  // results export
+  const exportCmd = new Command('export');
+  exportCmd.description('Export run records to JSON or CSV');
+  exportCmd.option('--format <format>', 'Output format: json or csv', 'json');
+  exportCmd.option('--output <path>', 'Output file path');
+
+  exportCmd.action(async (options: { format: string; output?: string }) => {
+    const records = await readRunRecords();
+
+    let content: string;
+    if (options.format === 'csv') {
+      content = formatCsv(records);
+    } else {
+      content = JSON.stringify(records, null, 2);
+    }
+
+    if (options.output) {
+      writeFileSync(options.output, content, 'utf-8');
+      logger.success(`Exported ${records.length} records to ${options.output}`);
+    } else {
+      console.log(content);
+    }
+  });
+
+  cmd.addCommand(listCmd);
+  cmd.addCommand(showCmd);
+  cmd.addCommand(exportCmd);
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -1,0 +1,122 @@
+import { Command } from 'commander';
+import { loadConfig, validateConfig } from '../../config/index.js';
+import { DynatraceClient } from '../../dt/client.js';
+import { runEvals } from '../../runner/index.js';
+import { Spinner } from '../../ui/spinner.js';
+import { renderTable } from '../../ui/table.js';
+import { formatDuration } from '../../ui/format.js';
+import { logger, configureLogger } from '../../logger/index.js';
+
+export function createRunCommand(): Command {
+  const cmd = new Command('run');
+  cmd.description('Run evaluations against recent GenAI traces from Dynatrace');
+
+  cmd.option('--config <path>', 'Path to eval config file (e.g. travel-advisor.dt-eval.yaml)');
+  cmd.option('--since <duration>', 'Time window for trace fetch (e.g. 1h, 6h, 24h)', '1h');
+  cmd.option('--sample <percent>', 'Percentage of traces to evaluate (0-100)', parseFloat, 100);
+  cmd.option('--metric <name>', 'Run a specific evaluator only');
+  cmd.option('--dry-run', 'Fetch and transform traces, print payloads, do not send');
+  cmd.option('--ci', 'Non-interactive mode: JSON stdout, exit 1 on threshold breach');
+  cmd.option('--concurrency <n>', 'Number of parallel evaluation workers', (v) => parseInt(v, 10), 5);
+  cmd.option('--debug', 'Enable debug logging with per-step timing');
+
+  cmd.action(async (options: {
+    config?: string;
+    since: string;
+    sample: number;
+    metric?: string;
+    dryRun?: boolean;
+    ci?: boolean;
+    concurrency: number;
+    debug?: boolean;
+  }) => {
+    if (options.debug) {
+      configureLogger({ level: 'debug' });
+    }
+    let config;
+    try {
+      config = loadConfig(options.config ? { projectFile: options.config } : undefined);
+      validateConfig(config);
+    } catch (err) {
+      if (options.ci) {
+        console.log(JSON.stringify({ error: (err as Error).message }));
+        process.exit(1);
+      }
+      logger.error(`Config error: ${(err as Error).message}`);
+      logger.error('Run "dt-eval-cli configure" to set up your configuration.');
+      process.exit(1);
+    }
+
+    const apiToken = config.dynatrace.apiToken;
+    if (!apiToken) {
+      const msg = 'dynatrace.apiToken is required. Set DT_API_TOKEN env var or configure it.';
+      if (options.ci) {
+        console.log(JSON.stringify({ error: msg }));
+      } else {
+        logger.error(msg);
+      }
+      process.exit(1);
+    }
+
+    const dtClient = new DynatraceClient({
+      environmentUrl: config.dynatrace.environmentUrl,
+      apiToken,
+      dtctlContext: config.dynatrace.dtctlContext,
+    });
+
+    const spinner = options.ci ? null : new Spinner('Fetching GenAI spans from Dynatrace...');
+    spinner?.start();
+
+    try {
+      const result = await runEvals(dtClient, config, {
+        since: options.since,
+        sample: options.sample,
+        metrics: options.metric ? [options.metric] : undefined,
+        dryRun: options.dryRun,
+        ci: options.ci,
+        concurrency: options.concurrency,
+      });
+
+      spinner?.succeed(`Evaluation run complete in ${formatDuration(result.durationMs)}`);
+
+      if (!options.ci && !options.dryRun) {
+        const metrics = options.metric ? [options.metric] : config.metrics.enabled;
+
+        console.log('\nEvaluation results:');
+        const headers = ['Evaluator', 'Results', 'Errors', 'Duration'];
+        const rows = metrics.map(m => [
+          m,
+          String(Math.floor(result.resultsWritten / metrics.length)),
+          String(result.errors > 0 ? Math.ceil(result.errors / metrics.length) : 0),
+          formatDuration(result.durationMs),
+        ]);
+        console.log(renderTable(headers, rows));
+
+        console.log(`\nRun ${result.runId} complete in ${formatDuration(result.durationMs)}`);
+        console.log(`${result.resultsWritten} evaluation results written to Dynatrace`);
+
+        if (result.thresholdBreaches.length > 0) {
+          logger.warn(`Threshold breaches: ${result.thresholdBreaches.length}`);
+          for (const breach of result.thresholdBreaches) {
+            logger.warn(`  - ${breach.metric} [${breach.traceId}]: score=${breach.score}`);
+          }
+        }
+      }
+
+      if (options.ci && result.thresholdBreaches.length > 0) {
+        process.exit(1);
+      }
+    } catch (err) {
+      const msg = (err as Error).message;
+      spinner?.fail(`Evaluation run failed: ${msg}`);
+      if (options.ci) {
+        console.log(JSON.stringify({ error: msg }));
+      } else {
+        logger.error(`Evaluation run failed: ${msg}`);
+      }
+      process.exit(1);
+    }
+  });
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/runs.ts
+++ b/dt-eval-cli/src/cli/commands/runs.ts
@@ -1,0 +1,110 @@
+import { Command } from 'commander';
+import { writeFileSync } from 'node:fs';
+import { readRunRecords } from '../../runner/checkpoint.js';
+import type { RunRecord } from '../../runner/checkpoint.js';
+import { renderTable } from '../../ui/table.js';
+import { formatDuration } from '../../ui/format.js';
+import { logger } from '../../logger/index.js';
+
+function formatCsv(records: RunRecord[]): string {
+  const headers = ['runId', 'timestamp', 'spansEvaluated', 'resultsWritten', 'errors', 'thresholdBreaches', 'durationMs', 'metrics', 'since'];
+  const rows = records.map(r => [
+    r.runId,
+    r.timestamp,
+    String(r.spansEvaluated),
+    String(r.resultsWritten),
+    String(r.errors),
+    String(r.thresholdBreaches),
+    String(r.durationMs),
+    r.metrics.join(';'),
+    r.since,
+  ].map(v => `"${v}"`).join(','));
+  return [headers.join(','), ...rows].join('\n');
+}
+
+export function createRunsCommand(): Command {
+  const cmd = new Command('runs');
+  cmd.description('View and export past evaluation runs');
+
+  // runs list
+  const listCmd = new Command('list');
+  listCmd.description('List recent evaluation runs');
+  listCmd.option('--limit <n>', 'Number of runs to show', parseInt, 10);
+
+  listCmd.action(async (options: { limit: number }) => {
+    const records = await readRunRecords();
+    if (records.length === 0) {
+      logger.info('No evaluation runs found.');
+      return;
+    }
+
+    const recent = records.slice(-options.limit);
+    const headers = ['Run ID', 'Timestamp', 'Spans', 'Results', 'Errors', 'Breaches', 'Duration'];
+    const rows = recent.map(r => [
+      r.runId,
+      new Date(r.timestamp).toLocaleString(),
+      String(r.spansEvaluated),
+      String(r.resultsWritten),
+      String(r.errors),
+      String(r.thresholdBreaches),
+      formatDuration(r.durationMs),
+    ]);
+
+    console.log(renderTable(headers, rows));
+  });
+
+  // runs show <runId>
+  const showCmd = new Command('show');
+  showCmd.description('Show details of a specific evaluation run');
+  showCmd.argument('<runId>', 'Run ID');
+
+  showCmd.action(async (runId: string) => {
+    const records = await readRunRecords();
+    const record = records.find(r => r.runId === runId || r.runId.startsWith(runId));
+
+    if (!record) {
+      logger.error(`Evaluation run not found: ${runId}`);
+      process.exit(1);
+    }
+
+    console.log(`Run ID:              ${record.runId}`);
+    console.log(`Timestamp:           ${record.timestamp}`);
+    console.log(`Time window:         ${record.since}`);
+    console.log(`Evaluators:          ${record.metrics.join(', ')}`);
+    console.log(`Spans evaluated:     ${record.spansEvaluated}`);
+    console.log(`Results written:     ${record.resultsWritten}`);
+    console.log(`Errors:              ${record.errors}`);
+    console.log(`Threshold breaches:  ${record.thresholdBreaches}`);
+    console.log(`Duration:            ${formatDuration(record.durationMs)}`);
+  });
+
+  // runs export
+  const exportCmd = new Command('export');
+  exportCmd.description('Export evaluation run history to JSON or CSV');
+  exportCmd.option('--format <format>', 'Output format: json or csv', 'json');
+  exportCmd.option('--output <path>', 'Output file path');
+
+  exportCmd.action(async (options: { format: string; output?: string }) => {
+    const records = await readRunRecords();
+
+    let content: string;
+    if (options.format === 'csv') {
+      content = formatCsv(records);
+    } else {
+      content = JSON.stringify(records, null, 2);
+    }
+
+    if (options.output) {
+      writeFileSync(options.output, content, 'utf-8');
+      logger.success(`Exported ${records.length} evaluation runs to ${options.output}`);
+    } else {
+      console.log(content);
+    }
+  });
+
+  cmd.addCommand(listCmd);
+  cmd.addCommand(showCmd);
+  cmd.addCommand(exportCmd);
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/schedule.ts
+++ b/dt-eval-cli/src/cli/commands/schedule.ts
@@ -1,0 +1,241 @@
+import { Command } from 'commander';
+import { randomUUID } from 'node:crypto';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig, validateConfig } from '../../config/index.js';
+import { DynatraceClient } from '../../dt/client.js';
+import { runEvals } from '../../runner/index.js';
+import { renderTable } from '../../ui/table.js';
+import { logger } from '../../logger/index.js';
+
+interface Schedule {
+  id: string;
+  name?: string;
+  cron: string;
+  since: string;
+  sample: number;
+  metrics?: string[];
+  enabled: boolean;
+  createdAt: string;
+  lastRunAt?: string;
+}
+
+const DEFAULT_STORAGE_DIR = join(homedir(), '.dt-eval');
+
+function getSchedulesPath(storageDir: string): string {
+  return join(storageDir, 'schedules.json');
+}
+
+async function readSchedules(storageDir?: string): Promise<Schedule[]> {
+  const dir = storageDir ?? DEFAULT_STORAGE_DIR;
+  const filePath = getSchedulesPath(dir);
+
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const schedules = JSON.parse(content) as Schedule[];
+    if (!Array.isArray(schedules)) return [];
+    return schedules;
+  } catch {
+    return [];
+  }
+}
+
+async function writeSchedules(schedules: Schedule[], storageDir?: string): Promise<void> {
+  const dir = storageDir ?? DEFAULT_STORAGE_DIR;
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const filePath = getSchedulesPath(dir);
+  writeFileSync(filePath, JSON.stringify(schedules, null, 2), 'utf-8');
+}
+
+function validateCron(cron: string): boolean {
+  const parts = cron.trim().split(/\s+/);
+  return parts.length === 5;
+}
+
+export function createScheduleCommand(): Command {
+  const cmd = new Command('schedule');
+  cmd.description('Manage scheduled evaluation runs');
+
+  // schedule add
+  const setCmd = new Command('add');
+  setCmd.description('Add a new evaluation schedule');
+  setCmd.requiredOption('--cron <expression>', 'Cron expression (e.g. "*/15 * * * *")');
+  setCmd.requiredOption('--since <duration>', 'Time window (e.g. 1h)');
+  setCmd.option('--sample <percent>', 'Percentage to sample', parseFloat, 100);
+  setCmd.option('--name <name>', 'Schedule name');
+  setCmd.option('--metrics <metrics>', 'Comma-separated metrics override');
+
+  setCmd.action(async (options: {
+    cron: string;
+    since: string;
+    sample: number;
+    name?: string;
+    metrics?: string;
+  }) => {
+    if (!validateCron(options.cron)) {
+      logger.error('Invalid cron expression. Must have exactly 5 parts (e.g. "*/15 * * * *")');
+      process.exit(1);
+    }
+
+    const schedule: Schedule = {
+      id: randomUUID(),
+      name: options.name,
+      cron: options.cron,
+      since: options.since,
+      sample: options.sample,
+      metrics: options.metrics ? options.metrics.split(',').map(m => m.trim()) : undefined,
+      enabled: true,
+      createdAt: new Date().toISOString(),
+    };
+
+    const schedules = await readSchedules();
+    schedules.push(schedule);
+    await writeSchedules(schedules);
+
+    logger.success(`Schedule created: ${schedule.id}`);
+  });
+
+  // schedule list
+  const listCmd = new Command('list');
+  listCmd.description('List all schedules');
+
+  listCmd.action(async () => {
+    const schedules = await readSchedules();
+
+    if (schedules.length === 0) {
+      logger.info('No schedules configured.');
+      return;
+    }
+
+    const headers = ['ID', 'Name', 'Cron', 'Since', 'Sample', 'Enabled', 'Last Run'];
+    const rows = schedules.map(s => [
+      s.id.slice(0, 8),
+      s.name ?? '-',
+      s.cron,
+      s.since,
+      `${s.sample}%`,
+      s.enabled ? 'yes' : 'no',
+      s.lastRunAt ? new Date(s.lastRunAt).toLocaleString() : 'never',
+    ]);
+
+    console.log(renderTable(headers, rows));
+  });
+
+  // schedule enable
+  const enableCmd = new Command('enable');
+  enableCmd.description('Enable a schedule');
+  enableCmd.argument('<id>', 'Schedule ID');
+
+  enableCmd.action(async (id: string) => {
+    const schedules = await readSchedules();
+    const schedule = schedules.find(s => s.id.startsWith(id));
+    if (!schedule) {
+      logger.error(`Schedule not found: ${id}`);
+      process.exit(1);
+    }
+    schedule.enabled = true;
+    await writeSchedules(schedules);
+    logger.success(`Schedule ${schedule.id} enabled`);
+  });
+
+  // schedule disable
+  const disableCmd = new Command('disable');
+  disableCmd.description('Disable a schedule');
+  disableCmd.argument('<id>', 'Schedule ID');
+
+  disableCmd.action(async (id: string) => {
+    const schedules = await readSchedules();
+    const schedule = schedules.find(s => s.id.startsWith(id));
+    if (!schedule) {
+      logger.error(`Schedule not found: ${id}`);
+      process.exit(1);
+    }
+    schedule.enabled = false;
+    await writeSchedules(schedules);
+    logger.success(`Schedule ${schedule.id} disabled`);
+  });
+
+  // schedule delete
+  const deleteCmd = new Command('delete');
+  deleteCmd.description('Delete a schedule');
+  deleteCmd.argument('<id>', 'Schedule ID');
+
+  deleteCmd.action(async (id: string) => {
+    const schedules = await readSchedules();
+    const index = schedules.findIndex(s => s.id.startsWith(id));
+    if (index === -1) {
+      logger.error(`Schedule not found: ${id}`);
+      process.exit(1);
+    }
+    const [removed] = schedules.splice(index, 1);
+    await writeSchedules(schedules);
+    logger.success(`Schedule ${removed?.id} deleted`);
+  });
+
+  // schedule run
+  const runCmd = new Command('run');
+  runCmd.description('Manually trigger a schedule now');
+  runCmd.argument('<id>', 'Schedule ID');
+
+  runCmd.action(async (id: string) => {
+    const schedules = await readSchedules();
+    const schedule = schedules.find(s => s.id.startsWith(id));
+    if (!schedule) {
+      logger.error(`Schedule not found: ${id}`);
+      process.exit(1);
+    }
+
+    let config;
+    try {
+      config = loadConfig();
+      validateConfig(config);
+    } catch (err) {
+      logger.error(`Config error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+
+    const apiToken = config.dynatrace.apiToken;
+    if (!apiToken) {
+      logger.error('dynatrace.apiToken is required');
+      process.exit(1);
+    }
+
+    const dtClient = new DynatraceClient({
+      environmentUrl: config.dynatrace.environmentUrl,
+      apiToken,
+    });
+
+    try {
+      const result = await runEvals(dtClient, config, {
+        since: schedule.since,
+        sample: schedule.sample,
+        metrics: schedule.metrics,
+      });
+
+      // Update lastRunAt
+      schedule.lastRunAt = new Date().toISOString();
+      await writeSchedules(schedules);
+
+      logger.success(`Schedule run complete: ${result.resultsWritten} results written`);
+    } catch (err) {
+      logger.error(`Schedule run failed: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+  cmd.addCommand(setCmd);
+  cmd.addCommand(listCmd);
+  cmd.addCommand(enableCmd);
+  cmd.addCommand(disableCmd);
+  cmd.addCommand(deleteCmd);
+  cmd.addCommand(runCmd);
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/status.ts
+++ b/dt-eval-cli/src/cli/commands/status.ts
@@ -1,0 +1,126 @@
+import { Command } from 'commander';
+import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig } from '../../config/index.js';
+import { printBanner } from '../../ui/banner.js';
+
+interface RunLogEntry {
+  runId: string;
+  timestamp: string;
+  spansEvaluated: number;
+  resultsWritten: number;
+  errors: number;
+  durationMs: number;
+}
+
+function getLastRunSummary(): RunLogEntry | null {
+  const runsPath = join(homedir(), '.dt-eval', 'runs.json');
+  if (!existsSync(runsPath)) {
+    return null;
+  }
+  try {
+    const content = readFileSync(runsPath, 'utf-8');
+    const runs = JSON.parse(content) as RunLogEntry[];
+    if (Array.isArray(runs) && runs.length > 0) {
+      return runs[runs.length - 1] ?? null;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return null;
+}
+
+async function checkDtConnection(environmentUrl: string, apiToken?: string): Promise<boolean | null> {
+  if (!environmentUrl || !apiToken) {
+    return false;
+  }
+  try {
+    const url = `${environmentUrl.replace(/\/$/, '')}/platform/storage/query/v1/query:execute`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Api-Token ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: 'fetch logs | limit 1', requestTimeoutMilliseconds: 5000 }),
+      signal: AbortSignal.timeout(8000),
+    });
+    // 200 or 400 (bad query) = connectivity OK; 401 = bad token; 403 = token lacks DQL scope
+    if (response.status === 401) return false;
+    if (response.status === 403) return null; // connected but token needs storage:logs:read scope
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createStatusCommand(): Command {
+  const cmd = new Command('status');
+  cmd.description('Show current configuration, connectivity, and last evaluation run');
+
+  cmd.action(async () => {
+    printBanner();
+    let config;
+    try {
+      config = loadConfig();
+    } catch (err) {
+      console.log('Status: config not found or invalid');
+      console.log(`  Error: ${(err as Error).message}`);
+      console.log('  Run "dt-eval-cli configure" to set up your configuration.');
+      return;
+    }
+
+    const projectConfigPath = join(process.cwd(), '.dt-eval.yaml');
+    const globalConfigPath = join(homedir(), '.dt-eval', 'config.yaml');
+
+    console.log('=== dt-eval-cli status ===\n');
+
+    console.log('Config:');
+    console.log(`  Project file:   ${existsSync(projectConfigPath) ? projectConfigPath : '(not found)'}`);
+    console.log(`  Global file:    ${existsSync(globalConfigPath) ? globalConfigPath : '(not found)'}`);
+    console.log(`  Schema version: ${config.schemaVersion}`);
+
+    console.log('\nDynatrace:');
+    console.log(`  Environment: ${config.dynatrace.environmentUrl || '(not set)'}`);
+    console.log(`  API token:   ${config.dynatrace.apiToken ? '***' : '(not set)'}`);
+
+    process.stdout.write('  Connection:  checking...');
+    const connected = await checkDtConnection(config.dynatrace.environmentUrl, config.dynatrace.apiToken);
+    const connLabel = connected === true ? 'OK' : connected === null ? 'OK (token needs storage:logs:read scope for DQL)' : 'FAILED';
+    process.stdout.write(`\r  Connection:  ${connLabel}     \n`);
+
+    console.log('\nEvaluator:');
+    console.log(`  Provider: ${config.judge.provider}`);
+    console.log(`  Model:    ${config.judge.model ?? '(auto)'}`);
+    console.log(`  API key:  ${config.judge.apiKey ? '***' : '(not set)'}`);
+
+    console.log('\nScope:');
+    console.log(`  Time window: ${config.scope.since}`);
+    console.log(`  Sampling:    ${config.scope.sampling.strategy} (${
+      config.scope.sampling.strategy === 'random'
+        ? `${config.scope.sampling.percent ?? 100}%`
+        : config.scope.sampling.strategy === 'latest'
+        ? `top ${config.scope.sampling.count ?? 'all'}`
+        : 'errors only'
+    })`);
+
+    console.log('\nEvaluators:');
+    console.log(`  Enabled: ${config.metrics.enabled.join(', ')}`);
+
+    const lastRun = getLastRunSummary();
+    console.log('\nLast evaluation run:');
+    if (lastRun) {
+      console.log(`  Run ID:          ${lastRun.runId}`);
+      console.log(`  Time:            ${lastRun.timestamp}`);
+      console.log(`  Spans evaluated: ${lastRun.spansEvaluated}`);
+      console.log(`  Results written: ${lastRun.resultsWritten}`);
+      console.log(`  Errors:          ${lastRun.errors}`);
+      console.log(`  Duration:        ${lastRun.durationMs}ms`);
+    } else {
+      console.log('  No evaluation runs recorded yet.');
+    }
+  });
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/validate.ts
+++ b/dt-eval-cli/src/cli/commands/validate.ts
@@ -1,0 +1,118 @@
+import { Command } from 'commander';
+import { loadConfig, validateConfig } from '../../config/index.js';
+import { DynatraceClient } from '../../dt/client.js';
+import { listPrompts } from 'dt-eval-lib';
+import { logger } from '../../logger/index.js';
+
+async function testDynatraceConnection(environmentUrl: string, apiToken: string): Promise<boolean> {
+  try {
+    const client = new DynatraceClient({ environmentUrl, apiToken });
+    await client.executeDql('fetch logs | limit 1');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function testAiProvider(provider: string, apiKey?: string, model?: string): Promise<{ ok: boolean; model?: string }> {
+  try {
+    if (provider === 'openai') {
+      const key = apiKey ?? process.env['OPENAI_API_KEY'];
+      if (!key) return { ok: false };
+      const resolvedModel = model ?? 'gpt-4o';
+      const response = await fetch('https://api.openai.com/v1/models', {
+        headers: { Authorization: `Bearer ${key}` },
+        signal: AbortSignal.timeout(8000),
+      });
+      return { ok: response.ok, model: resolvedModel };
+    } else if (provider === 'anthropic') {
+      const key = apiKey ?? process.env['ANTHROPIC_API_KEY'];
+      if (!key) return { ok: false };
+      const resolvedModel = model ?? 'claude-sonnet-4-6';
+      const response = await fetch('https://api.anthropic.com/v1/models', {
+        headers: {
+          'x-api-key': key,
+          'anthropic-version': '2023-06-01',
+        },
+        signal: AbortSignal.timeout(8000),
+      });
+      return { ok: response.ok, model: resolvedModel };
+    }
+    return { ok: false };
+  } catch {
+    return { ok: false };
+  }
+}
+
+export function createValidateCommand(): Command {
+  const cmd = new Command('validate');
+  cmd.description('Run pre-flight checks on config, connectivity, and evaluator keys');
+
+  cmd.action(async () => {
+    console.log('Running pre-flight checks...\n');
+
+    let config;
+    let configValid = false;
+
+    // 1. Schema validation
+    try {
+      config = loadConfig();
+      validateConfig(config);
+      configValid = true;
+      logger.success('Config schema valid');
+    } catch (err) {
+      logger.error(`Config schema invalid: ${(err as Error).message}`);
+    }
+
+    if (!config) {
+      console.log('\nCannot proceed without valid config.');
+      process.exit(1);
+    }
+
+    // 2. DT connection
+    const apiToken = config.dynatrace.apiToken;
+    if (!apiToken) {
+      logger.error('Dynatrace API token not set');
+    } else {
+      process.stdout.write('');
+      const dtOk = await testDynatraceConnection(config.dynatrace.environmentUrl, apiToken);
+      if (dtOk) {
+        logger.success(`Dynatrace connection  (${config.dynatrace.environmentUrl})`);
+      } else {
+        logger.error(`Dynatrace connection failed  (${config.dynatrace.environmentUrl})`);
+      }
+    }
+
+    // 3. AI provider
+    const { ok: aiOk, model: aiModel } = await testAiProvider(
+      config.judge.provider,
+      config.judge.apiKey,
+      config.judge.model,
+    );
+    if (aiOk) {
+      logger.success(`Evaluator provider reachable  (${config.judge.provider}, model: ${aiModel ?? 'unknown'})`);
+    } else {
+      logger.error(`Evaluator provider unreachable or API key invalid  (${config.judge.provider})`);
+    }
+
+    // 4. Evaluators
+    try {
+      const prompts = await listPrompts();
+      const builtIn = prompts.filter(p => !((p as Record<string, unknown>)['custom']));
+      const custom = prompts.filter(p => (p as Record<string, unknown>)['custom']);
+      logger.success(`${builtIn.length} built-in evaluators available`);
+      logger.success(`${custom.length} custom evaluators loaded`);
+    } catch (err) {
+      logger.error(`Failed to load evaluators: ${(err as Error).message}`);
+    }
+
+    if (configValid) {
+      console.log('\nAll checks passed. Ready to run evaluations.');
+    } else {
+      console.log('\nSome checks failed. Run "dt-eval-cli configure" to fix issues.');
+      process.exit(1);
+    }
+  });
+
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/commands/validate.ts
+++ b/dt-eval-cli/src/cli/commands/validate.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { loadConfig, validateConfig } from '../../config/index.js';
+import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
 import { DynatraceClient } from '../../dt/client.js';
 import { listPrompts } from 'dt-eval-lib';
 import { logger } from '../../logger/index.js';
@@ -14,12 +15,17 @@ async function testDynatraceConnection(environmentUrl: string, apiToken: string)
   }
 }
 
-async function testAiProvider(provider: string, apiKey?: string, model?: string): Promise<{ ok: boolean; model?: string }> {
+async function testAiProvider(
+  provider: string,
+  apiKey?: string,
+  model?: string,
+  options?: { baseUrl?: string; region?: string },
+): Promise<{ ok: boolean; model?: string }> {
+  const resolvedModel = model ?? DEFAULT_JUDGE_MODELS[provider] ?? 'unknown';
   try {
     if (provider === 'openai') {
       const key = apiKey ?? process.env['OPENAI_API_KEY'];
       if (!key) return { ok: false };
-      const resolvedModel = model ?? 'gpt-4o';
       const response = await fetch('https://api.openai.com/v1/models', {
         headers: { Authorization: `Bearer ${key}` },
         signal: AbortSignal.timeout(8000),
@@ -28,7 +34,6 @@ async function testAiProvider(provider: string, apiKey?: string, model?: string)
     } else if (provider === 'anthropic') {
       const key = apiKey ?? process.env['ANTHROPIC_API_KEY'];
       if (!key) return { ok: false };
-      const resolvedModel = model ?? 'claude-sonnet-4-6';
       const response = await fetch('https://api.anthropic.com/v1/models', {
         headers: {
           'x-api-key': key,
@@ -37,6 +42,32 @@ async function testAiProvider(provider: string, apiKey?: string, model?: string)
         signal: AbortSignal.timeout(8000),
       });
       return { ok: response.ok, model: resolvedModel };
+    } else if (provider === 'azure-openai') {
+      const key = apiKey ?? process.env['AZURE_OPENAI_API_KEY'];
+      const endpoint = options?.baseUrl ?? process.env['AZURE_OPENAI_ENDPOINT'];
+      if (!key || !endpoint) return { ok: false };
+      // Probe the Azure OpenAI models list endpoint
+      const url = `${endpoint.replace(/\/$/, '')}/openai/models?api-version=2024-02-01`;
+      const response = await fetch(url, {
+        headers: { 'api-key': key },
+        signal: AbortSignal.timeout(8000),
+      });
+      return { ok: response.ok, model: resolvedModel };
+    } else if (provider === 'gemini') {
+      const key = apiKey ?? process.env['GEMINI_API_KEY'] ?? process.env['GOOGLE_API_KEY'];
+      if (!key) return { ok: false };
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models?key=${key}`,
+        { signal: AbortSignal.timeout(8000) },
+      );
+      return { ok: response.ok, model: resolvedModel };
+    } else if (provider === 'bedrock') {
+      // Cannot probe Bedrock without the SDK + signing — just check AWS env vars are set
+      const hasCredentials =
+        !!(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY']) ||
+        !!(process.env['AWS_ROLE_ARN']) ||
+        !!(options?.region ?? process.env['AWS_REGION']);
+      return { ok: hasCredentials, model: resolvedModel };
     }
     return { ok: false };
   } catch {
@@ -88,6 +119,7 @@ export function createValidateCommand(): Command {
       config.judge.provider,
       config.judge.apiKey,
       config.judge.model,
+      { baseUrl: config.judge.baseUrl, region: config.judge.region },
     );
     if (aiOk) {
       logger.success(`Evaluator provider reachable  (${config.judge.provider}, model: ${aiModel ?? 'unknown'})`);

--- a/dt-eval-cli/src/cli/index.ts
+++ b/dt-eval-cli/src/cli/index.ts
@@ -1,0 +1,49 @@
+import { Command } from 'commander';
+import { createConfigureCommand } from './commands/configure.js';
+import { createRunCommand } from './commands/run.js';
+import { createStatusCommand } from './commands/status.js';
+import { createScheduleCommand } from './commands/schedule.js';
+import { createEvaluatorsCommand } from './commands/evaluators.js';
+import { createRunsCommand } from './commands/runs.js';
+import { createValidateCommand } from './commands/validate.js';
+import { configureLogger } from '../logger/index.js';
+import { printBanner } from '../ui/banner.js';
+
+export function createCli(): Command {
+  const program = new Command();
+
+  program
+    .name('dt-eval-cli')
+    .description('Run evaluations on your GenAI traces in Dynatrace')
+    .version('0.1.0');
+
+  // Show banner before the help text
+  program.addHelpText('beforeAll', () => {
+    printBanner();
+    return '';
+  });
+
+  program.option('--verbose', 'Enable verbose debug output');
+  program.option('--json', 'Output structured JSON (for CI/scripts)');
+
+  program.hook('preAction', (_thisCommand, _actionCommand) => {
+    const opts = program.opts<{ verbose?: boolean; json?: boolean }>();
+    if (opts.verbose) configureLogger({ level: 'debug' });
+    if (opts.json) configureLogger({ json: true });
+  });
+
+  program.addCommand(createConfigureCommand());
+  program.addCommand(createRunCommand());
+  program.addCommand(createStatusCommand());
+  program.addCommand(createValidateCommand());
+  program.addCommand(createEvaluatorsCommand());
+  program.addCommand(createRunsCommand());
+  program.addCommand(createScheduleCommand());
+
+  return program;
+}
+
+export async function runCli(argv?: string[]): Promise<void> {
+  const program = createCli();
+  await program.parseAsync(argv ?? process.argv);
+}

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -46,4 +46,7 @@ export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {
 export const DEFAULT_JUDGE_MODELS: Record<string, string> = {
   openai: 'gpt-4o',
   anthropic: 'claude-sonnet-4-6',
+  'azure-openai': 'gpt-4o',
+  gemini: 'gemini-2.0-flash',
+  bedrock: 'anthropic.claude-sonnet-4-5-20251001-v1:0',
 };

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -1,0 +1,49 @@
+import { CURRENT_SCHEMA_VERSION, type DtEvalConfig } from './schema.js';
+
+// All built-in LLM-as-judge metrics available in dt-eval-lib + drift
+export const ALL_METRICS = [
+  'toxicity',
+  'faithfulness',
+  'hallucination',
+  'pii-leakage',
+  'relevance',
+  'factual-accuracy',
+  'coherence',
+  'context-relevance',
+  'answer-completeness',
+  'prompt-injection',
+  'bias',
+  'summarization-quality',
+  'conciseness',
+  'drift',
+];
+
+export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {
+  dynatrace: Partial<DtEvalConfig['dynatrace']>;
+  judge: Partial<DtEvalConfig['judge']>;
+} = {
+  schemaVersion: CURRENT_SCHEMA_VERSION,
+  dynatrace: {
+    environmentUrl: '',
+  },
+  judge: {
+    provider: 'openai',
+    timeout: 30000,
+    maxRetries: 2,
+  },
+  scope: {
+    since: '1h',
+    sampling: {
+      strategy: 'random',
+      percent: 5,
+    },
+  },
+  metrics: {
+    enabled: ALL_METRICS,
+  },
+};
+
+export const DEFAULT_JUDGE_MODELS: Record<string, string> = {
+  openai: 'gpt-4o',
+  anthropic: 'claude-sonnet-4-6',
+};

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -90,7 +90,7 @@ function applyEnvVars(config: DtEvalConfig): DtEvalConfig {
     result.dynatrace.dtctlContext = process.env['DT_DTCTL_CONTEXT'];
   }
   if (process.env['JUDGE_PROVIDER']) {
-    result.judge.provider = process.env['JUDGE_PROVIDER'] as 'openai' | 'anthropic';
+    result.judge.provider = process.env['JUDGE_PROVIDER'] as JudgeConfig['provider'];
   }
   if (process.env['JUDGE_MODEL']) {
     result.judge.model = process.env['JUDGE_MODEL'];
@@ -99,11 +99,18 @@ function applyEnvVars(config: DtEvalConfig): DtEvalConfig {
   const provider = result.judge.provider;
   if (provider === 'openai') {
     if (process.env['OPENAI_API_KEY']) result.judge.apiKey = process.env['OPENAI_API_KEY'];
-    else if (process.env['AZURE_OPENAI_KEY']) result.judge.apiKey = process.env['AZURE_OPENAI_KEY'];
+    if (process.env['OPENAI_BASE_URL']) result.judge.baseUrl = process.env['OPENAI_BASE_URL'];
+  } else if (provider === 'anthropic') {
+    if (process.env['ANTHROPIC_API_KEY']) result.judge.apiKey = process.env['ANTHROPIC_API_KEY'];
+    if (process.env['ANTHROPIC_BASE_URL']) result.judge.baseUrl = process.env['ANTHROPIC_BASE_URL'];
+  } else if (provider === 'azure-openai') {
+    if (process.env['AZURE_OPENAI_API_KEY']) result.judge.apiKey = process.env['AZURE_OPENAI_API_KEY'];
     if (process.env['AZURE_OPENAI_ENDPOINT']) result.judge.baseUrl = process.env['AZURE_OPENAI_ENDPOINT'];
-    else if (process.env['OPENAI_BASE_URL']) result.judge.baseUrl = process.env['OPENAI_BASE_URL'];
-  } else if (provider === 'anthropic' && process.env['ANTHROPIC_API_KEY']) {
-    result.judge.apiKey = process.env['ANTHROPIC_API_KEY'];
+  } else if (provider === 'gemini') {
+    if (process.env['GEMINI_API_KEY']) result.judge.apiKey = process.env['GEMINI_API_KEY'];
+    else if (process.env['GOOGLE_API_KEY']) result.judge.apiKey = process.env['GOOGLE_API_KEY'];
+  } else if (provider === 'bedrock') {
+    if (process.env['AWS_REGION']) result.judge.region = process.env['AWS_REGION'];
   }
 
   return result;
@@ -168,8 +175,8 @@ export function validateConfig(config: DtEvalConfig): void {
 
   if (!config.judge?.provider) {
     issues.push('judge.provider is required');
-  } else if (!['openai', 'anthropic'].includes(config.judge.provider)) {
-    issues.push(`judge.provider must be one of: openai, anthropic (got "${config.judge.provider}")`);
+  } else if (!['openai', 'anthropic', 'azure-openai', 'gemini', 'bedrock'].includes(config.judge.provider)) {
+    issues.push(`judge.provider must be one of: openai, anthropic, azure-openai, gemini, bedrock (got "${config.judge.provider}")`);
   }
 
   if (!config.scope?.since) {

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -1,0 +1,195 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import {
+  CURRENT_SCHEMA_VERSION,
+  type DtEvalConfig,
+  type DynatraceConfig,
+  type JudgeConfig,
+  type ScopeConfig,
+  type MetricsConfig,
+} from './schema.js';
+import { DEFAULT_CONFIG, DEFAULT_JUDGE_MODELS } from './defaults.js';
+
+export class ConfigValidationError extends Error {
+  constructor(public readonly issues: string[]) {
+    super(`Config validation failed:\n${issues.map(i => `  - ${i}`).join('\n')}`);
+    this.name = 'ConfigValidationError';
+  }
+}
+
+export interface LoadConfigOptions {
+  projectFile?: string;
+  globalFile?: string;
+}
+
+function getGlobalConfigPath(): string {
+  return join(homedir(), '.dt-eval', 'config.yaml');
+}
+
+function getProjectConfigPath(): string {
+  return join(process.cwd(), '.dt-eval.yaml');
+}
+
+function readYamlFile(filePath: string): Partial<DtEvalConfig> | null {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    return parseYaml(content) as Partial<DtEvalConfig>;
+  } catch (err) {
+    throw new Error(`Failed to parse config file ${filePath}: ${(err as Error).message}`);
+  }
+}
+
+function deepMerge<T extends object>(base: T, override: Partial<T>): T {
+  const result = { ...base } as T;
+  for (const key of Object.keys(override) as (keyof T)[]) {
+    const overrideVal = override[key];
+    const baseVal = base[key];
+    if (
+      overrideVal !== null &&
+      overrideVal !== undefined &&
+      typeof overrideVal === 'object' &&
+      !Array.isArray(overrideVal) &&
+      baseVal !== null &&
+      baseVal !== undefined &&
+      typeof baseVal === 'object' &&
+      !Array.isArray(baseVal)
+    ) {
+      result[key] = deepMerge(baseVal as object, overrideVal as object) as T[keyof T];
+    } else if (overrideVal !== undefined) {
+      result[key] = overrideVal as T[keyof T];
+    }
+  }
+  return result;
+}
+
+/** Migrate legacy field names in-place before merging */
+function migrateLegacy(config: Partial<DtEvalConfig>): Partial<DtEvalConfig> {
+  const scope = config.scope as (DtEvalConfig['scope'] & { app?: string }) | undefined;
+  if (scope?.app && !scope.service) {
+    scope.service = scope.app;
+    delete scope.app;
+  }
+  return config;
+}
+
+function applyEnvVars(config: DtEvalConfig): DtEvalConfig {
+  const result = deepMerge(config, {});
+
+  if (process.env['DT_ENV_URL']) {
+    result.dynatrace.environmentUrl = process.env['DT_ENV_URL'];
+  }
+  if (process.env['DT_API_TOKEN']) {
+    result.dynatrace.apiToken = process.env['DT_API_TOKEN'];
+  }
+  if (process.env['DT_DTCTL_CONTEXT']) {
+    result.dynatrace.dtctlContext = process.env['DT_DTCTL_CONTEXT'];
+  }
+  if (process.env['JUDGE_PROVIDER']) {
+    result.judge.provider = process.env['JUDGE_PROVIDER'] as 'openai' | 'anthropic';
+  }
+  if (process.env['JUDGE_MODEL']) {
+    result.judge.model = process.env['JUDGE_MODEL'];
+  }
+
+  const provider = result.judge.provider;
+  if (provider === 'openai') {
+    if (process.env['OPENAI_API_KEY']) result.judge.apiKey = process.env['OPENAI_API_KEY'];
+    else if (process.env['AZURE_OPENAI_KEY']) result.judge.apiKey = process.env['AZURE_OPENAI_KEY'];
+    if (process.env['AZURE_OPENAI_ENDPOINT']) result.judge.baseUrl = process.env['AZURE_OPENAI_ENDPOINT'];
+    else if (process.env['OPENAI_BASE_URL']) result.judge.baseUrl = process.env['OPENAI_BASE_URL'];
+  } else if (provider === 'anthropic' && process.env['ANTHROPIC_API_KEY']) {
+    result.judge.apiKey = process.env['ANTHROPIC_API_KEY'];
+  }
+
+  return result;
+}
+
+export function resolveEffectiveConfig(partial: Partial<DtEvalConfig>): DtEvalConfig {
+  const base: DtEvalConfig = {
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    dynatrace: {
+      environmentUrl: DEFAULT_CONFIG.dynatrace.environmentUrl ?? '',
+    },
+    judge: {
+      provider: DEFAULT_CONFIG.judge.provider ?? 'openai',
+      timeout: DEFAULT_CONFIG.judge.timeout,
+      maxRetries: DEFAULT_CONFIG.judge.maxRetries,
+    },
+    scope: { ...DEFAULT_CONFIG.scope },
+    metrics: { ...DEFAULT_CONFIG.metrics },
+  };
+
+  const merged = deepMerge(base, partial as DtEvalConfig);
+
+  // Apply default model based on provider if not set
+  if (!merged.judge.model) {
+    merged.judge.model = DEFAULT_JUDGE_MODELS[merged.judge.provider];
+  }
+
+  return merged;
+}
+
+export function loadConfig(opts?: LoadConfigOptions): DtEvalConfig {
+  const globalPath = opts?.globalFile ?? getGlobalConfigPath();
+  const projectPath = opts?.projectFile ?? getProjectConfigPath();
+
+  const globalConfig = readYamlFile(globalPath) ?? {};
+  const projectConfig = readYamlFile(projectPath) ?? {};
+
+  // Merge: defaults < global < project (migrate legacy field names first)
+  const merged = resolveEffectiveConfig(deepMerge(migrateLegacy(globalConfig) as DtEvalConfig, migrateLegacy(projectConfig) as Partial<DtEvalConfig>));
+
+  // Apply env var overrides (highest precedence)
+  return applyEnvVars(merged);
+}
+
+export function saveConfig(config: DtEvalConfig, filePath: string): void {
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const yamlContent = stringifyYaml(config, { indent: 2 });
+  writeFileSync(filePath, yamlContent, 'utf-8');
+}
+
+export function validateConfig(config: DtEvalConfig): void {
+  const issues: string[] = [];
+
+  if (!config.dynatrace?.environmentUrl) {
+    issues.push('dynatrace.environmentUrl is required');
+  } else if (!/^https?:\/\//.test(config.dynatrace.environmentUrl)) {
+    issues.push('dynatrace.environmentUrl must be a valid URL starting with http:// or https://');
+  }
+
+  if (!config.judge?.provider) {
+    issues.push('judge.provider is required');
+  } else if (!['openai', 'anthropic'].includes(config.judge.provider)) {
+    issues.push(`judge.provider must be one of: openai, anthropic (got "${config.judge.provider}")`);
+  }
+
+  if (!config.scope?.since) {
+    issues.push('scope.since is required (e.g. "1h", "6h", "24h")');
+  } else if (!/^\d+[smhd]$/.test(config.scope.since)) {
+    issues.push('scope.since must be a duration like "1h", "30m", "24h"');
+  }
+
+  const { strategy } = config.scope?.sampling ?? {};
+  if (!strategy) {
+    issues.push('scope.sampling.strategy is required');
+  } else if (!['random', 'latest', 'errors-only'].includes(strategy)) {
+    issues.push(`scope.sampling.strategy must be one of: random, latest, errors-only`);
+  }
+
+  if (!config.metrics?.enabled?.length) {
+    issues.push('metrics.enabled must have at least one metric');
+  }
+
+  if (issues.length > 0) {
+    throw new ConfigValidationError(issues);
+  }
+}

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -8,12 +8,14 @@ export interface DynatraceConfig {
 }
 
 export interface JudgeConfig {
-  provider: 'openai' | 'anthropic';
+  provider: 'openai' | 'anthropic' | 'azure-openai' | 'gemini' | 'bedrock';
   apiKey?: string;
   baseUrl?: string;
   model?: string;
   timeout?: number;
   maxRetries?: number;
+  /** AWS region for Bedrock; Azure OpenAI deployment endpoint base region */
+  region?: string;
 }
 
 export interface ScopeConfig {

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -1,0 +1,47 @@
+export const CURRENT_SCHEMA_VERSION = 1;
+
+export interface DynatraceConfig {
+  environmentUrl: string;
+  apiToken?: string;
+  /** dtctl context name to use for DQL queries via OAuth (avoids Api-Token DQL scope requirement) */
+  dtctlContext?: string;
+}
+
+export interface JudgeConfig {
+  provider: 'openai' | 'anthropic';
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  timeout?: number;
+  maxRetries?: number;
+}
+
+export interface ScopeConfig {
+  service?: string; // service.name to filter spans (previously 'app')
+  since: string; // e.g. "1h", "6h", "24h"
+  sampling: {
+    strategy: 'random' | 'latest' | 'errors-only';
+    percent?: number; // for random
+    count?: number;   // for latest
+  };
+}
+
+export interface MetricsConfig {
+  enabled: string[]; // metric ids from eval-lib catalog
+}
+
+export interface AlertsConfig {
+  thresholds: Record<string, number>; // metric -> threshold score
+  webhooks?: Array<{ url: string; type: 'slack' | 'generic' }>;
+}
+
+export interface DtEvalConfig {
+  schemaVersion: number;
+  /** Human-readable name for this eval configuration (e.g. "travel-advisor-prod") */
+  name?: string;
+  dynatrace: DynatraceConfig;
+  judge: JudgeConfig;
+  scope: ScopeConfig;
+  metrics: MetricsConfig;
+  alerts?: AlertsConfig;
+}

--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -1,0 +1,67 @@
+import type { DynatraceClient } from './client.js';
+import type { GenAiSpan, BizeventPayload } from './types.js';
+import type { EvalResult } from 'dt-eval-lib';
+
+declare const __CLIENT_VERSION__: string;
+const CLIENT_NAME = 'dt-eval-cli';
+const CLIENT_VERSION = __CLIENT_VERSION__;
+
+export type { EvalResult };
+
+function scoringFormat(scoreValue: number): string {
+  return scoreValue > 1 ? 'score_1_to_5' : 'score_0_to_1';
+}
+
+export function buildBizeventPayload(
+  span: GenAiSpan,
+  metric: string,
+  result: EvalResult,
+  runId: string,
+  judgeProvider: string,
+  judgeModel: string,
+  serviceName?: string,
+): BizeventPayload {
+  const payload: BizeventPayload = {
+    'event.type': 'gen_ai.evaluation.result',
+    'trace_id': span.traceId,
+    'gen_ai.evaluation.name': metric,
+    'gen_ai.evaluation.type': 'ready_made',
+    'gen_ai.evaluation.version': 'v1.0',
+    'gen_ai.evaluation.spec_id': `evalspec_${metric}_v1`,
+    'gen_ai.evaluation.scoring_format': scoringFormat(result.score.value),
+    'gen_ai.evaluation.score.value': result.score.value,
+    'gen_ai.evaluation.score.label': result.score.label,
+    'gen_ai.evaluation.score.explanation': result.explanation.summary,
+    'gen_ai.evaluation.method': 'llm_as_judge',
+    'gen_ai.evaluation.input.question': span.input,
+    'gen_ai.evaluation.input.answer': span.output,
+    'gen_ai.request.model': judgeModel,
+    'gen_ai.provider.name': judgeProvider,
+    ...(serviceName ? { 'dt.service.name': serviceName } : {}),
+    'dt.eval.run_id': runId,
+    'gen_ai.eval.client': CLIENT_NAME,
+    'gen_ai.eval.client.version': CLIENT_VERSION,
+  };
+
+  if (span.spanId) {
+    payload['span_id'] = span.spanId;
+    payload['gen_ai.response.id'] = span.spanId;
+  }
+
+  if (span.systemInstruction) {
+    payload['gen_ai.evaluation.input.system_prompt'] = span.systemInstruction;
+  }
+
+  return payload;
+}
+
+export class BizeventWriter {
+  constructor(private readonly client: DynatraceClient) {}
+
+  async writeBatch(payloads: BizeventPayload[]): Promise<void> {
+    if (payloads.length === 0) {
+      return;
+    }
+    await this.client.ingestBizevents(payloads as unknown as object[]);
+  }
+}

--- a/dt-eval-cli/src/dt/client.ts
+++ b/dt-eval-cli/src/dt/client.ts
@@ -1,0 +1,170 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { logger } from '../logger/index.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface DynatraceClientConfig {
+  environmentUrl: string;
+  apiToken: string;
+  /** dtctl context name for DQL queries (OAuth). When set, DQL is executed via dtctl subprocess. */
+  dtctlContext?: string;
+}
+
+interface DqlExecuteResponse {
+  requestToken?: string;
+  state?: string;
+  result?: {
+    records: unknown[];
+  };
+}
+
+interface DqlPollResponse {
+  state: string;
+  result?: {
+    records: unknown[];
+  };
+}
+
+const POLL_INTERVAL_MS = 1000;
+const POLL_TIMEOUT_MS = 60_000;
+
+export class DynatraceClient {
+  private readonly environmentUrl: string;
+  private readonly apiToken: string;
+  private readonly dtctlContext?: string;
+
+  constructor(config: DynatraceClientConfig) {
+    this.environmentUrl = config.environmentUrl.replace(/\/$/, '');
+    this.apiToken = config.apiToken;
+    this.dtctlContext = config.dtctlContext;
+  }
+
+  private get headers(): Record<string, string> {
+    return {
+      Authorization: `Api-Token ${this.apiToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+  }
+
+  async executeDql(query: string): Promise<unknown> {
+    if (this.dtctlContext) {
+      return this.executeDqlViaDtctl(query);
+    }
+    return this.executeDqlViaApi(query);
+  }
+
+  private async executeDqlViaDtctl(query: string): Promise<unknown> {
+    const args = ['query', query, '--context', this.dtctlContext!, '-o', 'json', '--plain'];
+    logger.debug(`dtctl DQL via context=${this.dtctlContext}`);
+    const t0 = Date.now();
+    const { stdout } = await execFileAsync('dtctl', args, { timeout: 60_000 });
+    const parsed = JSON.parse(stdout) as { records?: unknown[] };
+    const records = parsed.records ?? [];
+    logger.timing('dtctl DQL subprocess', Date.now() - t0, { records: (records as unknown[]).length });
+    return records;
+  }
+
+  private async executeDqlViaApi(query: string): Promise<unknown> {
+    const url = `${this.environmentUrl}/platform/storage/query/v1/query:execute`;
+    const body = JSON.stringify({
+      query,
+      requestTimeoutMilliseconds: 30_000,
+      fetchTimeoutSeconds: 30,
+    });
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.headers,
+      body,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`DQL execute failed (${response.status}): ${text}`);
+    }
+
+    const data = (await response.json()) as DqlExecuteResponse;
+
+    if (data.state === 'RUNNING' && data.requestToken) {
+      return this.pollDqlResults(data.requestToken);
+    }
+
+    if (data.state === 'SUCCEEDED' || data.result) {
+      return data.result?.records ?? [];
+    }
+
+    throw new Error(`Unexpected DQL response state: ${data.state}`);
+  }
+
+  async ingestBizevents(events: object[]): Promise<void> {
+    // Use the classic API v2 bizevents endpoint which accepts Api-Token auth.
+    // Platform URLs use *.apps.dynatracelabs.com; classic uses *.dynatracelabs.com (no .apps.)
+    const baseUrl = this.environmentUrl
+      .replace(/\.apps\.(dynatracelabs\.com|dynatrace\.com)$/, '.$1');
+    const url = `${baseUrl}/api/v2/bizevents/ingest`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify(events),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Bizevent ingest failed (${response.status}): ${text}`);
+    }
+  }
+
+  async ingestMetrics(lines: string): Promise<void> {
+    const url = `${this.environmentUrl}/api/v2/metrics/ingest`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Api-Token ${this.apiToken}`,
+        'Content-Type': 'text/plain',
+      },
+      body: lines,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Metrics ingest failed (${response.status}): ${text}`);
+    }
+  }
+
+  private async pollDqlResults(requestToken: string): Promise<unknown> {
+    const url = `${this.environmentUrl}/platform/storage/query/v1/query:poll?requestToken=${encodeURIComponent(requestToken)}`;
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    let pollCount = 0;
+
+    while (Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+      pollCount++;
+
+      const t0 = Date.now();
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: this.headers,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`DQL poll failed (${response.status}): ${text}`);
+      }
+
+      const data = (await response.json()) as DqlPollResponse;
+      logger.debug(`DQL poll #${pollCount} state=${data.state} ${Date.now() - t0}ms`);
+
+      if (data.state === 'SUCCEEDED') {
+        return data.result?.records ?? [];
+      }
+
+      if (data.state === 'FAILED') {
+        throw new Error('DQL query execution failed on the server');
+      }
+    }
+
+    throw new Error(`DQL poll timed out after ${POLL_TIMEOUT_MS}ms`);
+  }
+}

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -1,0 +1,113 @@
+import type { GenAiSpan } from './types.js';
+
+export interface DqlQueryOptions {
+  service?: string;  // service.name to filter spans
+  since: string;     // "1h", "6h", "24h"
+  limit?: number;
+  errorsOnly?: boolean;
+}
+
+export type DqlResult = GenAiSpan[];
+
+// Spans use the traceloop/OpenLLMetry convention:
+//   gen_ai.provider.name  (not gen_ai.system)
+//   gen_ai.prompt.{i}.content / .role
+//   gen_ai.completion.{i}.content / .role
+// We fetch up to 3 prompt slots to capture system + multi-turn inputs.
+const PROMPT_SLOTS = 3;
+const COMPLETION_SLOTS = 1;
+
+export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
+  const { service, since, limit = 1000, errorsOnly = false } = opts;
+
+  const lines: string[] = ['fetch spans'];
+
+  // Only LLM chat spans with a provider and actual completion content
+  lines.push('| filter isNotNull(gen_ai.provider.name)');
+  lines.push('| filter llm.request.type == "chat"');
+  lines.push('| filter isNotNull(gen_ai.completion.0.content)');
+  lines.push(`| filter start_time > now() - ${since}`);
+
+  if (service) {
+    lines.push(`| filter service.name == "${service}" or dt.entity.service == "${service}"`);
+  }
+
+  if (errorsOnly) {
+    lines.push('| filter status.code == "ERROR" or isError == true');
+  }
+
+  const promptFields = Array.from({ length: PROMPT_SLOTS }, (_, i) =>
+    `gen_ai.prompt.${i}.content, gen_ai.prompt.${i}.role`,
+  ).join(', ');
+
+  const completionFields = Array.from({ length: COMPLETION_SLOTS }, (_, i) =>
+    `gen_ai.completion.${i}.content`,
+  ).join(', ');
+
+  lines.push(
+    `| fields trace.id, span.id, start_time, status.code, gen_ai.provider.name, gen_ai.request.model, ${promptFields}, ${completionFields}`,
+  );
+
+  lines.push(`| limit ${limit}`);
+
+  return lines.join('\n');
+}
+
+export function parseSpanResults(records: unknown[]): GenAiSpan[] {
+  const spans: GenAiSpan[] = [];
+
+  for (const record of records) {
+    if (!record || typeof record !== 'object') continue;
+
+    const r = record as Record<string, unknown>;
+    const traceId = asString(r['trace.id']);
+    if (!traceId) continue;
+
+    // Build input: concatenate non-system messages as "role: content" pairs
+    // Build context: extract the system message if present
+    const messages: string[] = [];
+    let systemInstruction: string | undefined;
+
+    for (let i = 0; i < PROMPT_SLOTS; i++) {
+      const content = asString(r[`gen_ai.prompt.${i}.content`]);
+      const role = asString(r[`gen_ai.prompt.${i}.role`]);
+      if (!content) continue;
+      if (role === 'system') {
+        systemInstruction = content;
+      } else {
+        messages.push(role ? `${role}: ${content}` : content);
+      }
+    }
+
+    const output = asString(r['gen_ai.completion.0.content']) ?? '';
+    const input = messages.join('\n') || (systemInstruction ?? '');
+
+    // Skip spans with no usable input or output
+    if (!input || !output) continue;
+
+    const statusCode = asString(r['status.code']);
+    const isError = statusCode === 'ERROR' || r['isError'] === true;
+
+    spans.push({
+      traceId,
+      spanId: asString(r['span.id']),
+      timestamp: asString(r['start_time']) ?? new Date().toISOString(),
+      input,
+      output,
+      systemInstruction,
+      system: asString(r['gen_ai.provider.name']),
+      requestModel: asString(r['gen_ai.request.model']),
+      isError: isError || undefined,
+    });
+  }
+
+  return spans;
+}
+
+function asString(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'object') return JSON.stringify(value);
+  return undefined;
+}

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -1,0 +1,36 @@
+export interface GenAiSpan {
+  traceId: string;
+  spanId?: string;
+  timestamp: string;
+  input: string;              // gen_ai.input.messages (stringified)
+  output: string;             // gen_ai.output.message
+  systemInstruction?: string; // gen_ai.system_instruction
+  system?: string;            // gen_ai.provider.name (e.g. "openai")
+  requestModel?: string;      // gen_ai.request.model
+  isError?: boolean;
+}
+
+export interface BizeventPayload {
+  'event.type': 'gen_ai.evaluation.result';
+  'trace_id': string;
+  'span_id'?: string;
+  'gen_ai.response.id'?: string;
+  'gen_ai.evaluation.name': string;
+  'gen_ai.evaluation.type': 'ready_made';
+  'gen_ai.evaluation.version': string;
+  'gen_ai.evaluation.spec_id': string;
+  'gen_ai.evaluation.scoring_format': string;
+  'gen_ai.evaluation.score.value': number;
+  'gen_ai.evaluation.score.label': 'pass' | 'fail';
+  'gen_ai.evaluation.score.explanation': string;
+  'gen_ai.evaluation.method': 'llm_as_judge';
+  'gen_ai.evaluation.input.question': string;
+  'gen_ai.evaluation.input.answer': string;
+  'gen_ai.evaluation.input.system_prompt'?: string;
+  'gen_ai.request.model'?: string;
+  'gen_ai.provider.name'?: string;
+  'dt.service.name'?: string;
+  'dt.eval.run_id': string;
+  'gen_ai.eval.client': string;
+  'gen_ai.eval.client.version': string;
+}

--- a/dt-eval-cli/src/index.ts
+++ b/dt-eval-cli/src/index.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S node --no-warnings
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Auto-load .env from cwd if present (no external dependency needed in Node 20+)
+const envFile = join(process.cwd(), '.env');
+if (existsSync(envFile)) {
+  const { readFileSync } = await import('node:fs');
+  for (const line of readFileSync(envFile, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const val = trimmed.slice(eqIdx + 1).trim();
+    if (key && !(key in process.env)) {
+      process.env[key] = val;
+    }
+  }
+}
+
+import { runCli } from './cli/index.js';
+
+runCli().catch(err => {
+  console.error((err as Error).message);
+  process.exit(1);
+});

--- a/dt-eval-cli/src/logger/index.ts
+++ b/dt-eval-cli/src/logger/index.ts
@@ -1,0 +1,136 @@
+import pc from 'picocolors';
+
+export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug';
+
+export interface LoggerOptions {
+  level?: LogLevel;   // default 'info'
+  json?: boolean;     // structured JSON output (for --ci/--json)
+  prefix?: string;    // e.g. '[dt-eval]'
+}
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+export class Logger {
+  private level: LogLevel;
+  private json: boolean;
+  private prefix: string;
+
+  constructor(options?: LoggerOptions) {
+    this.level = options?.level ?? 'info';
+    this.json = options?.json ?? false;
+    this.prefix = options?.prefix ?? '';
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return LEVEL_PRIORITY[level] <= LEVEL_PRIORITY[this.level];
+  }
+
+  private formatJsonLine(level: string, msg: string, meta?: Record<string, unknown>): string {
+    return JSON.stringify({
+      level,
+      msg,
+      ts: new Date().toISOString(),
+      ...(meta ?? {}),
+    });
+  }
+
+  private prefixMsg(msg: string): string {
+    return this.prefix ? `${this.prefix} ${msg}` : msg;
+  }
+
+  debug(msg: string, meta?: Record<string, unknown>): void {
+    if (!this.shouldLog('debug')) return;
+    const full = this.prefixMsg(msg);
+    if (this.json) {
+      process.stdout.write(this.formatJsonLine('debug', full, meta) + '\n');
+    } else {
+      process.stderr.write(pc.dim(`[debug] ${full}`) + '\n');
+    }
+  }
+
+  info(msg: string, meta?: Record<string, unknown>): void {
+    if (!this.shouldLog('info')) return;
+    const full = this.prefixMsg(msg);
+    if (this.json) {
+      process.stdout.write(this.formatJsonLine('info', full, meta) + '\n');
+    } else {
+      process.stdout.write(full + '\n');
+    }
+  }
+
+  warn(msg: string, meta?: Record<string, unknown>): void {
+    if (!this.shouldLog('warn')) return;
+    const full = this.prefixMsg(msg);
+    if (this.json) {
+      process.stdout.write(this.formatJsonLine('warn', full, meta) + '\n');
+    } else {
+      process.stderr.write(pc.yellow(`⚠ ${full}`) + '\n');
+    }
+  }
+
+  error(msg: string, meta?: Record<string, unknown>): void {
+    if (!this.shouldLog('error')) return;
+    const full = this.prefixMsg(msg);
+    if (this.json) {
+      process.stdout.write(this.formatJsonLine('error', full, meta) + '\n');
+    } else {
+      process.stderr.write(pc.red(`✖ ${full}`) + '\n');
+    }
+  }
+
+  success(msg: string, meta?: Record<string, unknown>): void {
+    if (!this.shouldLog('info')) return;
+    const full = this.prefixMsg(msg);
+    if (this.json) {
+      process.stdout.write(this.formatJsonLine('info', full, meta) + '\n');
+    } else {
+      process.stdout.write(pc.green(`✓ ${full}`) + '\n');
+    }
+  }
+
+  timing(label: string, ms: number, meta?: Record<string, unknown>): void {
+    if (!this.shouldLog('debug')) return;
+    const full = this.prefixMsg(`⏱  ${label}: ${ms}ms`);
+    if (this.json) {
+      process.stdout.write(this.formatJsonLine('debug', full, { durationMs: ms, ...meta }) + '\n');
+    } else {
+      process.stderr.write(pc.dim(`[debug] ${full}`) + '\n');
+    }
+  }
+
+  step(msg: string): void {
+    if (!this.shouldLog('info')) return;
+    const full = this.prefixMsg(msg);
+    if (this.json) {
+      process.stdout.write(this.formatJsonLine('info', full) + '\n');
+    } else {
+      process.stdout.write(pc.dim(`→ ${full}`) + '\n');
+    }
+  }
+
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  setJson(json: boolean): void {
+    this.json = json;
+  }
+}
+
+// Global singleton
+export const logger = new Logger();
+
+export function configureLogger(options: LoggerOptions): void {
+  if (options.level !== undefined) {
+    logger.setLevel(options.level);
+  }
+  if (options.json !== undefined) {
+    logger.setJson(options.json);
+  }
+}

--- a/dt-eval-cli/src/masker/index.ts
+++ b/dt-eval-cli/src/masker/index.ts
@@ -1,0 +1,45 @@
+import type { GenAiSpan } from '../dt/types.js';
+
+export interface MaskingConfig {
+  patterns?: RegExp[]; // additional user-defined patterns
+  enabled?: boolean;   // default true
+}
+
+const DEFAULT_PATTERNS: RegExp[] = [
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,              // email
+  /\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g,          // phone US
+  /\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13})\b/g,  // credit card
+  /\b\d{3}-\d{2}-\d{4}\b/g,                                              // SSN
+];
+
+const REDACTED = '[REDACTED]';
+
+export function maskPii(text: string, config?: MaskingConfig): string {
+  if (config?.enabled === false) {
+    return text;
+  }
+
+  let result = text;
+  const patterns = [...DEFAULT_PATTERNS, ...(config?.patterns ?? [])];
+
+  for (const pattern of patterns) {
+    // Reset lastIndex to ensure global patterns work correctly each time
+    const resetPattern = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`);
+    result = result.replace(resetPattern, REDACTED);
+  }
+
+  return result;
+}
+
+export function maskSpan(span: GenAiSpan, config?: MaskingConfig): GenAiSpan {
+  if (config?.enabled === false) {
+    return span;
+  }
+
+  return {
+    ...span,
+    input: maskPii(span.input, config),
+    output: maskPii(span.output, config),
+    systemInstruction: span.systemInstruction != null ? maskPii(span.systemInstruction, config) : span.systemInstruction,
+  };
+}

--- a/dt-eval-cli/src/runner/batch.ts
+++ b/dt-eval-cli/src/runner/batch.ts
@@ -1,0 +1,51 @@
+export interface BatchConfig {
+  concurrency: number; // default 5
+  batchSize: number;   // default 10
+}
+
+export interface BatchItemResult<T, R> {
+  item: T;
+  result?: R;
+  error?: Error;
+}
+
+const DEFAULT_BATCH_CONFIG: BatchConfig = {
+  concurrency: 5,
+  batchSize: 10,
+};
+
+export async function processBatch<T, R>(
+  items: T[],
+  handler: (item: T) => Promise<R>,
+  config?: Partial<BatchConfig>,
+): Promise<Array<BatchItemResult<T, R>>> {
+  const { concurrency } = { ...DEFAULT_BATCH_CONFIG, ...config };
+  const results: Array<BatchItemResult<T, R>> = [];
+
+  // Process with concurrency limit using a semaphore-like approach
+  const queue = [...items];
+  const inFlight: Promise<void>[] = [];
+
+  async function processItem(item: T): Promise<void> {
+    try {
+      const result = await handler(item);
+      results.push({ item, result });
+    } catch (err) {
+      results.push({
+        item,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+  }
+
+  // Chunk into groups and run concurrently within each group
+  for (let i = 0; i < items.length; i += concurrency) {
+    const batch = items.slice(i, i + concurrency);
+    const batchPromises = batch.map(item => processItem(item));
+    await Promise.all(batchPromises);
+  }
+
+  // Maintain original order
+  void inFlight;
+  return results;
+}

--- a/dt-eval-cli/src/runner/checkpoint.ts
+++ b/dt-eval-cli/src/runner/checkpoint.ts
@@ -1,0 +1,68 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface RunRecord {
+  runId: string;
+  timestamp: string;
+  spansEvaluated: number;
+  resultsWritten: number;
+  errors: number;
+  thresholdBreaches: number;
+  durationMs: number;
+  metrics: string[];
+  since: string;
+}
+
+const DEFAULT_STORAGE_DIR = join(homedir(), '.dt-eval');
+const MAX_RECORDS = 100;
+
+export async function appendRunRecord(record: RunRecord, storageDir?: string): Promise<void> {
+  const dir = storageDir ?? DEFAULT_STORAGE_DIR;
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  const filePath = join(dir, 'runs.json');
+
+  let records: RunRecord[] = [];
+  if (existsSync(filePath)) {
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      records = JSON.parse(content) as RunRecord[];
+      if (!Array.isArray(records)) {
+        records = [];
+      }
+    } catch {
+      records = [];
+    }
+  }
+
+  records.push(record);
+
+  // Keep only the most recent MAX_RECORDS
+  if (records.length > MAX_RECORDS) {
+    records = records.slice(records.length - MAX_RECORDS);
+  }
+
+  writeFileSync(filePath, JSON.stringify(records, null, 2), 'utf-8');
+}
+
+export async function readRunRecords(storageDir?: string): Promise<RunRecord[]> {
+  const dir = storageDir ?? DEFAULT_STORAGE_DIR;
+  const filePath = join(dir, 'runs.json');
+
+  if (!existsSync(filePath)) {
+    return [];
+  }
+
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const records = JSON.parse(content) as RunRecord[];
+    if (!Array.isArray(records)) {
+      return [];
+    }
+    return records;
+  } catch {
+    return [];
+  }
+}

--- a/dt-eval-cli/src/runner/drift.ts
+++ b/dt-eval-cli/src/runner/drift.ts
@@ -1,0 +1,158 @@
+import { detectDriftBatch, DRIFT_METRIC_ID } from 'dt-eval-lib';
+import type { DriftResult, DriftOptions } from 'dt-eval-lib';
+import type { DynatraceClient } from '../dt/client.js';
+import { logger } from '../logger/index.js';
+
+export { DRIFT_METRIC_ID };
+export type { DriftResult };
+
+interface ScoreRecord {
+  'gen_ai.evaluation.name'?: string;
+  'gen_ai.evaluation.score.value'?: number;
+  [key: string]: unknown;
+}
+
+async function fetchScoresFromDT(
+  dtClient: DynatraceClient,
+  serviceName: string | undefined,
+  window: string,
+  excludeRunId?: string,
+  excludeEvalType = 'drift',
+): Promise<Record<string, number[]>> {
+  const serviceFilter = serviceName ? `| filter dt.service.name == "${serviceName}"` : '';
+  const runFilter = excludeRunId ? `| filter dt.eval.run_id != "${excludeRunId}"` : '';
+
+  const query = `fetch bizevents
+| filter event.type == "gen_ai.evaluation.result"
+| filter gen_ai.evaluation.type != "${excludeEvalType}"
+${serviceFilter}
+${runFilter}
+| filter timestamp > now() - ${window}
+| fields gen_ai.evaluation.name, gen_ai.evaluation.score.value`;
+
+  try {
+    const records = await dtClient.executeDql(query) as ScoreRecord[];
+    const grouped: Record<string, number[]> = {};
+    for (const r of records) {
+      const metric = r['gen_ai.evaluation.name'];
+      const value = r['gen_ai.evaluation.score.value'];
+      if (typeof metric === 'string' && typeof value === 'number') {
+        (grouped[metric] ??= []).push(value);
+      }
+    }
+    return grouped;
+  } catch (err) {
+    logger.debug(`Drift DT query failed: ${(err as Error).message}`);
+    return {};
+  }
+}
+
+export async function runDriftDetection(
+  dtClient: DynatraceClient,
+  /** Scores collected from the current run. Empty when drift runs standalone. */
+  currentScores: Record<string, number[]>,
+  serviceName: string | undefined,
+  runId: string,
+  since: string,
+  baselineWindow = '7d',
+  options?: DriftOptions,
+): Promise<DriftResult[]> {
+  const hasCurrentRunScores = Object.values(currentScores).some(s => s.length > 0);
+
+  let resolvedCurrent = currentScores;
+  let resolvedBaseline: Record<string, number[]>;
+
+  if (hasCurrentRunScores) {
+    // Normal mode: current scores come from this run; baseline from previous runs in DT
+    logger.step('Fetching drift baseline from Dynatrace...');
+    const t0 = Date.now();
+    resolvedBaseline = await fetchScoresFromDT(dtClient, serviceName, baselineWindow, runId);
+    logger.timing('Drift baseline fetch', Date.now() - t0, { baselineWindow });
+  } else {
+    // Standalone mode: no LLM-as-judge metrics in this run — fetch both windows from DT
+    logger.step(`Fetching drift windows from Dynatrace (current: ${since}, baseline: ${baselineWindow})...`);
+    const t0 = Date.now();
+    const [current, baseline] = await Promise.all([
+      fetchScoresFromDT(dtClient, serviceName, since),
+      fetchScoresFromDT(dtClient, serviceName, baselineWindow),
+    ]);
+    resolvedCurrent = current;
+    // Baseline = full 7d window minus the recent `since` window overlap
+    // Simple approach: use full 7d as baseline (includes recent, slight overlap is acceptable)
+    resolvedBaseline = baseline;
+    logger.timing('Drift windows fetch', Date.now() - t0, {
+      currentMetrics: Object.keys(resolvedCurrent).length,
+      baselineMetrics: Object.keys(resolvedBaseline).length,
+    });
+  }
+
+  const metrics = [
+    ...new Set([...Object.keys(resolvedCurrent), ...Object.keys(resolvedBaseline)]),
+  ].filter(m => (resolvedCurrent[m]?.length ?? 0) > 0 || (resolvedBaseline[m]?.length ?? 0) > 0);
+
+  if (metrics.length === 0) {
+    logger.warn('Drift: no evaluation scores found in Dynatrace — run LLM-as-judge evals first to build a baseline');
+    return [];
+  }
+
+  const scoreMap: Record<string, { baseline: number[]; current: number[] }> = {};
+  for (const metric of metrics) {
+    scoreMap[metric] = {
+      baseline: resolvedBaseline[metric] ?? [],
+      current: resolvedCurrent[metric] ?? [],
+    };
+  }
+
+  const results = detectDriftBatch(scoreMap, options);
+
+  const detected = results.filter(r => r.detected);
+  if (detected.length === 0) {
+    logger.info(`Drift: no significant drift detected across ${results.length} metrics`);
+  } else {
+    for (const r of detected) {
+      const direction = r.meanShift < 0 ? '↓' : '↑';
+      logger.warn(
+        `Drift [${r.severity.toUpperCase()}] ${r.metric}: ` +
+        `mean ${direction}${Math.abs(r.meanShift).toFixed(3)} ` +
+        `(baseline ${r.baseline.mean.toFixed(3)} → current ${r.current.mean.toFixed(3)}, ` +
+        `pass rate ${(r.passRateChange * 100).toFixed(1)}%, ` +
+        `n_baseline=${r.baseline.sampleSize}, n_current=${r.current.sampleSize})`,
+      );
+    }
+  }
+
+  return results;
+}
+
+export function buildDriftBizevents(
+  results: DriftResult[],
+  runId: string,
+  serviceName: string | undefined,
+): object[] {
+  return results.map(r => ({
+    'event.type': 'gen_ai.evaluation.result',
+    'gen_ai.evaluation.type': 'drift',
+    'gen_ai.evaluation.method': 'statistical',
+    'gen_ai.evaluation.version': 'v1.0',
+    'gen_ai.evaluation.spec_id': 'evalspec_drift_v1',
+    'gen_ai.evaluation.name': r.metric,
+    'gen_ai.evaluation.score.value': r.effectSize,
+    'gen_ai.evaluation.score.label': r.detected ? 'fail' : 'pass',
+    'gen_ai.evaluation.score.explanation': r.detected
+      ? `Drift detected (${r.severity}): mean shift ${r.meanShift >= 0 ? '+' : ''}${r.meanShift.toFixed(3)}, pass rate change ${(r.passRateChange * 100).toFixed(1)}%`
+      : 'No significant drift detected',
+    'gen_ai.evaluation.drift.severity': r.severity,
+    'gen_ai.evaluation.drift.mean_shift': r.meanShift,
+    'gen_ai.evaluation.drift.pass_rate_change': r.passRateChange,
+    'gen_ai.evaluation.drift.effect_size': r.effectSize,
+    'gen_ai.evaluation.drift.baseline.mean': r.baseline.mean,
+    'gen_ai.evaluation.drift.baseline.pass_rate': r.baseline.passRate,
+    'gen_ai.evaluation.drift.baseline.sample_size': r.baseline.sampleSize,
+    'gen_ai.evaluation.drift.current.mean': r.current.mean,
+    'gen_ai.evaluation.drift.current.pass_rate': r.current.passRate,
+    'gen_ai.evaluation.drift.current.sample_size': r.current.sampleSize,
+    'dt.eval.run_id': runId,
+    'gen_ai.eval.client': 'dt-eval-cli',
+    ...(serviceName ? { 'dt.service.name': serviceName } : {}),
+  }));
+}

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -1,0 +1,241 @@
+import { randomUUID } from 'node:crypto';
+import { evaluate, type EvalConfig, type EvalInput, type EvalResult } from 'dt-eval-lib';
+import type { DynatraceClient } from '../dt/client.js';
+import type { DtEvalConfig } from '../config/schema.js';
+import type { GenAiSpan, BizeventPayload } from '../dt/types.js';
+import { buildGenAiSpanQuery, parseSpanResults } from '../dt/dql.js';
+import { BizeventWriter, buildBizeventPayload } from '../dt/bizevent.js';
+import { DRIFT_METRIC_ID, runDriftDetection, buildDriftBizevents } from './drift.js';
+import { applySampling } from './sampler.js';
+import { maskSpan } from '../masker/index.js';
+import { processBatch } from './batch.js';
+import { appendRunRecord } from './checkpoint.js';
+import { logger } from '../logger/index.js';
+
+export { logger };
+
+export interface RunOptions {
+  since?: string;
+  sample?: number;    // percent 0-100
+  metrics?: string[];
+  dryRun?: boolean;
+  ci?: boolean;
+  concurrency?: number;
+}
+
+export interface RunResult {
+  runId: string;
+  spansEvaluated: number;
+  resultsWritten: number;
+  errors: number;
+  thresholdBreaches: Array<{ metric: string; traceId: string; score: number }>;
+  durationMs: number;
+}
+
+interface EvalTask {
+  span: GenAiSpan;
+  metric: string;
+}
+
+interface EvalTaskResult {
+  span: GenAiSpan;
+  metric: string;
+  evalResult: EvalResult;
+}
+
+export type { EvalResult };
+
+export async function runEvals(
+  dtClient: DynatraceClient,
+  evalConfig: DtEvalConfig,
+  opts: RunOptions,
+): Promise<RunResult> {
+  const startTime = Date.now();
+  const runId = `run-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}-${randomUUID().slice(0, 8)}`;
+
+  const since = opts.since ?? evalConfig.scope.since;
+  const metrics = opts.metrics ?? evalConfig.metrics.enabled;
+  const concurrency = opts.concurrency ?? 5;
+
+  // 1. Fetch spans via DQL
+  logger.step('Fetching spans...');
+  const query = buildGenAiSpanQuery({
+    service: evalConfig.scope.service,
+    since,
+    errorsOnly: evalConfig.scope.sampling.strategy === 'errors-only',
+  });
+  logger.debug(`DQL query:\n${query}`);
+
+  const t0Dql = Date.now();
+  const rawRecords = await dtClient.executeDql(query) as unknown[];
+  logger.timing('DQL fetch', Date.now() - t0Dql, { rawRecords: (rawRecords as unknown[]).length });
+
+  const t0Parse = Date.now();
+  const allSpans = parseSpanResults(rawRecords);
+  logger.timing('Parse spans', Date.now() - t0Parse, { spans: allSpans.length });
+
+  // 2. Apply sampling
+  logger.step('Applying sampling...');
+  const scopeConfig = {
+    ...evalConfig.scope,
+    since,
+    ...(opts.sample !== undefined
+      ? { sampling: { ...evalConfig.scope.sampling, strategy: 'random' as const, percent: opts.sample } }
+      : {}),
+  };
+  const t0Sample = Date.now();
+  const sampledSpans = applySampling(allSpans, scopeConfig);
+  logger.timing('Sampling', Date.now() - t0Sample, { sampled: sampledSpans.length, total: allSpans.length });
+
+  // 3. Apply PII masking
+  logger.step('Masking PII...');
+  const t0Mask = Date.now();
+  const maskedSpans = sampledSpans.map(span => maskSpan(span));
+  logger.timing('PII masking', Date.now() - t0Mask, { spans: maskedSpans.length });
+
+  // 4. Build task list (span × metric), excluding drift which runs separately
+  const evalMetrics = metrics.filter(m => m !== DRIFT_METRIC_ID);
+  const runDrift = metrics.includes(DRIFT_METRIC_ID);
+
+  const tasks: EvalTask[] = maskedSpans.flatMap(span =>
+    evalMetrics.map(metric => ({ span, metric })),
+  );
+
+  if (opts.dryRun) {
+    console.log(JSON.stringify({ runId, tasks: tasks.length, spans: maskedSpans.length, metrics }, null, 2));
+    return {
+      runId,
+      spansEvaluated: maskedSpans.length,
+      resultsWritten: 0,
+      errors: 0,
+      thresholdBreaches: [],
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  // 5. Build provider config for dt-eval-lib
+  const judgeProvider = evalConfig.judge.provider;
+  const judgeModel = evalConfig.judge.model ?? '';
+  const libConfig: EvalConfig = {
+    provider: evalConfig.judge.provider,
+    apiKey: evalConfig.judge.apiKey,
+    baseUrl: evalConfig.judge.baseUrl,
+    model: evalConfig.judge.model,
+    timeout: evalConfig.judge.timeout,
+    maxRetries: evalConfig.judge.maxRetries,
+  };
+
+  // 6. Evaluate via dt-eval-lib in parallel batches
+  logger.info(`Evaluating ${maskedSpans.length} spans × ${metrics.length} metrics...`);
+  const t0Eval = Date.now();
+  let evalCount = 0;
+  const batchResults = await processBatch<EvalTask, EvalTaskResult>(
+    tasks,
+    async task => {
+      const t0 = Date.now();
+      const input: EvalInput = {
+        input: task.span.input,
+        output: task.span.output,
+        context: task.span.systemInstruction,
+      };
+      const evalResult = await evaluate(task.metric, input, libConfig);
+      evalCount++;
+      logger.debug(`eval [${evalCount}/${tasks.length}] ${task.metric} trace=${task.span.traceId.slice(0, 8)}… ${Date.now() - t0}ms score=${evalResult.score.value}`);
+      return { span: task.span, metric: task.metric, evalResult };
+    },
+    { concurrency },
+  );
+  logger.timing('Eval batch', Date.now() - t0Eval, { tasks: tasks.length, concurrency });
+
+  // 7. Collect results and errors
+  const successResults: EvalTaskResult[] = [];
+  let errors = 0;
+
+  for (const r of batchResults) {
+    if (r.error) {
+      errors++;
+      if (opts.ci) {
+        console.error(JSON.stringify({ error: r.error.message, item: r.item }));
+      }
+    } else if (r.result) {
+      successResults.push(r.result);
+    }
+  }
+
+  // 8. Write bizevents
+  logger.step('Writing bizevents...');
+  const writer = new BizeventWriter(dtClient);
+  const payloads: BizeventPayload[] = successResults.map(r =>
+    buildBizeventPayload(r.span, r.metric, r.evalResult, runId, judgeProvider, judgeModel, evalConfig.scope.service),
+  );
+
+  const t0Ingest = Date.now();
+  await writer.writeBatch(payloads);
+  logger.timing('Bizevent ingest', Date.now() - t0Ingest, { payloads: payloads.length });
+
+  // 9. Run drift detection (if selected as a metric)
+  if (runDrift && !opts.dryRun) {
+    // Build per-metric score arrays from this run
+    const currentScores: Record<string, number[]> = {};
+    for (const r of successResults) {
+      (currentScores[r.metric] ??= []).push(r.evalResult.score.value);
+    }
+    const driftResults = await runDriftDetection(
+      dtClient,
+      currentScores,
+      evalConfig.scope.service,
+      runId,
+      since,
+    );
+    if (driftResults.length > 0) {
+      const driftEvents = buildDriftBizevents(driftResults, runId, evalConfig.scope.service);
+      await dtClient.ingestBizevents(driftEvents);
+      logger.timing('Drift ingest', 0, { events: driftEvents.length });
+    }
+  }
+
+  // 10. Check thresholds
+  const thresholdBreaches: RunResult['thresholdBreaches'] = [];
+  if (evalConfig.alerts?.thresholds) {
+    for (const r of successResults) {
+      const threshold = evalConfig.alerts.thresholds[r.metric];
+      if (threshold !== undefined && r.evalResult.score.value < threshold) {
+        thresholdBreaches.push({
+          metric: r.metric,
+          traceId: r.span.traceId,
+          score: r.evalResult.score.value,
+        });
+      }
+    }
+  }
+
+  const result: RunResult = {
+    runId,
+    spansEvaluated: maskedSpans.length,
+    resultsWritten: payloads.length,
+    errors,
+    thresholdBreaches,
+    durationMs: Date.now() - startTime,
+  };
+
+  logger.success(`Run complete: ${payloads.length} results written`);
+
+  if (opts.ci) {
+    console.log(JSON.stringify(result));
+  }
+
+  // 10. Append run record to checkpoint
+  await appendRunRecord({
+    runId: result.runId,
+    timestamp: new Date().toISOString(),
+    spansEvaluated: result.spansEvaluated,
+    resultsWritten: result.resultsWritten,
+    errors: result.errors,
+    thresholdBreaches: result.thresholdBreaches.length,
+    durationMs: result.durationMs,
+    metrics,
+    since,
+  });
+
+  return result;
+}

--- a/dt-eval-cli/src/runner/sampler.ts
+++ b/dt-eval-cli/src/runner/sampler.ts
@@ -1,0 +1,39 @@
+import type { GenAiSpan } from '../dt/types.js';
+import type { ScopeConfig } from '../config/schema.js';
+
+function shuffleArray<T>(array: T[]): T[] {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j]!, arr[i]!];
+  }
+  return arr;
+}
+
+export function applySampling(spans: GenAiSpan[], config: ScopeConfig): GenAiSpan[] {
+  const { strategy, percent, count } = config.sampling;
+
+  if (strategy === 'random') {
+    const pct = percent ?? 100;
+    if (pct >= 100) {
+      return spans;
+    }
+    const shuffled = shuffleArray(spans);
+    const take = Math.floor((pct / 100) * shuffled.length);
+    return shuffled.slice(0, take);
+  }
+
+  if (strategy === 'latest') {
+    const take = count ?? spans.length;
+    const sorted = [...spans].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
+    return sorted.slice(0, take);
+  }
+
+  if (strategy === 'errors-only') {
+    return spans.filter(s => s.isError === true);
+  }
+
+  return spans;
+}

--- a/dt-eval-cli/src/ui/banner.ts
+++ b/dt-eval-cli/src/ui/banner.ts
@@ -1,0 +1,38 @@
+import figlet from 'figlet';
+
+const RESET = '\x1b[0m';
+
+// Pink → purple horizontal gradient
+const START = { r: 255, g: 80, b: 180 };  // hot pink
+const END   = { r: 110, g: 20, b: 240 };  // deep purple
+
+function colorAt(t: number): string {
+  const r = Math.round(START.r + (END.r - START.r) * t);
+  const g = Math.round(START.g + (END.g - START.g) * t);
+  const b = Math.round(START.b + (END.b - START.b) * t);
+  return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+function applyGradient(text: string): string {
+  const lines = text.split('\n');
+  const maxLen = Math.max(...lines.map(l => l.length), 1);
+
+  return lines.map(line => {
+    if (!line.trim()) return line;
+    return (
+      line
+        .split('')
+        .map((ch, i) => colorAt(i / (maxLen - 1)) + ch)
+        .join('') + RESET
+    );
+  }).join('\n');
+}
+
+export function printBanner(): void {
+  if (!process.stdout.isTTY) return;
+
+  const banner = figlet.textSync('DT-EVAL-CLI', { font: 'ANSI Shadow' });
+
+  process.stdout.write('\n' + applyGradient(banner) + '\n');
+  process.stdout.write('  welcome to eval-cli\n\n');
+}

--- a/dt-eval-cli/src/ui/format.ts
+++ b/dt-eval-cli/src/ui/format.ts
@@ -1,0 +1,47 @@
+import pc from 'picocolors';
+import type { RunResult } from '../runner/index.js';
+import type { DtEvalConfig } from '../config/schema.js';
+
+export function formatDuration(ms: number): string {
+  if (ms >= 1000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+  return `${Math.round(ms)}ms`;
+}
+
+export function formatScore(value: number, label: 'pass' | 'fail'): string {
+  const scoreStr = value.toFixed(2);
+  if (label === 'pass') {
+    return pc.green(`${scoreStr} ✓`);
+  }
+  return pc.red(`${scoreStr} ✗`);
+}
+
+export function formatRunSummary(result: RunResult): string {
+  const lines: string[] = [];
+  lines.push(`Run ${result.runId} complete in ${formatDuration(result.durationMs)}`);
+  lines.push(`  Spans evaluated: ${result.spansEvaluated}`);
+  lines.push(`  Results written: ${result.resultsWritten}`);
+  lines.push(`  Errors: ${result.errors}`);
+  if (result.thresholdBreaches.length > 0) {
+    lines.push(`  Threshold breaches: ${result.thresholdBreaches.length}`);
+    for (const breach of result.thresholdBreaches) {
+      lines.push(`    - ${breach.metric} [${breach.traceId}]: score=${breach.score}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function redactSecrets(config: DtEvalConfig): DtEvalConfig {
+  return {
+    ...config,
+    dynatrace: {
+      ...config.dynatrace,
+      apiToken: config.dynatrace.apiToken ? '***' : undefined,
+    },
+    judge: {
+      ...config.judge,
+      apiKey: config.judge.apiKey ? '***' : undefined,
+    },
+  };
+}

--- a/dt-eval-cli/src/ui/spinner.ts
+++ b/dt-eval-cli/src/ui/spinner.ts
@@ -1,0 +1,70 @@
+import pc from 'picocolors';
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+const INTERVAL_MS = 80;
+
+export class Spinner {
+  private text: string;
+  private frameIndex = 0;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private isTTY: boolean;
+
+  constructor(text: string) {
+    this.text = text;
+    this.isTTY = process.stderr.isTTY === true;
+  }
+
+  start(): this {
+    if (this.isTTY) {
+      this.interval = setInterval(() => {
+        const frame = SPINNER_FRAMES[this.frameIndex % SPINNER_FRAMES.length];
+        this.frameIndex++;
+        process.stderr.write(`\r${frame} ${this.text}`);
+      }, INTERVAL_MS);
+    } else {
+      process.stderr.write(`${this.text}...\n`);
+    }
+    return this;
+  }
+
+  update(text: string): this {
+    this.text = text;
+    if (!this.isTTY) {
+      process.stderr.write(`${text}...\n`);
+    }
+    return this;
+  }
+
+  succeed(text?: string): this {
+    this.stop();
+    const msg = text ?? this.text;
+    if (this.isTTY) {
+      process.stderr.write(`\r${pc.green('✓')} ${msg}\n`);
+    } else {
+      process.stderr.write(`✓ ${msg}\n`);
+    }
+    return this;
+  }
+
+  fail(text?: string): this {
+    this.stop();
+    const msg = text ?? this.text;
+    if (this.isTTY) {
+      process.stderr.write(`\r${pc.red('✗')} ${msg}\n`);
+    } else {
+      process.stderr.write(`✗ ${msg}\n`);
+    }
+    return this;
+  }
+
+  stop(): this {
+    if (this.interval !== null) {
+      clearInterval(this.interval);
+      this.interval = null;
+      if (this.isTTY) {
+        process.stderr.write('\r\x1b[K'); // clear line
+      }
+    }
+    return this;
+  }
+}

--- a/dt-eval-cli/src/ui/table.ts
+++ b/dt-eval-cli/src/ui/table.ts
@@ -1,0 +1,28 @@
+export function renderTable(headers: string[], rows: string[][]): string {
+  const allRows = [headers, ...rows];
+  const colWidths: number[] = headers.map((h, i) => {
+    const maxRowWidth = rows.reduce((max, row) => Math.max(max, (row[i] ?? '').length), 0);
+    return Math.max(h.length, maxRowWidth);
+  });
+
+  function formatRow(cells: string[]): string {
+    const padded = colWidths.map((w, i) => (cells[i] ?? '').padEnd(w));
+    return `│ ${padded.join(' │ ')} │`;
+  }
+
+  function formatSeparator(left: string, mid: string, right: string): string {
+    const parts = colWidths.map(w => '─'.repeat(w + 2));
+    return left + parts.join(mid) + right;
+  }
+
+  const lines: string[] = [];
+  lines.push(formatSeparator('┌', '┬', '┐'));
+  lines.push(formatRow(headers));
+  lines.push(formatSeparator('├', '┼', '┤'));
+  for (const row of rows) {
+    lines.push(formatRow(row));
+  }
+  lines.push(formatSeparator('└', '┴', '┘'));
+
+  return lines.join('\n');
+}

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { stringify as stringifyYaml } from 'yaml';
+import type { DtEvalConfig } from '../src/config/schema.js';
+
+// We need to test config in isolation, so we import after mocking fs paths
+let loadConfig: typeof import('../src/config/index.js').loadConfig;
+let saveConfig: typeof import('../src/config/index.js').saveConfig;
+let validateConfig: typeof import('../src/config/index.js').validateConfig;
+let resolveEffectiveConfig: typeof import('../src/config/index.js').resolveEffectiveConfig;
+let ConfigValidationError: typeof import('../src/config/index.js').ConfigValidationError;
+
+const TEST_DIR = join(tmpdir(), `dt-eval-test-${Date.now()}`);
+const GLOBAL_CONFIG_PATH = join(TEST_DIR, 'global-config.yaml');
+const PROJECT_CONFIG_PATH = join(TEST_DIR, 'project-config.yaml');
+
+function makeValidConfig(overrides?: Partial<DtEvalConfig>): DtEvalConfig {
+  return {
+    schemaVersion: 1,
+    dynatrace: {
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'test-token',
+    },
+    judge: {
+      provider: 'openai',
+      apiKey: 'test-key',
+      model: 'gpt-4o',
+      timeout: 30000,
+      maxRetries: 2,
+    },
+    scope: {
+      since: '1h',
+      sampling: { strategy: 'random', percent: 100 },
+    },
+    metrics: {
+      enabled: ['toxicity', 'relevance'],
+    },
+    ...overrides,
+  };
+}
+
+function writeYaml(filePath: string, data: unknown): void {
+  writeFileSync(filePath, stringifyYaml(data, { indent: 2 }), 'utf-8');
+}
+
+const ENV_KEYS = ['DT_ENV_URL', 'DT_API_TOKEN', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'JUDGE_PROVIDER', 'JUDGE_MODEL'] as const;
+let savedEnv: Partial<Record<string, string>> = {};
+
+describe('config', () => {
+  beforeEach(async () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    // Save and clear all relevant env vars so real environment doesn't bleed into tests
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    // Dynamic import to avoid module caching issues with env vars
+    const mod = await import('../src/config/index.js');
+    loadConfig = mod.loadConfig;
+    saveConfig = mod.saveConfig;
+    validateConfig = mod.validateConfig;
+    resolveEffectiveConfig = mod.resolveEffectiveConfig;
+    ConfigValidationError = mod.ConfigValidationError;
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    // Restore original env vars
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  describe('loadConfig', () => {
+    it('merges global and project file correctly with project taking precedence', () => {
+      const globalData = {
+        schemaVersion: 1,
+        dynatrace: { environmentUrl: 'https://global.dynatrace.com', apiToken: 'global-token' },
+        judge: { provider: 'openai', model: 'gpt-4o' },
+        scope: { since: '6h', sampling: { strategy: 'random', percent: 50 } },
+        metrics: { enabled: ['toxicity'] },
+      };
+      const projectData = {
+        dynatrace: { environmentUrl: 'https://project.dynatrace.com' },
+        scope: { since: '1h', sampling: { strategy: 'random', percent: 100 } },
+        metrics: { enabled: ['relevance', 'faithfulness'] },
+      };
+
+      writeYaml(GLOBAL_CONFIG_PATH, globalData);
+      writeYaml(PROJECT_CONFIG_PATH, projectData);
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+
+      expect(config.dynatrace.environmentUrl).toBe('https://project.dynatrace.com');
+      expect(config.dynatrace.apiToken).toBe('global-token'); // inherited from global
+      expect(config.scope.since).toBe('1h');
+      expect(config.metrics.enabled).toEqual(['relevance', 'faithfulness']);
+    });
+
+    it('applies default values when fields are missing', () => {
+      writeYaml(PROJECT_CONFIG_PATH, {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com' },
+        judge: { provider: 'openai' },
+      });
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+
+      expect(config.scope.since).toBe('1h');
+      expect(config.scope.sampling.strategy).toBe('random');
+      expect(config.scope.sampling.percent).toBe(100);
+      expect(config.metrics.enabled).toEqual(['toxicity', 'relevance', 'faithfulness']);
+      expect(config.judge.timeout).toBe(30000);
+      expect(config.judge.maxRetries).toBe(2);
+    });
+
+    it('returns valid config from only global file when no project file exists', () => {
+      writeYaml(GLOBAL_CONFIG_PATH, {
+        schemaVersion: 1,
+        dynatrace: { environmentUrl: 'https://global.dynatrace.com' },
+        judge: { provider: 'openai' },
+      });
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: join(TEST_DIR, 'nonexistent.yaml') });
+      expect(config.dynatrace.environmentUrl).toBe('https://global.dynatrace.com');
+    });
+  });
+
+  describe('env var overrides', () => {
+    it('DT_ENV_URL overrides dynatrace.environmentUrl', () => {
+      writeYaml(PROJECT_CONFIG_PATH, {
+        dynatrace: { environmentUrl: 'https://from-file.dynatrace.com' },
+        judge: { provider: 'openai' },
+      });
+      process.env['DT_ENV_URL'] = 'https://from-env.dynatrace.com';
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+      expect(config.dynatrace.environmentUrl).toBe('https://from-env.dynatrace.com');
+    });
+
+    it('DT_API_TOKEN overrides dynatrace.apiToken', () => {
+      writeYaml(PROJECT_CONFIG_PATH, {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com', apiToken: 'file-token' },
+        judge: { provider: 'openai' },
+      });
+      process.env['DT_API_TOKEN'] = 'env-token';
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+      expect(config.dynatrace.apiToken).toBe('env-token');
+    });
+
+    it('OPENAI_API_KEY sets judge.apiKey when provider is openai', () => {
+      writeYaml(PROJECT_CONFIG_PATH, {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com' },
+        judge: { provider: 'openai' },
+      });
+      process.env['OPENAI_API_KEY'] = 'openai-key-from-env';
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+      expect(config.judge.apiKey).toBe('openai-key-from-env');
+    });
+
+    it('ANTHROPIC_API_KEY sets judge.apiKey when provider is anthropic', () => {
+      writeYaml(PROJECT_CONFIG_PATH, {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com' },
+        judge: { provider: 'anthropic' },
+      });
+      process.env['ANTHROPIC_API_KEY'] = 'anthropic-key-from-env';
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+      expect(config.judge.apiKey).toBe('anthropic-key-from-env');
+    });
+
+    it('JUDGE_PROVIDER overrides judge.provider', () => {
+      writeYaml(PROJECT_CONFIG_PATH, {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com' },
+        judge: { provider: 'openai' },
+      });
+      process.env['JUDGE_PROVIDER'] = 'anthropic';
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+      expect(config.judge.provider).toBe('anthropic');
+    });
+
+    it('JUDGE_MODEL overrides judge.model', () => {
+      writeYaml(PROJECT_CONFIG_PATH, {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com' },
+        judge: { provider: 'openai', model: 'gpt-4o' },
+      });
+      process.env['JUDGE_MODEL'] = 'gpt-4o-mini';
+
+      const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH });
+      expect(config.judge.model).toBe('gpt-4o-mini');
+    });
+  });
+
+  describe('validateConfig', () => {
+    it('passes for a valid config', () => {
+      expect(() => validateConfig(makeValidConfig())).not.toThrow();
+    });
+
+    it('throws ConfigValidationError for missing dynatrace.environmentUrl', () => {
+      const config = makeValidConfig();
+      config.dynatrace.environmentUrl = '';
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        expect((err as InstanceType<typeof ConfigValidationError>).issues).toContain(
+          'dynatrace.environmentUrl is required',
+        );
+      }
+    });
+
+    it('throws ConfigValidationError for missing judge.provider', () => {
+      const config = makeValidConfig();
+      // @ts-expect-error: intentionally invalid for test
+      config.judge.provider = '';
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+    });
+
+    it('throws for invalid environmentUrl format', () => {
+      const config = makeValidConfig();
+      config.dynatrace.environmentUrl = 'not-a-url';
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues.some(i => i.includes('valid URL'))).toBe(true);
+      }
+    });
+
+    it('throws for empty metrics.enabled', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [];
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+    });
+
+    it('throws for invalid scope.since format', () => {
+      const config = makeValidConfig();
+      config.scope.since = 'invalid';
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('writes valid YAML to disk', async () => {
+      const { readFileSync } = await import('node:fs');
+      const { parse } = await import('yaml');
+      const config = makeValidConfig();
+      const outPath = join(TEST_DIR, 'output.yaml');
+
+      saveConfig(config, outPath);
+
+      const content = readFileSync(outPath, 'utf-8');
+      const parsed = parse(content);
+      expect(parsed.dynatrace.environmentUrl).toBe(config.dynatrace.environmentUrl);
+      expect(parsed.judge.provider).toBe(config.judge.provider);
+    });
+
+    it('roundtrip: save then load returns the same config', () => {
+      const config = makeValidConfig();
+      const outPath = join(TEST_DIR, 'roundtrip.yaml');
+
+      saveConfig(config, outPath);
+
+      const loaded = loadConfig({ globalFile: join(TEST_DIR, 'nonexistent.yaml'), projectFile: outPath });
+      expect(loaded.dynatrace.environmentUrl).toBe(config.dynatrace.environmentUrl);
+      expect(loaded.judge.provider).toBe(config.judge.provider);
+      expect(loaded.metrics.enabled).toEqual(config.metrics.enabled);
+      expect(loaded.scope.since).toBe(config.scope.since);
+    });
+  });
+
+  describe('resolveEffectiveConfig', () => {
+    it('fills in defaults for missing fields', () => {
+      const partial = {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com' },
+        judge: { provider: 'openai' as const },
+      };
+
+      const resolved = resolveEffectiveConfig(partial);
+      expect(resolved.scope.since).toBe('1h');
+      expect(resolved.scope.sampling.strategy).toBe('random');
+      expect(resolved.metrics.enabled).toEqual(['toxicity', 'relevance', 'faithfulness']);
+    });
+
+    it('does not override provided values with defaults', () => {
+      const partial = {
+        dynatrace: { environmentUrl: 'https://test.dynatrace.com' },
+        judge: { provider: 'anthropic' as const, model: 'claude-3-opus' },
+        scope: { since: '24h', sampling: { strategy: 'latest' as const, count: 50 } },
+        metrics: { enabled: ['coherence'] },
+      };
+
+      const resolved = resolveEffectiveConfig(partial);
+      expect(resolved.judge.provider).toBe('anthropic');
+      expect(resolved.judge.model).toBe('claude-3-opus');
+      expect(resolved.scope.since).toBe('24h');
+      expect(resolved.metrics.enabled).toEqual(['coherence']);
+    });
+  });
+});

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildBizeventPayload, BizeventWriter } from '../../src/dt/bizevent.js';
+import type { GenAiSpan } from '../../src/dt/types.js';
+import type { EvalResult } from 'dt-eval-lib';
+
+function makeSpan(overrides?: Partial<GenAiSpan>): GenAiSpan {
+  return {
+    traceId: 'trace-abc-123',
+    spanId: 'span-001',
+    timestamp: '2026-03-01T10:00:00Z',
+    input: 'What is the capital of France?',
+    output: 'Paris.',
+    system: 'openai',
+    requestModel: 'gpt-4o',
+    ...overrides,
+  };
+}
+
+function makeEvalResult(scoreValue = 0.9, scoreLabel: 'pass' | 'fail' = 'pass', summary = 'Response is accurate and helpful.'): EvalResult {
+  return {
+    score: { value: scoreValue, label: scoreLabel },
+    explanation: { summary },
+  };
+}
+
+describe('buildBizeventPayload', () => {
+  it('produces a payload with the correct schema fields', () => {
+    const span = makeSpan();
+    const result = makeEvalResult();
+    const payload = buildBizeventPayload(span, 'relevance', result, 'run-001', 'openai', 'gpt-4o');
+
+    expect(payload['event.type']).toBe('dt-eval.result');
+    expect(payload['event.provider']).toBe('dt-eval-cli');
+    expect(payload['trace.id']).toBe('trace-abc-123');
+    expect(payload['dt.eval.run_id']).toBe('run-001');
+    expect(payload['gen_ai.evaluation.name']).toBe('relevance');
+    expect(payload['gen_ai.evaluation.score.value']).toBe(0.9);
+    expect(payload['gen_ai.evaluation.judge.provider']).toBe('openai');
+    expect(payload['gen_ai.evaluation.judge.model']).toBe('gpt-4o');
+  });
+
+  it('sets event.type to "dt-eval.result"', () => {
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', makeEvalResult(), 'run-1', 'anthropic', 'claude');
+    expect(payload['event.type']).toBe('dt-eval.result');
+  });
+
+  it('sets score label to "pass" from eval result', () => {
+    const result = makeEvalResult(0.9, 'pass');
+    const payload = buildBizeventPayload(makeSpan(), 'relevance', result, 'run-1', 'openai', 'gpt-4o');
+    expect(payload['gen_ai.evaluation.score.label']).toBe('pass');
+  });
+
+  it('sets score label to "fail" from eval result', () => {
+    const result = makeEvalResult(0.1, 'fail');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', result, 'run-1', 'openai', 'gpt-4o');
+    expect(payload['gen_ai.evaluation.score.label']).toBe('fail');
+  });
+
+  it('uses the exact score.value from EvalResult', () => {
+    const result = makeEvalResult(0.75, 'pass');
+    const payload = buildBizeventPayload(makeSpan(), 'coherence', result, 'run-1', 'openai', 'gpt-4o');
+    expect(payload['gen_ai.evaluation.score.value']).toBe(0.75);
+  });
+
+  it('uses explanation.summary as the explanation string', () => {
+    const result = makeEvalResult(1, 'pass', 'No harmful content detected.');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', result, 'run-1', 'openai', 'gpt-4o');
+    expect(payload['gen_ai.evaluation.explanation']).toBe('No harmful content detected.');
+  });
+
+  it('includes judge provider and model metadata', () => {
+    const payload = buildBizeventPayload(makeSpan(), 'faithfulness', makeEvalResult(), 'run-1', 'anthropic', 'claude-sonnet-4-6');
+    expect(payload['gen_ai.evaluation.judge.provider']).toBe('anthropic');
+    expect(payload['gen_ai.evaluation.judge.model']).toBe('claude-sonnet-4-6');
+  });
+
+  it('copies gen_ai.system and gen_ai.request.model from span', () => {
+    const span = makeSpan({ system: 'openai', requestModel: 'gpt-4o-mini' });
+    const payload = buildBizeventPayload(span, 'relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    expect(payload['gen_ai.system']).toBe('openai');
+    expect(payload['gen_ai.request.model']).toBe('gpt-4o-mini');
+  });
+
+  it('omits gen_ai.system when span.system is absent', () => {
+    const span = makeSpan({ system: undefined });
+    const payload = buildBizeventPayload(span, 'relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    expect(payload['gen_ai.system']).toBeUndefined();
+  });
+
+  it('includes a valid ISO timestamp field', () => {
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    expect(payload.timestamp).toBeDefined();
+    expect(new Date(payload.timestamp).toISOString()).toBe(payload.timestamp);
+  });
+});
+
+describe('BizeventWriter', () => {
+  it('calls client.ingestBizevents with the payload', async () => {
+    const mockClient = {
+      ingestBizevents: vi.fn().mockResolvedValue(undefined),
+      executeDql: vi.fn(),
+      ingestMetrics: vi.fn(),
+    };
+
+    const writer = new BizeventWriter(mockClient as unknown as import('../../src/dt/client.js').DynatraceClient);
+    await writer.writeEvalResult(makeSpan(), 'toxicity', makeEvalResult(), 'run-001', 'openai', 'gpt-4o');
+
+    expect(mockClient.ingestBizevents).toHaveBeenCalledOnce();
+    const callArgs = mockClient.ingestBizevents.mock.calls[0]![0] as unknown[];
+    expect(callArgs).toHaveLength(1);
+    expect((callArgs[0] as Record<string, unknown>)['event.type']).toBe('dt-eval.result');
+  });
+
+  it('writeBatch sends all payloads in one call', async () => {
+    const mockClient = {
+      ingestBizevents: vi.fn().mockResolvedValue(undefined),
+      executeDql: vi.fn(),
+      ingestMetrics: vi.fn(),
+    };
+
+    const writer = new BizeventWriter(mockClient as unknown as import('../../src/dt/client.js').DynatraceClient);
+
+    const span1 = makeSpan({ traceId: 'trace-1' });
+    const span2 = makeSpan({ traceId: 'trace-2' });
+
+    const payloads = [
+      buildBizeventPayload(span1, 'toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
+      buildBizeventPayload(span2, 'relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
+    ];
+
+    await writer.writeBatch(payloads);
+
+    expect(mockClient.ingestBizevents).toHaveBeenCalledOnce();
+    const callArgs = mockClient.ingestBizevents.mock.calls[0]![0] as unknown[];
+    expect(callArgs).toHaveLength(2);
+  });
+
+  it('writeBatch does nothing for empty array', async () => {
+    const mockClient = {
+      ingestBizevents: vi.fn().mockResolvedValue(undefined),
+      executeDql: vi.fn(),
+      ingestMetrics: vi.fn(),
+    };
+    const writer = new BizeventWriter(mockClient as unknown as import('../../src/dt/client.js').DynatraceClient);
+    await writer.writeBatch([]);
+    expect(mockClient.ingestBizevents).not.toHaveBeenCalled();
+  });
+});

--- a/dt-eval-cli/tests/dt/client.test.ts
+++ b/dt-eval-cli/tests/dt/client.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DynatraceClient } from '../../src/dt/client.js';
+
+function makeMockFetch(responses: Array<() => Response>): ReturnType<typeof vi.fn> {
+  let callIndex = 0;
+  return vi.fn().mockImplementation(() => {
+    const responseFn = responses[callIndex % responses.length];
+    callIndex++;
+    return Promise.resolve(responseFn?.() ?? new Response('', { status: 200 }));
+  });
+}
+
+function makeSuccessResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeErrorResponse(status: number, text: string): Response {
+  return new Response(text, { status });
+}
+
+describe('DynatraceClient', () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('executeDql sends correct URL and headers', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeSuccessResponse({ state: 'SUCCEEDED', result: { records: [] } }),
+    );
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'test-token-123',
+    });
+
+    await client.executeDql('fetch spans | limit 1');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://test.live.dynatrace.com/platform/storage/query/v1/query:execute');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Api-Token test-token-123');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('executeDql returns records when state=SUCCEEDED immediately', async () => {
+    const records = [{ 'trace.id': 'abc', 'gen_ai.input.messages': 'q', 'gen_ai.output.message': 'a' }];
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      makeSuccessResponse({ state: 'SUCCEEDED', result: { records } }),
+    );
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'token',
+    });
+
+    const result = await client.executeDql('fetch spans | limit 1');
+    expect(result).toEqual(records);
+  });
+
+  it('executeDql polls when state=RUNNING and returns records on success', async () => {
+    const records = [{ 'trace.id': 'poll-trace' }];
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce(makeSuccessResponse({ state: 'RUNNING', requestToken: 'req-token-123' }))
+      .mockResolvedValueOnce(makeSuccessResponse({ state: 'RUNNING' }))
+      .mockResolvedValueOnce(makeSuccessResponse({ state: 'SUCCEEDED', result: { records } }));
+
+    globalThis.fetch = mockFetch;
+
+    // Mock setTimeout to avoid real delays
+    vi.useFakeTimers();
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'token',
+    });
+
+    const resultPromise = client.executeDql('fetch spans | limit 1');
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    vi.useRealTimers();
+    expect(result).toEqual(records);
+    // First call is execute, subsequent are polls
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('executeDql throws on non-ok HTTP response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeErrorResponse(401, 'Unauthorized'));
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'bad-token',
+    });
+
+    await expect(client.executeDql('fetch spans')).rejects.toThrow('401');
+  });
+
+  it('executeDql throws when poll times out', async () => {
+    // Return RUNNING state repeatedly — create fresh response each time
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('query:execute')) {
+        return Promise.resolve(makeSuccessResponse({ state: 'RUNNING', requestToken: 'tok' }));
+      }
+      // Poll endpoint — always returns RUNNING
+      return Promise.resolve(makeSuccessResponse({ state: 'RUNNING' }));
+    });
+
+    globalThis.fetch = mockFetch;
+
+    vi.useFakeTimers();
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'token',
+    });
+
+    // Wrap in expect to ensure the rejection is handled
+    const resultPromise = expect(client.executeDql('fetch spans')).rejects.toThrow(/timed out/i);
+    // Advance time past POLL_TIMEOUT_MS (60000ms)
+    await vi.advanceTimersByTimeAsync(65000);
+
+    vi.useRealTimers();
+
+    await resultPromise;
+  });
+
+  it('ingestBizevents sends correct URL and payload', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'token',
+    });
+
+    const events = [{ 'event.type': 'dt-eval.result' }];
+    await client.ingestBizevents(events);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://test.live.dynatrace.com/platform/ingest/v1/bizevents');
+    expect(JSON.parse(init.body as string)).toEqual(events);
+  });
+
+  it('ingestBizevents throws on non-ok response', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(makeErrorResponse(403, 'Forbidden'));
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'token',
+    });
+
+    await expect(client.ingestBizevents([{}])).rejects.toThrow('403');
+  });
+
+  it('ingestMetrics sends text/plain content-type', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'token',
+    });
+
+    await client.ingestMetrics('my.metric 1.0');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('text/plain');
+  });
+
+  it('authorization header uses Api-Token format', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeSuccessResponse({ state: 'SUCCEEDED', result: { records: [] } }),
+    );
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'my-secret-token',
+    });
+
+    await client.executeDql('fetch spans | limit 1');
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Api-Token my-secret-token');
+  });
+
+  it('trailing slash in environmentUrl is stripped', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeSuccessResponse({ state: 'SUCCEEDED', result: { records: [] } }),
+    );
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://test.live.dynatrace.com/',
+      apiToken: 'token',
+    });
+
+    await client.executeDql('fetch spans | limit 1');
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).not.toContain('//platform');
+    expect(url).toContain('https://test.live.dynatrace.com/platform');
+  });
+});

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { buildGenAiSpanQuery, parseSpanResults } from '../../src/dt/dql.js';
+
+describe('buildGenAiSpanQuery', () => {
+  it('includes timestamp filter with the given since value', () => {
+    const query = buildGenAiSpanQuery({ since: '1h' });
+    expect(query).toContain('timestamp > now() - 1h');
+  });
+
+  it('uses the correct since duration in filter', () => {
+    const query24h = buildGenAiSpanQuery({ since: '24h' });
+    expect(query24h).toContain('timestamp > now() - 24h');
+
+    const query6h = buildGenAiSpanQuery({ since: '6h' });
+    expect(query6h).toContain('timestamp > now() - 6h');
+  });
+
+  it('includes gen_ai.system not-null filter', () => {
+    const query = buildGenAiSpanQuery({ since: '1h' });
+    expect(query).toContain('isNotNull(gen_ai.system)');
+  });
+
+  it('filters by app when app is provided', () => {
+    const query = buildGenAiSpanQuery({ since: '1h', app: 'my-service' });
+    expect(query).toContain('my-service');
+  });
+
+  it('does not include app filter when app is not provided', () => {
+    const query = buildGenAiSpanQuery({ since: '1h' });
+    // Should not contain dt.entity.service or app.name filter
+    expect(query).not.toContain('dt.entity.service');
+    expect(query).not.toContain('app.name');
+  });
+
+  it('adds error filter when errorsOnly is true', () => {
+    const query = buildGenAiSpanQuery({ since: '1h', errorsOnly: true });
+    expect(query).toContain('ERROR');
+  });
+
+  it('does not add error filter when errorsOnly is false', () => {
+    const query = buildGenAiSpanQuery({ since: '1h', errorsOnly: false });
+    expect(query).not.toContain('status.code == "ERROR"');
+  });
+
+  it('includes a limit clause', () => {
+    const query = buildGenAiSpanQuery({ since: '1h', limit: 500 });
+    expect(query).toContain('limit 500');
+  });
+
+  it('uses default limit of 1000 when not specified', () => {
+    const query = buildGenAiSpanQuery({ since: '1h' });
+    expect(query).toContain('limit 1000');
+  });
+
+  it('includes required fields in the fields clause', () => {
+    const query = buildGenAiSpanQuery({ since: '1h' });
+    expect(query).toContain('gen_ai.input.messages');
+    expect(query).toContain('gen_ai.output.message');
+    expect(query).toContain('gen_ai.system');
+    expect(query).toContain('trace.id');
+    expect(query).toContain('timestamp');
+  });
+});
+
+describe('parseSpanResults', () => {
+  it('maps fields correctly for a well-formed record', () => {
+    const records = [
+      {
+        'trace.id': 'abc123',
+        'span.id': 'span001',
+        timestamp: '2026-03-01T10:00:00Z',
+        'gen_ai.input.messages': '[{"role":"user","content":"Hello"}]',
+        'gen_ai.output.message': 'Hi there!',
+        'gen_ai.system_instruction': 'Be helpful.',
+        'gen_ai.system': 'openai',
+        'gen_ai.request.model': 'gpt-4o',
+        'status.code': 'OK',
+      },
+    ];
+
+    const spans = parseSpanResults(records);
+
+    expect(spans).toHaveLength(1);
+    const span = spans[0]!;
+    expect(span.traceId).toBe('abc123');
+    expect(span.spanId).toBe('span001');
+    expect(span.timestamp).toBe('2026-03-01T10:00:00Z');
+    expect(span.input).toBe('[{"role":"user","content":"Hello"}]');
+    expect(span.output).toBe('Hi there!');
+    expect(span.systemInstruction).toBe('Be helpful.');
+    expect(span.system).toBe('openai');
+    expect(span.requestModel).toBe('gpt-4o');
+    expect(span.isError).toBeUndefined();
+  });
+
+  it('handles missing optional fields gracefully', () => {
+    const records = [
+      {
+        'trace.id': 'trace-min',
+        'gen_ai.input.messages': 'question',
+        'gen_ai.output.message': 'answer',
+      },
+    ];
+
+    const spans = parseSpanResults(records);
+    expect(spans).toHaveLength(1);
+    const span = spans[0]!;
+    expect(span.traceId).toBe('trace-min');
+    expect(span.spanId).toBeUndefined();
+    expect(span.systemInstruction).toBeUndefined();
+    expect(span.system).toBeUndefined();
+    expect(span.requestModel).toBeUndefined();
+  });
+
+  it('skips records with no traceId', () => {
+    const records = [
+      { 'gen_ai.input.messages': 'q', 'gen_ai.output.message': 'a' },
+      { 'trace.id': 'valid-trace', 'gen_ai.input.messages': 'q2', 'gen_ai.output.message': 'a2' },
+    ];
+
+    const spans = parseSpanResults(records);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.traceId).toBe('valid-trace');
+  });
+
+  it('skips null and non-object records', () => {
+    const records = [null, undefined, 'string', 42, { 'trace.id': 'valid' }];
+    const spans = parseSpanResults(records as unknown[]);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.traceId).toBe('valid');
+  });
+
+  it('marks span as isError when status.code is ERROR', () => {
+    const records = [
+      {
+        'trace.id': 'err-trace',
+        'gen_ai.input.messages': 'q',
+        'gen_ai.output.message': 'a',
+        'status.code': 'ERROR',
+      },
+    ];
+
+    const spans = parseSpanResults(records);
+    expect(spans[0]!.isError).toBe(true);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(parseSpanResults([])).toEqual([]);
+  });
+
+  it('handles object-typed input messages by stringifying', () => {
+    const records = [
+      {
+        'trace.id': 'obj-input',
+        'gen_ai.input.messages': [{ role: 'user', content: 'Hello' }],
+        'gen_ai.output.message': 'Hi',
+      },
+    ];
+
+    const spans = parseSpanResults(records);
+    expect(spans[0]!.input).toBe('[{"role":"user","content":"Hello"}]');
+  });
+});

--- a/dt-eval-cli/tests/logger/logger.test.ts
+++ b/dt-eval-cli/tests/logger/logger.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('Logger', () => {
+  let stdoutWrite: ReturnType<typeof vi.spyOn>;
+  let stderrWrite: ReturnType<typeof vi.spyOn>;
+  let Logger: typeof import('../../src/logger/index.js').Logger;
+  let loggerModule: typeof import('../../src/logger/index.js');
+
+  beforeEach(async () => {
+    stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    loggerModule = await import('../../src/logger/index.js');
+    Logger = loggerModule.Logger;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('info writes to stdout', () => {
+    const log = new Logger({ level: 'info' });
+    log.info('hello world');
+    expect(stdoutWrite).toHaveBeenCalledWith(expect.stringContaining('hello world'));
+  });
+
+  it('error writes to stderr', () => {
+    const log = new Logger({ level: 'info' });
+    log.error('something went wrong');
+    expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining('something went wrong'));
+  });
+
+  it('warn writes to stderr', () => {
+    const log = new Logger({ level: 'info' });
+    log.warn('careful here');
+    expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining('careful here'));
+  });
+
+  it('debug not emitted at info level', () => {
+    const log = new Logger({ level: 'info' });
+    log.debug('hidden debug message');
+    const allCalls = [
+      ...stdoutWrite.mock.calls.map(c => String(c[0])),
+      ...stderrWrite.mock.calls.map(c => String(c[0])),
+    ];
+    expect(allCalls.some(s => s.includes('hidden debug message'))).toBe(false);
+  });
+
+  it('debug emitted at debug level', () => {
+    const log = new Logger({ level: 'debug' });
+    log.debug('visible debug message');
+    expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining('visible debug message'));
+  });
+
+  it('success writes to stdout with check mark', () => {
+    const log = new Logger({ level: 'info' });
+    log.success('operation succeeded');
+    expect(stdoutWrite).toHaveBeenCalledWith(expect.stringContaining('operation succeeded'));
+    const call = stdoutWrite.mock.calls[0]?.[0] as string;
+    expect(call).toContain('✓');
+  });
+
+  it('json mode emits valid JSON lines', () => {
+    const log = new Logger({ level: 'info', json: true });
+    log.info('test message');
+    const call = stdoutWrite.mock.calls[0]?.[0] as string;
+    expect(() => JSON.parse(call.trim())).not.toThrow();
+  });
+
+  it('json mode includes level and msg fields', () => {
+    const log = new Logger({ level: 'info', json: true });
+    log.info('json msg test');
+    const call = stdoutWrite.mock.calls[0]?.[0] as string;
+    const parsed = JSON.parse(call.trim()) as Record<string, unknown>;
+    expect(parsed['level']).toBe('info');
+    expect(parsed['msg']).toContain('json msg test');
+  });
+
+  it('setLevel changes level at runtime', () => {
+    const log = new Logger({ level: 'info' });
+    log.debug('should not appear');
+    expect(stderrWrite).not.toHaveBeenCalled();
+
+    log.setLevel('debug');
+    log.debug('should appear now');
+    expect(stderrWrite).toHaveBeenCalledWith(expect.stringContaining('should appear now'));
+  });
+
+  it('logger singleton is shared instance', async () => {
+    const mod1 = await import('../../src/logger/index.js');
+    const mod2 = await import('../../src/logger/index.js');
+    expect(mod1.logger).toBe(mod2.logger);
+  });
+});

--- a/dt-eval-cli/tests/masker/pii.test.ts
+++ b/dt-eval-cli/tests/masker/pii.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { maskPii, maskSpan } from '../../src/masker/index.js';
+import type { GenAiSpan } from '../../src/dt/types.js';
+
+function makeSpan(overrides?: Partial<GenAiSpan>): GenAiSpan {
+  return {
+    traceId: 'trace-abc-123',
+    timestamp: '2026-03-01T10:00:00Z',
+    input: 'Hello world',
+    output: 'Hi there',
+    ...overrides,
+  };
+}
+
+describe('maskPii', () => {
+  it('masks email addresses', () => {
+    const result = maskPii('Contact me at user@example.com for details');
+    expect(result).not.toContain('user@example.com');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('masks multiple email addresses in one string', () => {
+    const result = maskPii('Email alice@test.com or bob@example.org');
+    expect(result).not.toContain('alice@test.com');
+    expect(result).not.toContain('bob@example.org');
+    const redactedCount = (result.match(/\[REDACTED\]/g) ?? []).length;
+    expect(redactedCount).toBe(2);
+  });
+
+  it('masks US phone numbers', () => {
+    const result = maskPii('Call me at 555-867-5309 anytime');
+    expect(result).not.toContain('555-867-5309');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('masks US phone numbers with different formats', () => {
+    const inputs = ['(800) 555-1234', '800.555.1234', '+1 800 555 1234'];
+    for (const phone of inputs) {
+      const result = maskPii(`Call ${phone}`);
+      expect(result).not.toContain(phone);
+    }
+  });
+
+  it('masks credit card numbers (Visa)', () => {
+    const result = maskPii('My card is 4111111111111111');
+    expect(result).not.toContain('4111111111111111');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('masks credit card numbers (Mastercard)', () => {
+    const result = maskPii('Use card 5500005555555559');
+    expect(result).not.toContain('5500005555555559');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('masks SSNs', () => {
+    const result = maskPii('SSN: 123-45-6789');
+    expect(result).not.toContain('123-45-6789');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('leaves non-PII text unchanged', () => {
+    const text = 'The quick brown fox jumps over the lazy dog.';
+    expect(maskPii(text)).toBe(text);
+  });
+
+  it('multiple PII patterns in one string are all masked', () => {
+    const text = 'Email: admin@corp.com, SSN: 987-65-4320, Phone: 415-555-0100';
+    const result = maskPii(text);
+    expect(result).not.toContain('admin@corp.com');
+    expect(result).not.toContain('987-65-4320');
+    expect(result).not.toContain('415-555-0100');
+    const redactedCount = (result.match(/\[REDACTED\]/g) ?? []).length;
+    expect(redactedCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('applies custom patterns', () => {
+    const customPattern = /\b[A-Z]{2}\d{6}\b/g; // passport-like: AB123456
+    const result = maskPii('Passport: AB123456', { patterns: [customPattern] });
+    expect(result).not.toContain('AB123456');
+    expect(result).toContain('[REDACTED]');
+  });
+
+  it('returns original text when masking is disabled', () => {
+    const text = 'Email: user@example.com';
+    expect(maskPii(text, { enabled: false })).toBe(text);
+  });
+
+  it('handles empty string without error', () => {
+    expect(maskPii('')).toBe('');
+  });
+});
+
+describe('maskSpan', () => {
+  it('masks input field', () => {
+    const span = makeSpan({ input: 'My email is user@example.com' });
+    const masked = maskSpan(span);
+    expect(masked.input).not.toContain('user@example.com');
+    expect(masked.input).toContain('[REDACTED]');
+  });
+
+  it('masks output field', () => {
+    const span = makeSpan({ output: 'Your SSN is 123-45-6789' });
+    const masked = maskSpan(span);
+    expect(masked.output).not.toContain('123-45-6789');
+    expect(masked.output).toContain('[REDACTED]');
+  });
+
+  it('masks systemInstruction field when present', () => {
+    const span = makeSpan({ systemInstruction: 'Contact admin@corp.com for issues' });
+    const masked = maskSpan(span);
+    expect(masked.systemInstruction).not.toContain('admin@corp.com');
+    expect(masked.systemInstruction).toContain('[REDACTED]');
+  });
+
+  it('leaves traceId unchanged', () => {
+    const span = makeSpan({ traceId: 'trace-abc-123', input: 'user@test.com' });
+    const masked = maskSpan(span);
+    expect(masked.traceId).toBe('trace-abc-123');
+  });
+
+  it('leaves spanId unchanged', () => {
+    const span = makeSpan({ spanId: 'span-001', input: 'user@test.com' });
+    const masked = maskSpan(span);
+    expect(masked.spanId).toBe('span-001');
+  });
+
+  it('leaves timestamp unchanged', () => {
+    const span = makeSpan({ timestamp: '2026-03-01T10:00:00Z', input: 'user@test.com' });
+    const masked = maskSpan(span);
+    expect(masked.timestamp).toBe('2026-03-01T10:00:00Z');
+  });
+
+  it('returns a new span object (does not mutate original)', () => {
+    const span = makeSpan({ input: 'user@test.com' });
+    const masked = maskSpan(span);
+    expect(masked).not.toBe(span);
+    expect(span.input).toBe('user@test.com'); // original unchanged
+  });
+
+  it('returns original span when masking is disabled', () => {
+    const span = makeSpan({ input: 'user@test.com' });
+    const result = maskSpan(span, { enabled: false });
+    expect(result).toBe(span);
+    expect(result.input).toBe('user@test.com');
+  });
+
+  it('handles span with undefined systemInstruction gracefully', () => {
+    const span = makeSpan({ systemInstruction: undefined });
+    const masked = maskSpan(span);
+    expect(masked.systemInstruction).toBeUndefined();
+  });
+});

--- a/dt-eval-cli/tests/runner/batch.test.ts
+++ b/dt-eval-cli/tests/runner/batch.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { processBatch } from '../../src/runner/batch.js';
+
+describe('processBatch', () => {
+  it('processes all items and returns results for each', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const handler = async (n: number) => n * 2;
+
+    const results = await processBatch(items, handler);
+
+    expect(results).toHaveLength(5);
+    expect(results.every(r => r.error === undefined)).toBe(true);
+    expect(results.map(r => r.result)).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('returns empty results for empty input', async () => {
+    const results = await processBatch<number, number>([], async n => n);
+    expect(results).toHaveLength(0);
+  });
+
+  it('collects errors without throwing', async () => {
+    const items = [1, 2, 3];
+    const handler = async (n: number) => {
+      if (n === 2) throw new Error('item 2 failed');
+      return n;
+    };
+
+    const results = await processBatch(items, handler);
+
+    expect(results).toHaveLength(3);
+    const errorResult = results.find(r => r.item === 2)!;
+    expect(errorResult.error).toBeInstanceOf(Error);
+    expect(errorResult.error?.message).toBe('item 2 failed');
+    expect(errorResult.result).toBeUndefined();
+  });
+
+  it('partial failure does not stop other items from processing', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const handler = async (n: number) => {
+      if (n === 3) throw new Error('fail');
+      return n * 10;
+    };
+
+    const results = await processBatch(items, handler);
+
+    // 4 successes and 1 error
+    const successes = results.filter(r => r.result !== undefined);
+    const errors = results.filter(r => r.error !== undefined);
+
+    expect(successes).toHaveLength(4);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('returns a result entry for each item', async () => {
+    const items = ['a', 'b', 'c'];
+    const results = await processBatch(items, async s => s.toUpperCase());
+
+    expect(results).toHaveLength(3);
+    for (const r of results) {
+      expect(r.item).toBeDefined();
+    }
+  });
+
+  it('respects concurrency limit by not exceeding it', async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    const handler = async (n: number) => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      concurrent--;
+      return n;
+    };
+
+    await processBatch(items, handler, { concurrency: 3 });
+
+    expect(maxConcurrent).toBeLessThanOrEqual(3);
+  });
+
+  it('handles non-Error thrown values by wrapping them in Error', async () => {
+    const items = [1];
+    const handler = async (_n: number) => {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw 'string error';
+    };
+
+    const results = await processBatch(items, handler);
+    expect(results[0]!.error).toBeInstanceOf(Error);
+    expect(results[0]!.error?.message).toBe('string error');
+  });
+
+  it('uses default concurrency of 5 when not specified', async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const items = Array.from({ length: 30 }, (_, i) => i);
+    const handler = async (n: number) => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      concurrent--;
+      return n;
+    };
+
+    await processBatch(items, handler);
+    expect(maxConcurrent).toBeLessThanOrEqual(5);
+  });
+});

--- a/dt-eval-cli/tests/runner/checkpoint.test.ts
+++ b/dt-eval-cli/tests/runner/checkpoint.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdirSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { appendRunRecord, readRunRecords } from '../../src/runner/checkpoint.js';
+import type { RunRecord } from '../../src/runner/checkpoint.js';
+
+const TEST_DIR = join(tmpdir(), `dt-eval-checkpoint-test-${Date.now()}`);
+
+function makeRecord(overrides?: Partial<RunRecord>): RunRecord {
+  return {
+    runId: `run-${Math.random().toString(36).slice(2)}`,
+    timestamp: new Date().toISOString(),
+    spansEvaluated: 10,
+    resultsWritten: 10,
+    errors: 0,
+    thresholdBreaches: 0,
+    durationMs: 1234,
+    metrics: ['toxicity', 'relevance'],
+    since: '1h',
+    ...overrides,
+  };
+}
+
+describe('checkpoint', () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it('appendRunRecord creates file if missing', async () => {
+    const record = makeRecord({ runId: 'run-create-test' });
+    await appendRunRecord(record, TEST_DIR);
+
+    const records = await readRunRecords(TEST_DIR);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.runId).toBe('run-create-test');
+  });
+
+  it('appendRunRecord appends to existing records', async () => {
+    const r1 = makeRecord({ runId: 'run-first' });
+    const r2 = makeRecord({ runId: 'run-second' });
+
+    await appendRunRecord(r1, TEST_DIR);
+    await appendRunRecord(r2, TEST_DIR);
+
+    const records = await readRunRecords(TEST_DIR);
+    expect(records).toHaveLength(2);
+    expect(records[0]!.runId).toBe('run-first');
+    expect(records[1]!.runId).toBe('run-second');
+  });
+
+  it('readRunRecords returns empty array when file missing', async () => {
+    const records = await readRunRecords(join(TEST_DIR, 'nonexistent'));
+    expect(records).toEqual([]);
+  });
+
+  it('readRunRecords returns existing records', async () => {
+    const r = makeRecord({ runId: 'run-read-test', spansEvaluated: 42 });
+    await appendRunRecord(r, TEST_DIR);
+
+    const records = await readRunRecords(TEST_DIR);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.spansEvaluated).toBe(42);
+  });
+
+  it('limits to 100 most recent records when appending', async () => {
+    // Append 105 records
+    for (let i = 0; i < 105; i++) {
+      await appendRunRecord(makeRecord({ runId: `run-${i}` }), TEST_DIR);
+    }
+
+    const records = await readRunRecords(TEST_DIR);
+    expect(records).toHaveLength(100);
+    // The first 5 should have been pruned, last record should be run-104
+    expect(records[records.length - 1]!.runId).toBe('run-104');
+    expect(records[0]!.runId).toBe('run-5');
+  });
+});

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { DtEvalConfig } from '../../src/config/schema.js';
+import type { GenAiSpan } from '../../src/dt/types.js';
+
+// Mock dt-eval-lib
+vi.mock('dt-eval-lib', () => ({
+  evaluate: vi.fn().mockResolvedValue({
+    score: { value: 0.9, label: 'pass' },
+    explanation: { summary: 'Looks good', reasoning: 'No issues' },
+  }),
+}));
+
+// Mock appendRunRecord from checkpoint to avoid filesystem writes
+vi.mock('../../src/runner/checkpoint.js', () => ({
+  appendRunRecord: vi.fn().mockResolvedValue(undefined),
+}));
+
+function makeSpan(overrides?: Partial<GenAiSpan>): GenAiSpan {
+  return {
+    traceId: `trace-${Math.random().toString(36).slice(2, 8)}`,
+    spanId: 'span-001',
+    timestamp: new Date().toISOString(),
+    input: 'What is the capital of France?',
+    output: 'Paris is the capital of France.',
+    system: 'openai',
+    requestModel: 'gpt-4o',
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides?: Partial<DtEvalConfig>): DtEvalConfig {
+  return {
+    schemaVersion: 1,
+    dynatrace: {
+      environmentUrl: 'https://test.live.dynatrace.com',
+      apiToken: 'test-token',
+    },
+    judge: {
+      provider: 'openai',
+      apiKey: 'sk-test',
+      model: 'gpt-4o',
+      timeout: 30000,
+      maxRetries: 2,
+    },
+    scope: {
+      since: '1h',
+      sampling: { strategy: 'random', percent: 100 },
+    },
+    metrics: {
+      enabled: ['toxicity', 'relevance'],
+    },
+    ...overrides,
+  };
+}
+
+function makeDtClient(spans: GenAiSpan[]) {
+  const records = spans.map(s => ({
+    'trace.id': s.traceId,
+    'span.id': s.spanId,
+    timestamp: s.timestamp,
+    'gen_ai.input.messages': s.input,
+    'gen_ai.output.message': s.output,
+    'gen_ai.system': s.system,
+    'gen_ai.request.model': s.requestModel,
+    'gen_ai.system_instruction': s.systemInstruction,
+  }));
+  return {
+    executeDql: vi.fn().mockResolvedValue(records),
+    ingestBizevents: vi.fn().mockResolvedValue(undefined),
+    ingestMetrics: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('runEvals', () => {
+  let runEvals: typeof import('../../src/runner/index.js').runEvals;
+  let evaluate: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import('../../src/runner/index.js');
+    runEvals = mod.runEvals;
+    const dtEvalLib = await import('dt-eval-lib');
+    evaluate = dtEvalLib.evaluate as ReturnType<typeof vi.fn>;
+  });
+
+  it('fetches spans and evaluates them', async () => {
+    const spans = [makeSpan({ traceId: 'trace-001' }), makeSpan({ traceId: 'trace-002' })];
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig();
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    expect(dtClient.executeDql).toHaveBeenCalledOnce();
+    expect(result.spansEvaluated).toBe(2);
+    // 2 spans × 2 metrics = 4 evaluations
+    expect(evaluate).toHaveBeenCalledTimes(4);
+    expect(result.resultsWritten).toBe(4);
+  });
+
+  it('applies sampling (sample=50 takes ~half)', async () => {
+    const spans = Array.from({ length: 20 }, (_, i) => makeSpan({ traceId: `trace-${i}` }));
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig();
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h', sample: 50 },
+    );
+
+    // With 50% sampling of 20 spans, should get ~10
+    expect(result.spansEvaluated).toBeLessThanOrEqual(15);
+    expect(result.spansEvaluated).toBeGreaterThanOrEqual(5);
+  });
+
+  it('applies PII masking before eval', async () => {
+    const spanWithPii = makeSpan({
+      traceId: 'trace-pii',
+      input: 'My email is user@example.com, help me',
+      output: 'Call me at 555-123-4567',
+    });
+    const dtClient = makeDtClient([spanWithPii]);
+    const config = makeConfig({ metrics: { enabled: ['toxicity'] } });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    expect(evaluate).toHaveBeenCalledOnce();
+    const callArgs = evaluate.mock.calls[0] as unknown[];
+    const evalInput = callArgs[1] as { input: string; output: string };
+    expect(evalInput.input).not.toContain('user@example.com');
+    expect(evalInput.output).not.toContain('555-123-4567');
+    expect(evalInput.input).toContain('[REDACTED]');
+    expect(evalInput.output).toContain('[REDACTED]');
+  });
+
+  it('writes bizevents for each span×metric', async () => {
+    const spans = [makeSpan(), makeSpan()];
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig({ metrics: { enabled: ['toxicity', 'relevance', 'faithfulness'] } });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    // 2 spans × 3 metrics = 6 results, all written in one batch
+    expect(dtClient.ingestBizevents).toHaveBeenCalledOnce();
+    const [payloads] = dtClient.ingestBizevents.mock.calls[0] as [unknown[]];
+    expect(payloads).toHaveLength(6);
+  });
+
+  it('dry-run returns correct counts without writing bizevents', async () => {
+    const spans = [makeSpan(), makeSpan(), makeSpan()];
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig();
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h', dryRun: true },
+    );
+
+    expect(result.spansEvaluated).toBe(3);
+    expect(result.resultsWritten).toBe(0);
+    expect(dtClient.ingestBizevents).not.toHaveBeenCalled();
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it('threshold breach detected when score below threshold', async () => {
+    evaluate.mockResolvedValue({
+      score: { value: 0.3, label: 'fail' },
+      explanation: { summary: 'Poor quality' },
+    });
+
+    const spans = [makeSpan({ traceId: 'trace-breach' })];
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig({
+      metrics: { enabled: ['toxicity'] },
+      alerts: { thresholds: { toxicity: 0.5 } },
+    });
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    expect(result.thresholdBreaches).toHaveLength(1);
+    expect(result.thresholdBreaches[0]!.metric).toBe('toxicity');
+    expect(result.thresholdBreaches[0]!.score).toBe(0.3);
+  });
+
+  it('errors in individual evals do not stop the batch', async () => {
+    let callCount = 0;
+    evaluate.mockImplementation(() => {
+      callCount++;
+      if (callCount % 2 === 0) {
+        return Promise.reject(new Error('eval failed'));
+      }
+      return Promise.resolve({
+        score: { value: 0.9, label: 'pass' },
+        explanation: { summary: 'Good' },
+      });
+    });
+
+    const spans = Array.from({ length: 4 }, (_, i) => makeSpan({ traceId: `trace-${i}` }));
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig({ metrics: { enabled: ['toxicity'] } });
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    // 4 evals, 2 succeed, 2 fail
+    expect(result.errors).toBe(2);
+    expect(result.resultsWritten).toBe(2);
+  });
+
+  it('ci mode logs breaches', async () => {
+    evaluate.mockResolvedValue({
+      score: { value: 0.2, label: 'fail' },
+      explanation: { summary: 'Bad' },
+    });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const spans = [makeSpan({ traceId: 'trace-ci' })];
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig({
+      metrics: { enabled: ['toxicity'] },
+      alerts: { thresholds: { toxicity: 0.5 } },
+    });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h', ci: true },
+    );
+
+    // ci mode should output JSON result
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('empty span set returns zero results', async () => {
+    const dtClient = makeDtClient([]);
+    const config = makeConfig();
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    expect(result.spansEvaluated).toBe(0);
+    expect(result.resultsWritten).toBe(0);
+    expect(result.errors).toBe(0);
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+});

--- a/dt-eval-cli/tests/runner/sampler.test.ts
+++ b/dt-eval-cli/tests/runner/sampler.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { applySampling } from '../../src/runner/sampler.js';
+import type { GenAiSpan } from '../../src/dt/types.js';
+import type { ScopeConfig } from '../../src/config/schema.js';
+
+function makeSpan(traceId: string, overrides?: Partial<GenAiSpan>): GenAiSpan {
+  return {
+    traceId,
+    timestamp: new Date().toISOString(),
+    input: 'test input',
+    output: 'test output',
+    ...overrides,
+  };
+}
+
+function makeScope(overrides: Partial<ScopeConfig> = {}): ScopeConfig {
+  return {
+    since: '1h',
+    sampling: { strategy: 'random', percent: 100 },
+    ...overrides,
+  };
+}
+
+function makeSpans(count: number, errorIndices: number[] = []): GenAiSpan[] {
+  return Array.from({ length: count }, (_, i) => {
+    const isError = errorIndices.includes(i);
+    const ts = new Date(Date.now() - i * 60_000).toISOString();
+    return makeSpan(`trace-${i}`, { timestamp: ts, isError: isError || undefined });
+  });
+}
+
+describe('applySampling — random strategy', () => {
+  it('returns all spans when percent is 100', () => {
+    const spans = makeSpans(10);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'random', percent: 100 } }));
+    expect(result).toHaveLength(10);
+  });
+
+  it('returns correct percentage of spans', () => {
+    const spans = makeSpans(100);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'random', percent: 50 } }));
+    expect(result).toHaveLength(50);
+  });
+
+  it('returns correct percentage (10%)', () => {
+    const spans = makeSpans(100);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'random', percent: 10 } }));
+    expect(result).toHaveLength(10);
+  });
+
+  it('never returns more than input size', () => {
+    const spans = makeSpans(5);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'random', percent: 100 } }));
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
+
+  it('returns empty for 0% sample', () => {
+    const spans = makeSpans(10);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'random', percent: 0 } }));
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns all spans when percent is omitted (defaults to 100)', () => {
+    const spans = makeSpans(5);
+    const scope = makeScope({ sampling: { strategy: 'random' } });
+    const result = applySampling(spans, scope);
+    expect(result).toHaveLength(5);
+  });
+});
+
+describe('applySampling — latest strategy', () => {
+  it('returns most recent N spans', () => {
+    const spans = makeSpans(10); // span 0 is most recent (timestamp = now), span 9 is oldest
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'latest', count: 3 } }));
+    expect(result).toHaveLength(3);
+    // First result should have the most recent timestamp
+    const timestamps = result.map(s => new Date(s.timestamp).getTime());
+    const maxTimestamp = Math.max(...spans.map(s => new Date(s.timestamp).getTime()));
+    expect(timestamps[0]).toBe(maxTimestamp);
+  });
+
+  it('returns all spans when count exceeds span count', () => {
+    const spans = makeSpans(5);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'latest', count: 100 } }));
+    expect(result).toHaveLength(5);
+  });
+
+  it('returns spans sorted by timestamp descending', () => {
+    const spans = makeSpans(5);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'latest', count: 5 } }));
+    for (let i = 1; i < result.length; i++) {
+      expect(new Date(result[i - 1]!.timestamp).getTime()).toBeGreaterThanOrEqual(
+        new Date(result[i]!.timestamp).getTime(),
+      );
+    }
+  });
+
+  it('returns all spans when count is not specified', () => {
+    const spans = makeSpans(5);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'latest' } }));
+    expect(result).toHaveLength(5);
+  });
+});
+
+describe('applySampling — errors-only strategy', () => {
+  it('returns only error spans', () => {
+    const spans = makeSpans(10, [2, 5, 7]); // error at indices 2, 5, 7
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'errors-only' } }));
+    expect(result).toHaveLength(3);
+    expect(result.every(s => s.isError === true)).toBe(true);
+  });
+
+  it('returns empty array when there are no error spans', () => {
+    const spans = makeSpans(10);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'errors-only' } }));
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns all spans if all are errors', () => {
+    const spans = makeSpans(5, [0, 1, 2, 3, 4]);
+    const result = applySampling(spans, makeScope({ sampling: { strategy: 'errors-only' } }));
+    expect(result).toHaveLength(5);
+  });
+});
+
+describe('applySampling — edge cases', () => {
+  it('handles empty input for all strategies', () => {
+    const strategies: Array<ScopeConfig['sampling']['strategy']> = ['random', 'latest', 'errors-only'];
+    for (const strategy of strategies) {
+      const result = applySampling([], makeScope({ sampling: { strategy } }));
+      expect(result).toHaveLength(0);
+    }
+  });
+});

--- a/dt-eval-cli/tsconfig.json
+++ b/dt-eval-cli/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/dt-eval-cli/tsup.config.ts
+++ b/dt-eval-cli/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+import { readFileSync } from 'node:fs';
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string };
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node20',
+  define: {
+    __CLIENT_VERSION__: JSON.stringify(version),
+  },
+});

--- a/dt-eval-cli/vitest.config.ts
+++ b/dt-eval-cli/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+    },
+  },
+  resolve: {
+    extensions: ['.ts', '.js'],
+  },
+});

--- a/dt-eval-deploy/package.json
+++ b/dt-eval-deploy/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "dt-eval-deploy",
+  "version": "0.1.0",
+  "description": "Serverless packaging and Terraform modules for dt-eval (Lambda, Cloud Run, Azure Functions)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "terraform"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "dt-eval-lib": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/dt-eval-deploy/src/index.ts
+++ b/dt-eval-deploy/src/index.ts
@@ -1,0 +1,4 @@
+// dt-eval-deploy
+// Serverless packaging and Terraform modules for dt-eval.
+// Supports AWS Lambda, Google Cloud Run, and Azure Functions.
+export {};

--- a/dt-eval-deploy/tsconfig.json
+++ b/dt-eval-deploy/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/dt-eval-deploy/tsup.config.ts
+++ b/dt-eval-deploy/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node20',
+});

--- a/dt-eval-instrument/package.json
+++ b/dt-eval-instrument/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "dt-eval-instrument",
+  "version": "0.1.0",
+  "description": "OTEL self-monitoring for dt-eval — emits traces, metrics, and logs for eval runs",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "dev": "tsx src/index.ts"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.57.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsup": "^8.3.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/dt-eval-instrument/src/index.ts
+++ b/dt-eval-instrument/src/index.ts
@@ -1,0 +1,4 @@
+// dt-eval-instrument
+// OTEL self-monitoring for dt-eval eval runs.
+// Emits traces, metrics, and logs to the configured Dynatrace OTEL endpoint.
+export {};

--- a/dt-eval-instrument/tsconfig.json
+++ b/dt-eval-instrument/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/dt-eval-instrument/tsup.config.ts
+++ b/dt-eval-instrument/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node20',
+});

--- a/dt-eval-lib/package-lock.json
+++ b/dt-eval-lib/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.0.0",
         "@biomejs/biome": "2.4.9",
+        "@google/genai": "^1.0.0",
         "dotenv": "^17.3.1",
         "openai": "^4.73.0",
         "tsup": "^8.3.0",
@@ -23,10 +25,18 @@
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.0.0",
+        "@google/genai": "^1.0.0",
         "openai": "^4.73.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-runtime": {
+          "optional": true
+        },
+        "@google/genai": {
           "optional": true
         },
         "openai": {
@@ -48,6 +58,759 @@
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
         "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1028.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1028.0.tgz",
+      "integrity": "sha512-FFdtkxWFmKX1Ka/vjDRKpYsm0/HTlab5qpHl8LAXRmJjhSSiLGiCnJYsYFN+zp3NucL02kM1DlpFU8Xnm7d8Ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/eventstream-handler-node": "^3.972.13",
+        "@aws-sdk/middleware-eventstream": "^3.972.9",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/middleware-websocket": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/token-providers": "3.1028.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/eventstream-serde-browser": "^4.2.13",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.13",
+        "@smithy/eventstream-serde-node": "^4.2.13",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.973.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.27.tgz",
+      "integrity": "sha512-CUZ5m8hwMCH6OYI4Li/WgMfIEx10Q2PLI9Y3XOUTPGZJ53aZ0007jCv+X/ywsaERyKPdw5MRZWk877roQksQ4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/xml-builder": "^3.972.17",
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.25.tgz",
+      "integrity": "sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.27.tgz",
+      "integrity": "sha512-3V3Usj9Gs93h865DqN4M2NWJhC5kXU9BvZskfN3+69omuYlE3TZxOEcVQtBGLOloJB7BVfJKXVLqeNhOzHqSlQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.29.tgz",
+      "integrity": "sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-login": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.29.tgz",
+      "integrity": "sha512-OGOslTbOlxXexKMqhxCEbBQbUIfuhGxU5UXw3Fm56ypXHvrXH4aTt/xb5Y884LOoteP1QST1lVZzHfcTnWhiPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.25.tgz",
+      "integrity": "sha512-HR7ynNRdNhNsdVCOCegy1HsfsRzozCOPtD3RzzT1JouuaHobWyRfJzCBue/3jP7gECHt+kQyZUvwg/cYLWurNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.29.tgz",
+      "integrity": "sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/token-providers": "3.1026.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1026.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1026.0.tgz",
+      "integrity": "sha512-Ieq/HiRrbEtrYP387Nes0XlR7H1pJiJOZKv+QyQzMYpvTiDs0VKy2ZB3E2Zf+aFovWmeE7lRE4lXyF7dYM6GgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.29.tgz",
+      "integrity": "sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.13.tgz",
+      "integrity": "sha512-2Pi1kD0MDkMAxDHqvpi/hKMs9hXUYbj2GLEjCwy+0jzfLChAsF50SUYnOeTI+RztA+Ic4pnLAdB03f1e8nggxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/eventstream-codec": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.9.tgz",
+      "integrity": "sha512-ypgOvpWxQTCnQyDHGxnTviqqANE7FIIzII7VczJnTPCJcJlu17hMQXnvE47aKSKsawVJAaaRsyOEbHQuLJF9ng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.9.tgz",
+      "integrity": "sha512-je5vRdNw4SkuTnmRbFZLdye4sQ0faLt8kwka5wnnSU30q1mHO4X+idGEJOOE+Tn1ME7Oryn05xxkDvIb3UaLaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.9.tgz",
+      "integrity": "sha512-HsVgDrruhqI28RkaXALm8grJ7Agc1wF6Et0xh6pom8NdO2VdO/SD9U/tPwUjewwK/pVoka+EShBxyCvgsPCtog==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.10.tgz",
+      "integrity": "sha512-RVQQbq5orQ/GHUnXvqEOj2HHPBJm+mM+ySwZKS5UaLBwra5ugRtiH09PLUoOZRl7a1YzaOzXSuGbn9iD5j60WQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.29.tgz",
+      "integrity": "sha512-f/sIRzuTfEjg6NsbMYvye2VsmnQoNgntntleQyx5uGacUYzszbfIlO3GcI6G6daWUmTm0IDZc11qMHWwF0o0mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-retry": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.15.tgz",
+      "integrity": "sha512-hsZ35FORQsN5hwNdMD6zWmHCphbXkDxO6j+xwCUiuMb0O6gzS/PWgttQNl1OAn7h/uqZAMUG4yOS0wY/yhAieg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-format-url": "^3.972.9",
+        "@smithy/eventstream-codec": "^4.2.13",
+        "@smithy/eventstream-serde-browser": "^4.2.13",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/signature-v4": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.19.tgz",
+      "integrity": "sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.11.tgz",
+      "integrity": "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1028.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1028.0.tgz",
+      "integrity": "sha512-2vDFrEhJDlUHyvDxqDyOk97cejMM8GJDyQbFfOCEWclGwhTjlj1mdyj36xsxh7DYyuquhjqfbvhpl6ZzsVol0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.7.tgz",
+      "integrity": "sha512-reXRwoJ6CfChoqAsBszUYajAF8Z2LRE+CRcKocvFSMpIiLOtYU3aJ9trmn6VVPAzbbY5LXF+FfmUslbXk1SYFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.6.tgz",
+      "integrity": "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-endpoints": "^3.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.9.tgz",
+      "integrity": "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.9.tgz",
+      "integrity": "sha512-sn/LMzTbGjYqCCF24390WxPd6hkpoSptiUn5DzVp4cD71yqw+yGEGm1YCxyEoPXyc8qciM8UzLJcZBFslxo5Uw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/types": "^4.14.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.15.tgz",
+      "integrity": "sha512-fYn3s9PtKdgQkczGZCFMgkNEe8aq1JCVbnRqjqN9RSVW43xn2RV9xdcZ3z01a48Jpkuh/xCmBKJxdLOo4Ozg7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.17.tgz",
+      "integrity": "sha512-Ra7hjqAZf1OXRRMueB13qex7mFJRDK/pgCvdSFemXBT8KCGnQDPoKzHY1SjN+TjJVmnpSF14W5tJ1vDamFu+Gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -655,6 +1418,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.49.0.tgz",
+      "integrity": "sha512-hO69Zl0H3x+L0KL4stl1pLYgnqnwHoLqtKy6MRlNnW8TAxjqMdOUVafomKd4z1BePkzoxJWbYILny9a2Zk43VQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -693,6 +1480,80 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.0",
@@ -1044,6 +1905,688 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.14",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.14.tgz",
+      "integrity": "sha512-N55f8mPEccpzKetUagdvmAy8oohf0J5cuj9jLI1TaSceRlq0pJsIZepY3kmAXAhyxqXPV6hDerDQhqQPKWgAoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.14",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.14.tgz",
+      "integrity": "sha512-vJ0IhpZxZAkFYOegMKSrxw7ujhhT2pass/1UEcZ4kfl5srTAqtPU5I7MdYQoreVas3204ykCiNhY1o7Xlz6Yyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-stream": "^4.5.22",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.13.tgz",
+      "integrity": "sha512-wboCPijzf6RJKLOvnjDAiBxGSmSnGXj35o5ZAWKDaHa/cvQ5U3ZJ13D4tMCE8JG4dxVAZFy/P0x/V9CwwdfULQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.13.tgz",
+      "integrity": "sha512-vYahwBAtRaAcFbOmE9aLr12z7RiHYDSLcnogSdxfm7kKfsNa3wH+NU5r7vTeB5rKvLsWyPjVX8iH94brP7umiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.13.tgz",
+      "integrity": "sha512-wwybfcOX0tLqCcBP378TIU9IqrDuZq/tDV48LlZNydMpCnqnYr+hWBAYbRE+rFFf/p7IkDJySM3bgiMKP2ihPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.13.tgz",
+      "integrity": "sha512-ied1lO559PtAsMJzg2TKRlctLnEi1PfkNeMMpdwXDImk1zV9uvS/Oxoy/vcy9uv1GKZAjDAB5xT6ziE9fzm5wA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.13.tgz",
+      "integrity": "sha512-hFyK+ORJrxAN3RYoaD6+gsGDQjeix8HOEkosoajvXYZ4VeqonM3G4jd9IIRm/sWGXUKmudkY9KdYjzosUqdM8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.13.tgz",
+      "integrity": "sha512-kRrq4EKLGeOxhC2CBEhRNcu1KSzNJzYY7RK3S7CxMPgB5dRrv55WqQOtRwQxQLC04xqORFLUgnDlc6xrNUULaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.16.tgz",
+      "integrity": "sha512-nYDRUIvNd4mFmuXraRWt6w5UsZTNqtj4hXJA/iiOD4tuseIdLP9Lq38teH/SZTcIFCa2f+27o7hYpIsWktJKEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.13.tgz",
+      "integrity": "sha512-4/oy9h0jjmY80a2gOIo75iLl8TOPhmtx4E2Hz+PfMjvx/vLtGY4TMU/35WRyH2JHPfT5CVB38u4JRow7gnmzJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.13.tgz",
+      "integrity": "sha512-jvC0RB/8BLj2SMIkY0Npl425IdnxZJxInpZJbu563zIRnVjpDMXevU3VMCRSabaLB0kf/eFIOusdGstrLJ8IDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.13.tgz",
+      "integrity": "sha512-IPMLm/LE4AZwu6qiE8Rr8vJsWhs9AtOdySRXrOM7xnvclp77Tyh7hMs/FRrMf26kgIe67vFJXXOSmVxS7oKeig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.29",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.29.tgz",
+      "integrity": "sha512-R9Q/58U+qBiSARGWbAbFLczECg/RmysRksX6Q8BaQEpt75I7LI6WGDZnjuC9GXSGKljEbA7N118LhGaMbfrTXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
+        "@smithy/util-middleware": "^4.2.13",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.1.tgz",
+      "integrity": "sha512-/zY+Gp7Qj2D2hVm3irkCyONER7E9MiX3cUUm/k2ZmhkzZkrPgwVS4aJ5NriZUEN/M0D1hhjrgjUmX04HhRwdWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/service-error-classification": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.1",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.17.tgz",
+      "integrity": "sha512-0T2mcaM6v9W1xku86Dk0bEW7aEseG6KenFkPK98XNw0ZhOqOiD1MrMsdnQw9QsL3/Oa85T53iSMlm0SZdSuIEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.13.tgz",
+      "integrity": "sha512-g72jN/sGDLyTanrCLH9fhg3oysO3f7tQa6eWWsMyn2BiYNCgjF24n4/I9wff/5XidFvjj9ilipAoQrurTUrLvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.13.tgz",
+      "integrity": "sha512-iGxQ04DsKXLckbgnX4ipElrOTk+IHgTyu0q0WssZfYhDm9CQWHmu6cOeI5wmWRxpXbBDhIIfXMWz5tPEtcVqbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.2.tgz",
+      "integrity": "sha512-/oD7u8M0oj2ZTFw7GkuuHWpIxtWdLlnyNkbrWcyVYhd5RJNDuczdkb0wfnQICyNFrVPlr8YHOhamjNy3zidhmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/querystring-builder": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.13.tgz",
+      "integrity": "sha512-bGzUCthxRmezuxkbu9wD33wWg9KX3hJpCXpQ93vVkPrHn9ZW6KNNdY5xAUWNuRCwQ+VyboFuWirG1lZhhkcyRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.13.tgz",
+      "integrity": "sha512-+HsmuJUF4u8POo6s8/a2Yb/AQ5t/YgLovCuHF9oxbocqv+SZ6gd8lC2duBFiCA/vFHoHQhoq7QjqJqZC6xOxxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.13.tgz",
+      "integrity": "sha512-tG4aOYFCZdPMjbgfhnIQ322H//ojujldp1SrHPHpBSb3NqgUp3dwiUGRJzie87hS1DYwWGqDuPaowoDF+rYCbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.13.tgz",
+      "integrity": "sha512-hqW3Q4P+CDzUyQ87GrboGMeD7XYNMOF+CuTwu936UQRB/zeYn3jys8C3w+wMkDfY7CyyyVwZQ5cNFoG0x1pYmA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.13.tgz",
+      "integrity": "sha512-a0s8XZMfOC/qpqq7RCPvJlk93rWFrElH6O++8WJKz0FqnA4Y7fkNi/0mnGgSH1C4x6MFsuBA8VKu4zxFrMe5Vw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.8.tgz",
+      "integrity": "sha512-VZCZx2bZasxdqxVgEAhREvDSlkatTPnkdWy1+Kiy8w7kYPBosW0V5IeDwzDUMvWBt56zpK658rx1cOBFOYaPaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.13.tgz",
+      "integrity": "sha512-YpYSyM0vMDwKbHD/JA7bVOF6kToVRpa+FM5ateEVRpsTNu564g1muBlkTubXhSKKYXInhpADF46FPyrZcTLpXg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.9.tgz",
+      "integrity": "sha512-ovaLEcTU5olSeHcRXcxV6viaKtpkHZumn6Ps0yn7dRf2rRSfy794vpjOtrWDO0d1auDSvAqxO+lyhERSXQ03EQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.14",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-stream": "^4.5.22",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.0.tgz",
+      "integrity": "sha512-OWgntFLW88kx2qvf/c/67Vno1yuXm/f9M7QFAtVkkO29IJXGBIg0ycEaBTH0kvCtwmvZxRujrgP5a86RvsXJAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.13.tgz",
+      "integrity": "sha512-2G03yoboIRZlZze2+PT4GZEjgwQsJjUgn6iTsvxA02bVceHR6vp4Cuk7TUnPFWKF+ffNUk3kj4COwkENS2K3vw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.45",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.45.tgz",
+      "integrity": "sha512-ag9sWc6/nWZAuK3Wm9KlFJUnRkXLrXn33RFjIAmCTFThqLHY+7wCst10BGq56FxslsDrjhSie46c8OULS+BiIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.49.tgz",
+      "integrity": "sha512-jlN6vHwE8gY5AfiFBavtD3QtCX2f7lM3BKkz7nFKSNfFR5nXLXLg6sqXTJEEyDwtxbztIDBQCfjsGVXlIru2lQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.4.tgz",
+      "integrity": "sha512-BKoR/ubPp9KNKFxPpg1J28N1+bgu8NGAtJblBP7yHy8yQPBWhIAv9+l92SlQLpolGm71CVO+btB60gTgzT0wog==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.13.tgz",
+      "integrity": "sha512-GTooyrlmRTqvUen4eK7/K1p6kryF7bnDfq6XsAbIsf2mo51B/utaH+XThY6dKgNCWzMAaH/+OLmqaBuLhLWRow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.1.tgz",
+      "integrity": "sha512-FwmicpgWOkP5kZUjN3y+3JIom8NLGqSAJBeoIgK0rIToI817TEBHCrd0A2qGeKQlgDeP+Jzn4i0H/NLAXGy9uQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.13",
+        "@smithy/types": "^4.14.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.22.tgz",
+      "integrity": "sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/types": "^4.14.0",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1071,6 +2614,13 @@
         "@types/node": "*",
         "form-data": "^4.0.4"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -1225,6 +2775,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -1261,6 +2821,51 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -1385,6 +2990,16 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1451,6 +3066,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1514,7 +3139,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1580,6 +3204,50 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1596,6 +3264,40 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/fix-dts-default-cjs-exports": {
@@ -1648,6 +3350,19 @@
         "node": ">= 12.20"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1671,6 +3386,55 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1723,6 +3487,34 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -1780,6 +3572,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -1798,6 +3604,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lilconfig": {
@@ -1829,6 +3668,13 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2014,6 +3860,36 @@
         }
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2044,7 +3920,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2094,7 +3969,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2147,6 +4021,31 @@
         }
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -2179,6 +4078,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -2226,6 +4135,27 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2265,6 +4195,19 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/sucrase": {
@@ -2398,6 +4341,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/tsup": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
@@ -2457,7 +4407,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2478,7 +4427,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2507,7 +4455,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3138,6 +5085,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     }
   }

--- a/dt-eval-lib/package.json
+++ b/dt-eval-lib/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": ">=18"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
     "@aws-sdk/client-bedrock-runtime": "^3.0.0",

--- a/dt-eval-lib/package.json
+++ b/dt-eval-lib/package.json
@@ -28,6 +28,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.0.0",
+    "@google/genai": "^1.0.0",
     "openai": "^4.73.0"
   },
   "peerDependenciesMeta": {
@@ -36,11 +38,19 @@
     },
     "@anthropic-ai/sdk": {
       "optional": true
+    },
+    "@google/genai": {
+      "optional": true
+    },
+    "@aws-sdk/client-bedrock-runtime": {
+      "optional": true
     }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.0.0",
     "@biomejs/biome": "2.4.9",
+    "@google/genai": "^1.0.0",
     "dotenv": "^17.3.1",
     "openai": "^4.73.0",
     "tsup": "^8.3.0",

--- a/dt-eval-lib/src/engine/providers/azure-openai.ts
+++ b/dt-eval-lib/src/engine/providers/azure-openai.ts
@@ -1,0 +1,80 @@
+import { AzureOpenAI } from "openai";
+import { EvalResponseError } from "../../errors";
+import { BaseProvider } from "./base";
+import type { LLMJudgeResponse, ProviderConfig } from "./types";
+import { validateLLMResponse } from "./validate";
+
+interface ResponseSchema {
+  name: string;
+  strict: boolean;
+  schema: {
+    type: string;
+    properties: Record<string, { type: string; description: string }>;
+    required: readonly string[];
+    additionalProperties: boolean;
+  };
+}
+
+const RESPONSE_SCHEMA = {
+  name: "eval_response",
+  strict: true,
+  schema: {
+    type: "object",
+    properties: {
+      scoreValue: { type: "number", description: "The evaluation score" },
+      summary: { type: "string", description: "Brief summary of the evaluation" },
+      reasoning: { type: "string", description: "Detailed reasoning for the score" },
+    },
+    required: ["scoreValue", "summary", "reasoning"],
+    additionalProperties: false,
+  },
+} as const satisfies ResponseSchema;
+
+export class AzureOpenAIProvider extends BaseProvider {
+  private client: AzureOpenAI;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    if (!config.apiKey) {
+      throw new Error("AzureOpenAI requires an API key (AZURE_OPENAI_API_KEY)");
+    }
+    if (!config.baseUrl) {
+      throw new Error("AzureOpenAI requires an endpoint (AZURE_OPENAI_ENDPOINT)");
+    }
+    this.client = new AzureOpenAI({
+      apiKey: config.apiKey,
+      endpoint: config.baseUrl,
+      // Use a recent stable API version; can be overridden via baseUrl if needed
+      apiVersion: "2024-02-01",
+      timeout: this.timeout,
+      maxRetries: 0,
+    });
+  }
+
+  async call(prompt: string): Promise<LLMJudgeResponse> {
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are an expert LLM evaluation judge. Respond only with the requested JSON structure.",
+        },
+        { role: "user", content: prompt },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: RESPONSE_SCHEMA,
+      },
+      temperature: 0,
+    });
+
+    const content = response.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new EvalResponseError("Azure OpenAI returned an empty response");
+    }
+
+    const parsed = JSON.parse(content);
+    return validateLLMResponse(parsed);
+  }
+}

--- a/dt-eval-lib/src/engine/providers/base.ts
+++ b/dt-eval-lib/src/engine/providers/base.ts
@@ -1,16 +1,18 @@
 import type { LLMJudgeResponse, LLMProvider, ProviderConfig } from "./types";
 
 export abstract class BaseProvider implements LLMProvider {
-  protected readonly apiKey: string;
+  protected readonly apiKey?: string;
   protected readonly model: string;
   protected readonly timeout: number;
   protected readonly baseUrl?: string;
+  protected readonly region?: string;
 
   constructor(config: ProviderConfig) {
     this.apiKey = config.apiKey;
     this.model = config.model;
     this.timeout = config.timeout;
     this.baseUrl = config.baseUrl;
+    this.region = config.region;
   }
 
   abstract call(prompt: string): Promise<LLMJudgeResponse>;

--- a/dt-eval-lib/src/engine/providers/bedrock.ts
+++ b/dt-eval-lib/src/engine/providers/bedrock.ts
@@ -1,0 +1,48 @@
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  type Message,
+} from "@aws-sdk/client-bedrock-runtime";
+import { EvalResponseError } from "../../errors";
+import { BaseProvider } from "./base";
+import type { LLMJudgeResponse, ProviderConfig } from "./types";
+import { validateLLMResponse } from "./validate";
+
+const SYSTEM_PROMPT =
+  "You are an expert LLM evaluation judge. Respond with a JSON object containing exactly three fields: scoreValue (number), summary (string), reasoning (string). No markdown, no code fences — just raw JSON.";
+
+export class BedrockProvider extends BaseProvider {
+  private client: BedrockRuntimeClient;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    const region = config.region ?? process.env["AWS_REGION"] ?? "us-east-1";
+    this.client = new BedrockRuntimeClient({ region });
+  }
+
+  async call(prompt: string): Promise<LLMJudgeResponse> {
+    const messages: Message[] = [{ role: "user", content: [{ text: prompt }] }];
+
+    const command = new ConverseCommand({
+      modelId: this.model,
+      messages,
+      system: [{ text: SYSTEM_PROMPT }],
+      inferenceConfig: { temperature: 0, maxTokens: 1024 },
+    });
+
+    const response = await this.client.send(command);
+
+    const outputMessage = response.output?.message;
+    const textBlock = outputMessage?.content?.find((b) => b.text !== undefined);
+
+    if (!textBlock?.text) {
+      throw new EvalResponseError("Bedrock returned an empty response");
+    }
+
+    // Strip optional markdown code fences that some models add
+    const raw = textBlock.text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+
+    const parsed = JSON.parse(raw);
+    return validateLLMResponse(parsed);
+  }
+}

--- a/dt-eval-lib/src/engine/providers/gemini.ts
+++ b/dt-eval-lib/src/engine/providers/gemini.ts
@@ -1,0 +1,51 @@
+import { GoogleGenAI } from "@google/genai";
+import { EvalResponseError } from "../../errors";
+import { BaseProvider } from "./base";
+import type { LLMJudgeResponse, ProviderConfig } from "./types";
+import { validateLLMResponse } from "./validate";
+
+const SYSTEM_INSTRUCTION =
+  "You are an expert LLM evaluation judge. Respond only with the requested JSON structure.";
+
+const RESPONSE_SCHEMA = {
+  type: "object" as const,
+  properties: {
+    scoreValue: { type: "number" as const, description: "The evaluation score" },
+    summary: { type: "string" as const, description: "Brief summary of the evaluation" },
+    reasoning: { type: "string" as const, description: "Detailed reasoning for the score" },
+  },
+  required: ["scoreValue", "summary", "reasoning"],
+};
+
+export class GeminiProvider extends BaseProvider {
+  private client: GoogleGenAI;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    if (!config.apiKey) {
+      throw new Error("Gemini requires an API key (GEMINI_API_KEY or GOOGLE_API_KEY)");
+    }
+    this.client = new GoogleGenAI({ apiKey: config.apiKey });
+  }
+
+  async call(prompt: string): Promise<LLMJudgeResponse> {
+    const response = await this.client.models.generateContent({
+      model: this.model,
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
+      config: {
+        systemInstruction: SYSTEM_INSTRUCTION,
+        responseMimeType: "application/json",
+        responseSchema: RESPONSE_SCHEMA,
+        temperature: 0,
+      },
+    });
+
+    const text = response.text;
+    if (!text) {
+      throw new EvalResponseError("Gemini returned an empty response");
+    }
+
+    const parsed = JSON.parse(text);
+    return validateLLMResponse(parsed);
+  }
+}

--- a/dt-eval-lib/src/engine/providers/index.ts
+++ b/dt-eval-lib/src/engine/providers/index.ts
@@ -5,22 +5,31 @@ import type { LLMProvider } from "./types";
 const DEFAULT_MODELS: Record<string, string> = {
   openai: "gpt-5.1",
   anthropic: "claude-sonnet-4-20250514",
+  "azure-openai": "gpt-4o", // deployment name; users should override with their deployment
+  gemini: "gemini-2.0-flash",
+  bedrock: "anthropic.claude-sonnet-4-5-20251001-v1:0",
 };
 
 const ENV_KEYS: Record<string, string> = {
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",
+  "azure-openai": "AZURE_OPENAI_API_KEY",
+  gemini: "GEMINI_API_KEY",
+  // bedrock: no single API key — uses AWS credential chain
 };
 
 const ENV_BASE_URL_KEYS: Record<string, string> = {
   openai: "OPENAI_BASE_URL",
   anthropic: "ANTHROPIC_BASE_URL",
+  "azure-openai": "AZURE_OPENAI_ENDPOINT",
 };
+
+const SUPPORTED_PROVIDERS = new Set(Object.keys(DEFAULT_MODELS));
 
 export async function createProvider(options: ProviderOptions): Promise<LLMProvider> {
   const provider = options.provider;
-  if (provider !== "openai" && provider !== "anthropic") {
-    throw new EvalConfigError(`Unknown provider: ${provider}`);
+  if (!SUPPORTED_PROVIDERS.has(provider)) {
+    throw new EvalConfigError(`Unknown provider: ${provider}. Supported: ${[...SUPPORTED_PROVIDERS].join(", ")}`);
   }
 
   const timeout = options.timeout ?? 30000;
@@ -28,16 +37,33 @@ export async function createProvider(options: ProviderOptions): Promise<LLMProvi
     throw new EvalConfigError(`timeout must be a positive integer (ms), got ${timeout}`);
   }
 
-  const apiKey = options.apiKey ?? process.env[ENV_KEYS[provider]];
+  const model = options.model ?? DEFAULT_MODELS[provider];
+  const baseUrl = options.baseUrl ?? (ENV_BASE_URL_KEYS[provider] ? process.env[ENV_BASE_URL_KEYS[provider]] : undefined);
+
+  // Bedrock uses the AWS credential chain — no API key required
+  if (provider === "bedrock") {
+    const region = options.region ?? process.env["AWS_REGION"];
+    const { BedrockProvider } = await import("./bedrock");
+    return new BedrockProvider({ model, timeout, baseUrl, region });
+  }
+
+  // All other providers require an API key
+  const envKey = ENV_KEYS[provider];
+
+  // Gemini also accepts GOOGLE_API_KEY as a fallback
+  const apiKey =
+    options.apiKey ??
+    (provider === "gemini"
+      ? (process.env["GEMINI_API_KEY"] ?? process.env["GOOGLE_API_KEY"])
+      : process.env[envKey]);
 
   if (!apiKey) {
+    const envHint = provider === "gemini" ? "GEMINI_API_KEY or GOOGLE_API_KEY" : envKey;
     throw new EvalConfigError(
-      `Missing API key for ${provider}. Provide it via provider.apiKey or set the ${ENV_KEYS[provider]} environment variable.`,
+      `Missing API key for ${provider}. Provide it via provider.apiKey or set the ${envHint} environment variable.`,
     );
   }
 
-  const baseUrl = options.baseUrl ?? process.env[ENV_BASE_URL_KEYS[provider]];
-  const model = options.model ?? DEFAULT_MODELS[provider];
   const providerConfig = { apiKey, model, timeout, baseUrl };
 
   switch (provider) {
@@ -49,5 +75,19 @@ export async function createProvider(options: ProviderOptions): Promise<LLMProvi
       const { AnthropicProvider } = await import("./anthropic");
       return new AnthropicProvider(providerConfig);
     }
+    case "azure-openai": {
+      if (!baseUrl) {
+        throw new EvalConfigError(
+          "azure-openai requires an endpoint. Provide provider.baseUrl or set AZURE_OPENAI_ENDPOINT.",
+        );
+      }
+      const { AzureOpenAIProvider } = await import("./azure-openai");
+      return new AzureOpenAIProvider({ ...providerConfig, baseUrl });
+    }
+    case "gemini": {
+      const { GeminiProvider } = await import("./gemini");
+      return new GeminiProvider(providerConfig);
+    }
   }
 }
+

--- a/dt-eval-lib/src/engine/providers/types.ts
+++ b/dt-eval-lib/src/engine/providers/types.ts
@@ -7,10 +7,12 @@ export interface LLMJudgeResponse {
 
 /** Configuration passed to provider constructors */
 export interface ProviderConfig {
-  apiKey: string;
+  apiKey?: string;
   model: string;
   timeout: number;
   baseUrl?: string;
+  /** AWS region — used by Bedrock */
+  region?: string;
 }
 
 /** Interface that each LLM provider must implement */

--- a/dt-eval-lib/src/engine/types.ts
+++ b/dt-eval-lib/src/engine/types.ts
@@ -1,22 +1,24 @@
 import type { Score } from "../scoring/types";
 
 /** Provider selection */
-export type Provider = "openai" | "anthropic";
+export type Provider = "openai" | "anthropic" | "azure-openai" | "gemini" | "bedrock";
 
 /** Provider-related configuration */
 export interface ProviderOptions {
   /** Which LLM provider to use */
   provider: Provider;
-  /** API key — falls back to OPENAI_API_KEY / ANTHROPIC_API_KEY env vars */
+  /** API key — falls back to provider-specific env var (not used for bedrock) */
   apiKey?: string;
-  /** Base URL for the provider API — falls back to OPENAI_BASE_URL / ANTHROPIC_BASE_URL env vars */
+  /** Base URL / endpoint for the provider API */
   baseUrl?: string;
-  /** Model override — defaults to gpt-5.1 / claude-sonnet-4-20250514 */
+  /** Model override — falls back to provider-specific default */
   model?: string;
   /** Request timeout in ms — default 30000 */
   timeout?: number;
   /** Max retries on transient errors — default 2 */
   maxRetries?: number;
+  /** AWS region for Bedrock — falls back to AWS_REGION env var */
+  region?: string;
 }
 
 /** Scoring-related configuration */

--- a/dt-eval-lib/tests/engine.test.ts
+++ b/dt-eval-lib/tests/engine.test.ts
@@ -1,18 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // We'll mock the provider modules so no real API calls are made
-vi.mock("openai", () => {
-  return {
-    default: vi.fn().mockImplementation(() => ({
-      chat: {
-        completions: {
-          create: vi.fn(),
-        },
-      },
-    })),
-  };
-});
-
 vi.mock("@anthropic-ai/sdk", () => {
   return {
     default: vi.fn().mockImplementation(() => ({
@@ -23,8 +11,43 @@ vi.mock("@anthropic-ai/sdk", () => {
   };
 });
 
+vi.mock("openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openai")>();
+  return {
+    ...actual,
+    default: vi.fn().mockImplementation(() => ({
+      chat: { completions: { create: vi.fn() } },
+    })),
+    AzureOpenAI: vi.fn().mockImplementation(() => ({
+      chat: { completions: { create: vi.fn() } },
+    })),
+  };
+});
+
+vi.mock("@google/genai", () => {
+  return {
+    GoogleGenAI: vi.fn().mockImplementation(() => ({
+      models: {
+        generateContent: vi.fn(),
+      },
+    })),
+  };
+});
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+  return {
+    BedrockRuntimeClient: vi.fn().mockImplementation(() => ({
+      send: vi.fn(),
+    })),
+    ConverseCommand: vi.fn(),
+  };
+});
+
 import { evaluate } from "../src/engine/index";
 import { AnthropicProvider } from "../src/engine/providers/anthropic";
+import { AzureOpenAIProvider } from "../src/engine/providers/azure-openai";
+import { BedrockProvider } from "../src/engine/providers/bedrock";
+import { GeminiProvider } from "../src/engine/providers/gemini";
 import { createProvider } from "../src/engine/providers/index";
 import { OpenAIProvider } from "../src/engine/providers/openai";
 import type { LLMJudgeResponse, LLMProvider } from "../src/engine/providers/types";
@@ -493,5 +516,144 @@ describe("provider factory", () => {
       if (origUrl !== undefined) process.env.ANTHROPIC_BASE_URL = origUrl;
       else delete process.env.ANTHROPIC_BASE_URL;
     }
+  });
+
+  it("creates AzureOpenAI provider when provider is 'azure-openai'", async () => {
+    const provider = await createProvider({
+      provider: "azure-openai",
+      apiKey: "test-azure-key",
+      baseUrl: "https://my-resource.openai.azure.com",
+      timeout: 30000,
+    });
+    expect(provider).toBeInstanceOf(AzureOpenAIProvider);
+  });
+
+  it("throws when azure-openai is missing endpoint", async () => {
+    await expect(
+      createProvider({
+        provider: "azure-openai",
+        apiKey: "test-azure-key",
+        timeout: 30000,
+      }),
+    ).rejects.toThrow("azure-openai requires an endpoint");
+  });
+
+  it("throws when azure-openai is missing API key", async () => {
+    const origKey = process.env.AZURE_OPENAI_API_KEY;
+    delete process.env.AZURE_OPENAI_API_KEY;
+    try {
+      await expect(
+        createProvider({
+          provider: "azure-openai",
+          baseUrl: "https://my-resource.openai.azure.com",
+          timeout: 30000,
+        }),
+      ).rejects.toThrow("Missing API key for azure-openai");
+    } finally {
+      if (origKey !== undefined) process.env.AZURE_OPENAI_API_KEY = origKey;
+    }
+  });
+
+  it("falls back to AZURE_OPENAI_API_KEY env var", async () => {
+    const origKey = process.env.AZURE_OPENAI_API_KEY;
+    process.env.AZURE_OPENAI_API_KEY = "env-azure-key";
+    try {
+      const provider = await createProvider({
+        provider: "azure-openai",
+        baseUrl: "https://my-resource.openai.azure.com",
+        timeout: 30000,
+      });
+      expect(provider).toBeInstanceOf(AzureOpenAIProvider);
+    } finally {
+      if (origKey !== undefined) process.env.AZURE_OPENAI_API_KEY = origKey;
+      else delete process.env.AZURE_OPENAI_API_KEY;
+    }
+  });
+
+  it("creates Gemini provider when provider is 'gemini'", async () => {
+    const provider = await createProvider({
+      provider: "gemini",
+      apiKey: "test-gemini-key",
+      timeout: 30000,
+    });
+    expect(provider).toBeInstanceOf(GeminiProvider);
+  });
+
+  it("falls back to GEMINI_API_KEY env var", async () => {
+    const origKey = process.env.GEMINI_API_KEY;
+    process.env.GEMINI_API_KEY = "env-gemini-key";
+    try {
+      const provider = await createProvider({
+        provider: "gemini",
+        timeout: 30000,
+      });
+      expect(provider).toBeInstanceOf(GeminiProvider);
+    } finally {
+      if (origKey !== undefined) process.env.GEMINI_API_KEY = origKey;
+      else delete process.env.GEMINI_API_KEY;
+    }
+  });
+
+  it("falls back to GOOGLE_API_KEY env var for gemini", async () => {
+    const origGemini = process.env.GEMINI_API_KEY;
+    const origGoogle = process.env.GOOGLE_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    process.env.GOOGLE_API_KEY = "env-google-key";
+    try {
+      const provider = await createProvider({
+        provider: "gemini",
+        timeout: 30000,
+      });
+      expect(provider).toBeInstanceOf(GeminiProvider);
+    } finally {
+      if (origGemini !== undefined) process.env.GEMINI_API_KEY = origGemini;
+      if (origGoogle !== undefined) process.env.GOOGLE_API_KEY = origGoogle;
+      else delete process.env.GOOGLE_API_KEY;
+    }
+  });
+
+  it("throws when gemini is missing API key", async () => {
+    const origGemini = process.env.GEMINI_API_KEY;
+    const origGoogle = process.env.GOOGLE_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    try {
+      await expect(
+        createProvider({ provider: "gemini", timeout: 30000 }),
+      ).rejects.toThrow("Missing API key for gemini");
+    } finally {
+      if (origGemini !== undefined) process.env.GEMINI_API_KEY = origGemini;
+      if (origGoogle !== undefined) process.env.GOOGLE_API_KEY = origGoogle;
+    }
+  });
+
+  it("creates Bedrock provider when provider is 'bedrock'", async () => {
+    const provider = await createProvider({
+      provider: "bedrock",
+      region: "us-east-1",
+      timeout: 30000,
+    });
+    expect(provider).toBeInstanceOf(BedrockProvider);
+  });
+
+  it("creates Bedrock provider without explicit region (uses env/default)", async () => {
+    const origRegion = process.env.AWS_REGION;
+    process.env.AWS_REGION = "eu-west-1";
+    try {
+      const provider = await createProvider({
+        provider: "bedrock",
+        timeout: 30000,
+      });
+      expect(provider).toBeInstanceOf(BedrockProvider);
+    } finally {
+      if (origRegion !== undefined) process.env.AWS_REGION = origRegion;
+      else delete process.env.AWS_REGION;
+    }
+  });
+
+  it("throws on unknown provider", async () => {
+    await expect(
+      createProvider({ provider: "unknown-provider" as never, timeout: 30000 }),
+    ).rejects.toThrow("Unknown provider: unknown-provider");
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dt-eval",
+  "version": "0.1.0",
+  "description": "Open-source evaluation toolkit for LLM observability on Dynatrace",
+  "private": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "workspaces": [
+    "dt-eval-cli",
+    "dt-eval-lib",
+    "dt-eval-instrument",
+    "dt-eval-deploy"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present",
+    "lint": "npm run lint --workspaces --if-present"
+  }
+}


### PR DESCRIPTION
## Summary

- Renames the monorepo concept to **dt-eval** and adds a root `package.json` with npm workspaces covering all four packages
- Scaffolds two new packages: `dt-eval-instrument` (OTEL self-monitoring) and `dt-eval-deploy` (serverless packaging + Terraform modules)
- Fixes `dt-eval-lib` license from MIT → Apache-2.0 to match the repo
- Replaces the boilerplate README with a public-facing doc modelled on the openevals style: concise intro, working quickstart, structured feature sections

## Packages after this PR

| Package | Status |
|---------|--------|
| `dt-eval-cli` | existing |
| `dt-eval-lib` | existing |
| `dt-eval-instrument` | new (stub) |
| `dt-eval-deploy` | new (stub) |

## Notes

`dt-eval-instrument` and `dt-eval-deploy` are stubs with `src/index.ts`, `package.json`, `tsconfig.json`, and `tsup.config.ts` — ready to be filled in as implementation progresses.