### PR TITLE
feat: add Azure OpenAI and Bedrock provider support

### DIFF
--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -235,14 +235,42 @@ export function createConfigureCommand(): Command {
         anthropic: 'Anthropic API key',
         'azure-openai': 'Azure OpenAI API key (AZURE_OPENAI_API_KEY)',
         gemini: 'Gemini API key (GEMINI_API_KEY or GOOGLE_API_KEY)',
-        bedrock: 'AWS region for Bedrock (e.g. us-east-1) — leave blank to use AWS_REGION env var',
+        bedrock: 'AWS Access Key ID — leave blank to rely on AWS_ACCESS_KEY_ID env var / IAM role',
       };
 
       let apiKey: string;
+      let bedrockSecretKey = '';
+      let bedrockRegion = '';
+      let azureBaseUrl = '';
+      let azureApiVersion = '';
+
       if (provider === 'bedrock') {
         apiKey = await input({
           message: providerApiKeyLabel[provider],
+          default: existing.judge?.apiKey ?? '',
+        });
+        bedrockSecretKey = await password({
+          message: 'AWS Secret Access Key — leave blank to rely on AWS_SECRET_ACCESS_KEY env var',
+          mask: '*',
+        });
+        bedrockRegion = await input({
+          message: 'AWS region (e.g. us-east-1)',
           default: existing.judge?.region ?? process.env['AWS_REGION'] ?? 'us-east-1',
+        });
+      } else if (provider === 'azure-openai') {
+        apiKey = await password({
+          message: providerApiKeyLabel[provider] ?? `${provider} API key`,
+        });
+        azureBaseUrl = await input({
+          message: 'Azure OpenAI endpoint URL (e.g. https://my-resource.openai.azure.com/)',
+          default: existing.judge?.baseUrl ?? process.env['AZURE_OPENAI_ENDPOINT'] ?? '',
+        });
+        azureApiVersion = await input({
+          message: 'Azure OpenAI API version (e.g. 2025-04-01-preview)',
+          default:
+            existing.judge?.apiVersion ??
+            process.env['AZURE_OPENAI_API_VERSION'] ??
+            '2025-04-01-preview',
         });
       } else {
         apiKey = await password({
@@ -250,8 +278,13 @@ export function createConfigureCommand(): Command {
         });
       }
 
+      const modelPlaceholder =
+        provider === 'azure-openai'
+          ? 'Required: enter your Azure deployment name (e.g. my-gpt4-deployment)'
+          : 'Leave blank for provider default';
+
       const model = await input({
-        message: 'Evaluator model  (leave blank for provider default)',
+        message: `Evaluator model  (${modelPlaceholder})`,
         default: existing.judge?.model ?? '',
       });
 
@@ -290,9 +323,15 @@ export function createConfigureCommand(): Command {
         },
         judge: {
           provider,
-          ...(provider === 'bedrock'
-            ? { region: apiKey || existing.judge?.region }
-            : { apiKey: apiKey || existing.judge?.apiKey }),
+          apiKey: apiKey || existing.judge?.apiKey,
+          ...(provider === 'bedrock' && {
+            secretKey: bedrockSecretKey || existing.judge?.secretKey,
+            region: bedrockRegion || existing.judge?.region,
+          }),
+          ...(provider === 'azure-openai' && {
+            baseUrl: azureBaseUrl || existing.judge?.baseUrl,
+            apiVersion: azureApiVersion || existing.judge?.apiVersion,
+          }),
           model: model || existing.judge?.model,
           timeout: existing.judge?.timeout ?? 30000,
           maxRetries: existing.judge?.maxRetries ?? 2,

--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -29,7 +29,7 @@ export function createRunCommand(): Command {
   cmd.argument('[config]', 'Path to eval config file (e.g. travel-advisor.dt-eval.yaml)');
   cmd.option('--config <path>', 'Path to eval config file (alias for positional argument)');
   cmd.option('--since <duration>', 'Time window for trace fetch (e.g. 1h, 6h, 24h)', '1h');
-  cmd.option('--sample <percent>', 'Percentage of traces to evaluate (0-100)', parseFloat, 100);
+  cmd.option('--sample <percent>', 'Override sampling: percentage of traces to evaluate (0-100). When omitted, uses the strategy from your config file.', parseFloat);
   cmd.option('--metric <name>', 'Run a specific evaluator only');
   cmd.option('--dry-run', 'Fetch and transform traces, print payloads, do not send');
   cmd.option('--ci', 'Non-interactive mode: JSON stdout, exit 1 on threshold breach');

--- a/dt-eval-cli/src/cli/commands/status.ts
+++ b/dt-eval-cli/src/cli/commands/status.ts
@@ -97,11 +97,12 @@ export function createStatusCommand(): Command {
 
     console.log('\nScope:');
     console.log(`  Time window: ${config.scope.since}`);
-    console.log(`  Sampling:    ${config.scope.sampling.strategy} (${
-      config.scope.sampling.strategy === 'random'
-        ? `${config.scope.sampling.percent ?? 100}%`
-        : config.scope.sampling.strategy === 'latest'
-        ? `top ${config.scope.sampling.count ?? 'all'}`
+    const sampling = config.scope.sampling;
+    console.log(`  Sampling:    ${sampling?.strategy ?? 'random'} (${
+      !sampling || sampling.strategy === 'random'
+        ? `${sampling?.percent ?? 5}%`
+        : sampling.strategy === 'latest'
+        ? `top ${sampling.count ?? 'all'}`
         : 'errors only'
     })`);
 

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -51,4 +51,6 @@ export const DEFAULT_JUDGE_MODELS: Record<string, string> = {
   anthropic: 'claude-sonnet-4-6',
   vertex: 'gemini-2.5-pro',
   gemini: 'gemini-2.5-flash',
+  // azure-openai: no default — deployment names are user-defined in Azure portal
+  bedrock: 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
 };

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -187,9 +187,7 @@ export function validateConfig(config: DtEvalConfig): void {
   }
 
   const { strategy } = config.scope?.sampling ?? {};
-  if (!strategy) {
-    issues.push('scope.sampling.strategy is required');
-  } else if (!['random', 'latest', 'errors-only'].includes(strategy)) {
+  if (strategy && !['random', 'latest', 'errors-only'].includes(strategy)) {
     issues.push(`scope.sampling.strategy must be one of: random, latest, errors-only`);
   }
 

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -106,6 +106,7 @@ function applyEnvVars(config: DtEvalConfig): DtEvalConfig {
   } else if (provider === 'azure-openai') {
     if (process.env['AZURE_OPENAI_API_KEY']) result.judge.apiKey = process.env['AZURE_OPENAI_API_KEY'];
     if (process.env['AZURE_OPENAI_ENDPOINT']) result.judge.baseUrl = process.env['AZURE_OPENAI_ENDPOINT'];
+    if (process.env['AZURE_OPENAI_API_VERSION']) result.judge.apiVersion = process.env['AZURE_OPENAI_API_VERSION'];
   } else if (provider === 'gemini') {
     if (process.env['GEMINI_API_KEY']) result.judge.apiKey = process.env['GEMINI_API_KEY'];
     else if (process.env['GOOGLE_API_KEY']) result.judge.apiKey = process.env['GOOGLE_API_KEY'];

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -27,7 +27,7 @@ export interface JudgeConfig {
 export interface ScopeConfig {
   service?: string; // service.name to filter spans (previously 'app')
   since: string; // e.g. "1h", "6h", "24h"
-  sampling: {
+  sampling?: {
     strategy: 'random' | 'latest' | 'errors-only';
     percent?: number; // for random
     count?: number;   // for latest

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -9,12 +9,18 @@ export interface DynatraceConfig {
 
 export interface JudgeConfig {
   provider: 'openai' | 'anthropic' | 'azure-openai' | 'gemini' | 'bedrock';
+  /** API key. For Bedrock: AWS access key ID. */
   apiKey?: string;
+  /** For Bedrock: AWS secret access key. Falls back to AWS_SECRET_ACCESS_KEY env var. */
+  secretKey?: string;
+  /** For azure-openai: endpoint URL (e.g. https://my-resource.openai.azure.com/). Falls back to AZURE_OPENAI_ENDPOINT. */
   baseUrl?: string;
+  /** For azure-openai: API version (e.g. 2025-04-01-preview). Falls back to AZURE_OPENAI_API_VERSION. Required for azure-openai. */
+  apiVersion?: string;
   model?: string;
   timeout?: number;
   maxRetries?: number;
-  /** AWS region for Bedrock; Azure OpenAI deployment endpoint base region */
+  /** For Bedrock: AWS region (e.g. us-east-1). Falls back to AWS_DEFAULT_REGION / AWS_REGION env vars. */
   region?: string;
 }
 

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -63,7 +63,7 @@ export async function runEvals(
   const query = buildGenAiSpanQuery({
     app: evalConfig.scope.service,
     since,
-    errorsOnly: evalConfig.scope.sampling.strategy === 'errors-only',
+    errorsOnly: evalConfig.scope.sampling?.strategy === 'errors-only',
   });
   logger.debug(`DQL query:\n${query}`);
 

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -118,13 +118,19 @@ export async function runEvals(
   // 5. Build provider config for dt-eval-lib
   const judgeProvider = evalConfig.judge.provider;
   const judgeModel = evalConfig.judge.model ?? '';
+
   const libConfig: EvalConfig = {
-    provider: evalConfig.judge.provider,
-    apiKey: evalConfig.judge.apiKey,
-    baseUrl: evalConfig.judge.baseUrl,
-    model: evalConfig.judge.model,
-    timeout: evalConfig.judge.timeout,
-    maxRetries: evalConfig.judge.maxRetries,
+    provider: {
+      provider: evalConfig.judge.provider as import('dt-eval-lib').Provider,
+      apiKey: evalConfig.judge.apiKey,
+      baseUrl: evalConfig.judge.baseUrl,
+      apiVersion: evalConfig.judge.apiVersion,
+      region: evalConfig.judge.region,
+      secretKey: evalConfig.judge.secretKey,
+      model: evalConfig.judge.model,
+      timeout: evalConfig.judge.timeout,
+      maxRetries: evalConfig.judge.maxRetries,
+    },
   };
 
   // 6. Evaluate via dt-eval-lib in parallel batches

--- a/dt-eval-cli/src/runner/sampler.ts
+++ b/dt-eval-cli/src/runner/sampler.ts
@@ -11,7 +11,7 @@ function shuffleArray<T>(array: T[]): T[] {
 }
 
 export function applySampling(spans: GenAiSpan[], config: ScopeConfig): GenAiSpan[] {
-  const { strategy, percent, count } = config.sampling;
+  const { strategy, percent, count } = config.sampling ?? { strategy: 'random' as const, percent: 5 };
 
   if (strategy === 'random') {
     const pct = percent ?? 100;

--- a/dt-eval-lib/package.json
+++ b/dt-eval-lib/package.json
@@ -20,7 +20,10 @@
     "lint": "biome check src tests",
     "lint:fix": "biome check --write src tests",
     "format": "biome format --write src tests",
-    "format:check": "biome format src tests"
+    "format:check": "biome format src tests",
+    "e2e:azure": "tsx _temp_tests/azure-openai-e2e.ts",
+    "e2e:bedrock": "tsx _temp_tests/bedrock-e2e.ts",
+    "e2e:vertex": "tsx _temp_tests/vertex-e2e.ts"
   },
   "engines": {
     "node": ">=20"
@@ -43,6 +46,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.0.0",
     "@google/genai": "^1.0.0",
     "openai": "^4.73.0"
   },
@@ -53,12 +57,16 @@
     "@anthropic-ai/sdk": {
       "optional": true
     },
+    "@aws-sdk/client-bedrock-runtime": {
+      "optional": true
+    },
     "@google/genai": {
       "optional": true
     }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1031.0",
     "@biomejs/biome": "2.4.9",
     "@google/genai": "^1.0.0",
     "dotenv": "^17.3.1",

--- a/dt-eval-lib/src/engine/providers/azure-openai.ts
+++ b/dt-eval-lib/src/engine/providers/azure-openai.ts
@@ -1,0 +1,64 @@
+import { AzureOpenAI } from "openai";
+import { EvalConfigError, EvalResponseError } from "../../errors";
+import { BaseProvider } from "./base";
+import type { LLMJudgeResponse, ProviderConfig } from "./types";
+import { validateLLMResponse } from "./validate";
+
+export class AzureOpenAIProvider extends BaseProvider {
+  private client: AzureOpenAI;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    if (!config.baseUrl) {
+      throw new EvalConfigError(
+        "azure-openai requires baseUrl (e.g. https://my-resource.openai.azure.com/)",
+      );
+    }
+    if (!config.apiVersion) {
+      throw new EvalConfigError(
+        "azure-openai requires apiVersion (e.g. 2025-04-01-preview). Check your Azure deployment's supported API versions.",
+      );
+    }
+    this.client = new AzureOpenAI({
+      endpoint: config.baseUrl.replace(/\/$/, ""),
+      apiKey: config.apiKey,
+      apiVersion: config.apiVersion,
+      deployment: config.model,
+      timeout: config.timeout,
+      maxRetries: 0,
+    });
+  }
+
+  async call(prompt: string): Promise<LLMJudgeResponse> {
+    // Use json_object mode — Azure deployment model versions vary in structured-output support.
+    // temperature is omitted intentionally: reasoning models (o-series, gpt-5.x) only accept the
+    // default value and will reject an explicit 0.
+    const response = await this.client.chat.completions.create({
+      model: this.model,
+      messages: [
+        {
+          role: "system",
+          content:
+            'You are an expert LLM evaluation judge. Respond only with valid JSON: {"scoreValue": <number>, "summary": "<string>", "reasoning": "<string>"}',
+        },
+        { role: "user", content: prompt },
+      ],
+      response_format: { type: "json_object" },
+    });
+
+    const content = response.choices?.[0]?.message?.content;
+    if (!content) {
+      throw new EvalResponseError("Azure OpenAI returned an empty response");
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      throw new EvalResponseError(
+        `Azure OpenAI returned non-JSON content: ${content.slice(0, 200)}`,
+      );
+    }
+    return validateLLMResponse(parsed);
+  }
+}

--- a/dt-eval-lib/src/engine/providers/base.ts
+++ b/dt-eval-lib/src/engine/providers/base.ts
@@ -5,12 +5,18 @@ export abstract class BaseProvider implements LLMProvider {
   protected readonly model: string;
   protected readonly timeout: number;
   protected readonly baseUrl?: string;
+  protected readonly apiVersion?: string;
+  protected readonly region?: string;
+  protected readonly secretKey?: string;
 
   constructor(config: ProviderConfig) {
     this.apiKey = config.apiKey;
     this.model = config.model;
     this.timeout = config.timeout;
     this.baseUrl = config.baseUrl;
+    this.apiVersion = config.apiVersion;
+    this.region = config.region;
+    this.secretKey = config.secretKey;
   }
 
   abstract call(prompt: string): Promise<LLMJudgeResponse>;

--- a/dt-eval-lib/src/engine/providers/bedrock.ts
+++ b/dt-eval-lib/src/engine/providers/bedrock.ts
@@ -1,0 +1,58 @@
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+  type Message,
+} from "@aws-sdk/client-bedrock-runtime";
+import { EvalResponseError } from "../../errors";
+import { BaseProvider } from "./base";
+import type { LLMJudgeResponse, ProviderConfig } from "./types";
+import { validateLLMResponse } from "./validate";
+
+const SYSTEM_PROMPT =
+  'You are an expert LLM evaluation judge. Respond only with valid JSON: {"scoreValue": <number>, "summary": "<string>", "reasoning": "<string>"}';
+
+export class BedrockProvider extends BaseProvider {
+  private client: BedrockRuntimeClient;
+
+  constructor(config: ProviderConfig) {
+    super(config);
+    this.client = new BedrockRuntimeClient({
+      region: config.region ?? "us-east-1",
+      credentials: config.apiKey
+        ? {
+            accessKeyId: config.apiKey,
+            secretAccessKey: config.secretKey ?? "",
+          }
+        : undefined,
+    });
+  }
+
+  async call(prompt: string): Promise<LLMJudgeResponse> {
+    const messages: Message[] = [{ role: "user", content: [{ text: prompt }] }];
+
+    const response = await this.client.send(
+      new ConverseCommand({
+        modelId: this.model,
+        system: [{ text: SYSTEM_PROMPT }],
+        messages,
+        inferenceConfig: { temperature: 0, maxTokens: 1024 },
+      }),
+      { abortSignal: AbortSignal.timeout(this.timeout) },
+    );
+
+    const content = response.output?.message?.content?.[0];
+    const text = content && "text" in content ? content.text : undefined;
+
+    if (!text) {
+      throw new EvalResponseError("Bedrock returned an empty response");
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new EvalResponseError(`Bedrock returned non-JSON content: ${text.slice(0, 200)}`);
+    }
+    return validateLLMResponse(parsed);
+  }
+}

--- a/dt-eval-lib/src/engine/providers/index.ts
+++ b/dt-eval-lib/src/engine/providers/index.ts
@@ -7,28 +7,38 @@ const DEFAULT_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-6",
   vertex: "gemini-3.1-pro-preview",
   gemini: "gemini-3-flash-preview",
+  // azure-openai: no default — deployment names are user-defined in Azure portal
+  bedrock: "us.anthropic.claude-3-5-haiku-20241022-v1:0",
 };
 
-const ENV_KEYS: Record<string, string> = {
+const ENV_API_KEY: Record<string, string> = {
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",
   vertex: "GOOGLE_API_KEY",
   gemini: "GOOGLE_API_KEY",
+  "azure-openai": "AZURE_OPENAI_API_KEY",
+  bedrock: "AWS_ACCESS_KEY_ID",
 };
 
-const ENV_BASE_URL_KEYS: Record<string, string> = {
+const ENV_BASE_URL: Record<string, string> = {
   openai: "OPENAI_BASE_URL",
   anthropic: "ANTHROPIC_BASE_URL",
+  "azure-openai": "AZURE_OPENAI_ENDPOINT",
 };
+
+const VALID_PROVIDERS = new Set([
+  "openai",
+  "anthropic",
+  "vertex",
+  "gemini",
+  "azure-openai",
+  "bedrock",
+]);
 
 export async function createProvider(options: ProviderOptions): Promise<LLMProvider> {
   const provider = options.provider;
-  if (
-    provider !== "openai" &&
-    provider !== "anthropic" &&
-    provider !== "vertex" &&
-    provider !== "gemini"
-  ) {
+
+  if (!VALID_PROVIDERS.has(provider)) {
     throw new EvalConfigError(`Unknown provider: ${provider}`);
   }
 
@@ -39,38 +49,90 @@ export async function createProvider(options: ProviderOptions): Promise<LLMProvi
 
   const model = options.model ?? DEFAULT_MODELS[provider];
 
+  // --- Google (Vertex / Gemini) ---
   if (provider === "vertex" || provider === "gemini") {
-    const apiKey = options.apiKey ?? process.env[ENV_KEYS[provider]];
-
+    const apiKey = options.apiKey ?? process.env[ENV_API_KEY[provider]];
     if (!apiKey) {
       throw new EvalConfigError(
-        `Missing API key for ${provider}. Provide it via provider.apiKey or set the ${ENV_KEYS[provider]} environment variable.`,
+        `Missing API key for ${provider}. Provide provider.apiKey or set ${ENV_API_KEY[provider]}.`,
       );
     }
-
     const { GoogleProvider } = await import("./google");
     return new GoogleProvider({ apiKey, model, timeout, vertexai: provider === "vertex" });
   }
 
-  const apiKey = options.apiKey ?? process.env[ENV_KEYS[provider]];
+  // --- Azure OpenAI ---
+  if (provider === "azure-openai") {
+    const apiKey = options.apiKey ?? process.env[ENV_API_KEY[provider]];
+    const baseUrl = options.baseUrl ?? process.env[ENV_BASE_URL[provider]];
+    const apiVersion = options.apiVersion ?? process.env.AZURE_OPENAI_API_VERSION;
 
+    if (!apiKey) {
+      throw new EvalConfigError(
+        "Missing API key for azure-openai. Provide provider.apiKey or set AZURE_OPENAI_API_KEY.",
+      );
+    }
+    if (!baseUrl) {
+      throw new EvalConfigError(
+        "Missing endpoint for azure-openai. Provide provider.baseUrl or set AZURE_OPENAI_ENDPOINT.",
+      );
+    }
+    if (!apiVersion) {
+      throw new EvalConfigError(
+        "Missing API version for azure-openai. Provide provider.apiVersion or set AZURE_OPENAI_API_VERSION.",
+      );
+    }
+    if (!options.model) {
+      throw new EvalConfigError(
+        "Missing model for azure-openai. Provide provider.model set to your Azure deployment name " +
+          "(e.g. my-gpt4-deployment). Azure deployment names are user-defined and have no default.",
+      );
+    }
+
+    const { AzureOpenAIProvider } = await import("./azure-openai");
+    return new AzureOpenAIProvider({ apiKey, model, timeout, baseUrl, apiVersion });
+  }
+
+  // --- Bedrock ---
+  if (provider === "bedrock") {
+    const accessKeyId = options.apiKey ?? process.env.AWS_ACCESS_KEY_ID;
+    const secretAccessKey = options.secretKey ?? process.env.AWS_SECRET_ACCESS_KEY;
+
+    if (!accessKeyId || !secretAccessKey) {
+      throw new EvalConfigError(
+        "Missing AWS credentials for bedrock. Provide provider.apiKey (access key ID) + provider.secretKey, or set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY.",
+      );
+    }
+
+    const { BedrockProvider } = await import("./bedrock");
+    return new BedrockProvider({
+      apiKey: accessKeyId,
+      secretKey: secretAccessKey,
+      model,
+      timeout,
+      region:
+        options.region ?? process.env.AWS_DEFAULT_REGION ?? process.env.AWS_REGION ?? "us-east-1",
+    });
+  }
+
+  // --- OpenAI / Anthropic ---
+  const apiKey = options.apiKey ?? process.env[ENV_API_KEY[provider]];
   if (!apiKey) {
     throw new EvalConfigError(
-      `Missing API key for ${provider}. Provide it via provider.apiKey or set the ${ENV_KEYS[provider]} environment variable.`,
+      `Missing API key for ${provider}. Provide provider.apiKey or set ${ENV_API_KEY[provider]}.`,
     );
   }
 
-  const baseUrl = options.baseUrl ?? process.env[ENV_BASE_URL_KEYS[provider]];
-  const providerConfig = { apiKey, model, timeout, baseUrl };
+  const baseUrl = options.baseUrl ?? process.env[ENV_BASE_URL[provider]];
 
   switch (provider) {
     case "openai": {
       const { OpenAIProvider } = await import("./openai");
-      return new OpenAIProvider(providerConfig);
+      return new OpenAIProvider({ apiKey, model, timeout, baseUrl });
     }
     case "anthropic": {
       const { AnthropicProvider } = await import("./anthropic");
-      return new AnthropicProvider(providerConfig);
+      return new AnthropicProvider({ apiKey, model, timeout, baseUrl });
     }
   }
 }

--- a/dt-eval-lib/src/engine/providers/types.ts
+++ b/dt-eval-lib/src/engine/providers/types.ts
@@ -11,6 +11,12 @@ export interface ProviderConfig {
   model: string;
   timeout: number;
   baseUrl?: string;
+  /** Azure OpenAI api-version (e.g. "2026-04-01-preview"). Only used for Azure endpoints. */
+  apiVersion?: string;
+  /** AWS region for Bedrock. */
+  region?: string;
+  /** AWS secret access key for Bedrock. Paired with apiKey (access key ID). */
+  secretKey?: string;
 }
 
 /** Interface that each LLM provider must implement */

--- a/dt-eval-lib/src/engine/providers/validate.ts
+++ b/dt-eval-lib/src/engine/providers/validate.ts
@@ -3,20 +3,45 @@ import type { LLMJudgeResponse } from "./types";
 
 export function validateLLMResponse(parsed: unknown): LLMJudgeResponse {
   const response = parsed as Record<string, unknown>;
+
+  // Standard format: { scoreValue, summary, reasoning }
   if (
-    typeof response?.scoreValue !== "number" ||
-    !Number.isFinite(response.scoreValue) ||
-    typeof response?.summary !== "string" ||
-    typeof response?.reasoning !== "string"
+    typeof response?.scoreValue === "number" &&
+    Number.isFinite(response.scoreValue) &&
+    typeof response?.summary === "string" &&
+    typeof response?.reasoning === "string"
   ) {
-    const preview = JSON.stringify(parsed).slice(0, 200);
-    throw new EvalResponseError(
-      `Malformed LLM response: expected { scoreValue: number, summary: string, reasoning: string }, got ${preview}`,
-    );
+    return {
+      scoreValue: response.scoreValue as number,
+      summary: response.summary as string,
+      reasoning: response.reasoning as string,
+    };
   }
-  return {
-    scoreValue: response.scoreValue as number,
-    summary: response.summary as string,
-    reasoning: response.reasoning as string,
-  };
+
+  // Alternative format produced by some reasoning models:
+  // { score: { value, label }, explanation: { summary, reasoning?, claims?, ... } }
+  const score = response?.score as Record<string, unknown> | undefined;
+  const explanation = response?.explanation as Record<string, unknown> | undefined;
+  if (
+    typeof score?.value === "number" &&
+    Number.isFinite(score.value) &&
+    typeof explanation?.summary === "string"
+  ) {
+    // Use reasoning if present; otherwise serialize the full explanation object
+    // (models like Claude/gpt-5.x may return structured claims instead of free-text reasoning)
+    const reasoning =
+      typeof explanation?.reasoning === "string"
+        ? explanation.reasoning
+        : JSON.stringify(explanation);
+    return {
+      scoreValue: score.value as number,
+      summary: explanation.summary as string,
+      reasoning,
+    };
+  }
+
+  const preview = JSON.stringify(parsed).slice(0, 200);
+  throw new EvalResponseError(
+    `Malformed LLM response: expected { scoreValue: number, summary: string, reasoning: string }, got ${preview}`,
+  );
 }

--- a/dt-eval-lib/src/engine/types.ts
+++ b/dt-eval-lib/src/engine/types.ts
@@ -1,7 +1,7 @@
 import type { Score } from "../scoring/types";
 
 /** Provider selection */
-export type Provider = "openai" | "anthropic" | "vertex" | "gemini";
+export type Provider = "openai" | "anthropic" | "vertex" | "gemini" | "azure-openai" | "bedrock";
 
 /** Provider-related configuration */
 export interface ProviderOptions {
@@ -11,6 +11,12 @@ export interface ProviderOptions {
   apiKey?: string;
   /** Base URL for the provider API — falls back to OPENAI_BASE_URL / ANTHROPIC_BASE_URL env vars */
   baseUrl?: string;
+  /** Azure OpenAI api-version (e.g. "2026-04-01-preview"). Only used for Azure endpoints. */
+  apiVersion?: string;
+  /** AWS region for Bedrock (e.g. "us-east-1"). Only used for bedrock provider. */
+  region?: string;
+  /** AWS secret access key for Bedrock. Paired with apiKey (access key ID). */
+  secretKey?: string;
   /** Model override — defaults to gpt-4.1 / claude-sonnet-4-6 / gemini-2.5-pro (vertex) / gemini-2.5-flash (gemini) */
   model?: string;
   /** Request timeout in ms — default 30000 */

--- a/dt-eval-lib/tests/engine.test.ts
+++ b/dt-eval-lib/tests/engine.test.ts
@@ -2,16 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // We'll mock the provider modules so no real API calls are made
 vi.mock("openai", () => {
+  const mockClient = {
+    chat: {
+      completions: {
+        create: vi.fn(),
+      },
+    },
+  };
   return {
     // biome-ignore lint/complexity/useArrowFunction: function expression required for new-able mock in vitest 4.x
     default: vi.fn().mockImplementation(function () {
-      return {
-        chat: {
-          completions: {
-            create: vi.fn(),
-          },
-        },
-      };
+      return mockClient;
+    }),
+    // biome-ignore lint/complexity/useArrowFunction: function expression required for new-able mock in vitest 4.x
+    AzureOpenAI: vi.fn().mockImplementation(function () {
+      return mockClient;
     }),
   };
 });
@@ -25,6 +30,19 @@ vi.mock("@anthropic-ai/sdk", () => {
           create: vi.fn(),
         },
       };
+    }),
+  };
+});
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => {
+  return {
+    // biome-ignore lint/complexity/useArrowFunction: function expression required for new-able mock in vitest 4.x
+    BedrockRuntimeClient: vi.fn().mockImplementation(function () {
+      return { send: vi.fn() };
+    }),
+    // biome-ignore lint/complexity/useArrowFunction: function expression required for new-able mock in vitest 4.x
+    ConverseCommand: vi.fn().mockImplementation(function (input) {
+      return input;
     }),
   };
 });
@@ -44,6 +62,8 @@ vi.mock("@google/genai", () => {
 
 import { evaluate } from "../src/engine/index";
 import { AnthropicProvider } from "../src/engine/providers/anthropic";
+import { AzureOpenAIProvider } from "../src/engine/providers/azure-openai";
+import { BedrockProvider } from "../src/engine/providers/bedrock";
 import { GoogleProvider } from "../src/engine/providers/google";
 import { createProvider } from "../src/engine/providers/index";
 import { OpenAIProvider } from "../src/engine/providers/openai";
@@ -710,5 +730,191 @@ describe("evaluate() — gemini provider", () => {
       score: { value: 1, label: "pass" },
       explanation: { summary: "Good output", reasoning: "Output is correct" },
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Azure OpenAI provider
+// ---------------------------------------------------------------------------
+
+describe("provider factory — azure-openai", () => {
+  beforeEach(async () => {
+    const actual = await vi.importActual<typeof import("../src/engine/providers/index")>(
+      "../src/engine/providers/index",
+    );
+    vi.mocked(createProvider).mockImplementation(actual.createProvider);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AZURE_OPENAI_API_KEY;
+    delete process.env.AZURE_OPENAI_ENDPOINT;
+    delete process.env.AZURE_OPENAI_API_VERSION;
+  });
+
+  it("creates AzureOpenAIProvider when all required fields are provided", async () => {
+    const provider = await createProvider({
+      provider: "azure-openai",
+      apiKey: "test-key",
+      baseUrl: "https://my-resource.openai.azure.com/",
+      apiVersion: "2025-04-01-preview",
+      model: "my-gpt4-deployment",
+      timeout: 30000,
+      maxRetries: 2,
+    });
+    expect(provider).toBeInstanceOf(AzureOpenAIProvider);
+  });
+
+  it("throws EvalConfigError when apiKey is missing", async () => {
+    await expect(
+      createProvider({
+        provider: "azure-openai",
+        baseUrl: "https://my-resource.openai.azure.com/",
+        apiVersion: "2025-04-01-preview",
+        model: "my-gpt4-deployment",
+        timeout: 30000,
+        maxRetries: 2,
+      }),
+    ).rejects.toBeInstanceOf(EvalConfigError);
+  });
+
+  it("throws EvalConfigError when baseUrl is missing", async () => {
+    await expect(
+      createProvider({
+        provider: "azure-openai",
+        apiKey: "test-key",
+        apiVersion: "2025-04-01-preview",
+        model: "my-gpt4-deployment",
+        timeout: 30000,
+        maxRetries: 2,
+      }),
+    ).rejects.toBeInstanceOf(EvalConfigError);
+  });
+
+  it("throws EvalConfigError when apiVersion is missing", async () => {
+    await expect(
+      createProvider({
+        provider: "azure-openai",
+        apiKey: "test-key",
+        baseUrl: "https://my-resource.openai.azure.com/",
+        model: "my-gpt4-deployment",
+        timeout: 30000,
+        maxRetries: 2,
+      }),
+    ).rejects.toBeInstanceOf(EvalConfigError);
+  });
+
+  it("throws EvalConfigError when model (deployment name) is missing", async () => {
+    await expect(
+      createProvider({
+        provider: "azure-openai",
+        apiKey: "test-key",
+        baseUrl: "https://my-resource.openai.azure.com/",
+        apiVersion: "2025-04-01-preview",
+        timeout: 30000,
+        maxRetries: 2,
+      }),
+    ).rejects.toBeInstanceOf(EvalConfigError);
+  });
+
+  it("falls back to env vars when fields are not provided in options", async () => {
+    process.env.AZURE_OPENAI_API_KEY = "env-key";
+    process.env.AZURE_OPENAI_ENDPOINT = "https://env-resource.openai.azure.com/";
+    process.env.AZURE_OPENAI_API_VERSION = "2025-04-01-preview";
+    const provider = await createProvider({
+      provider: "azure-openai",
+      model: "my-deployment",
+      timeout: 30000,
+      maxRetries: 2,
+    });
+    expect(provider).toBeInstanceOf(AzureOpenAIProvider);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bedrock provider
+// ---------------------------------------------------------------------------
+
+describe("provider factory — bedrock", () => {
+  beforeEach(async () => {
+    const actual = await vi.importActual<typeof import("../src/engine/providers/index")>(
+      "../src/engine/providers/index",
+    );
+    vi.mocked(createProvider).mockImplementation(actual.createProvider);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+  });
+
+  it("creates BedrockProvider when credentials are provided", async () => {
+    const provider = await createProvider({
+      provider: "bedrock",
+      apiKey: "AKIAIOSFODNN7EXAMPLE",
+      secretKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      timeout: 30000,
+      maxRetries: 2,
+    });
+    expect(provider).toBeInstanceOf(BedrockProvider);
+  });
+
+  it("throws EvalConfigError when credentials are missing", async () => {
+    await expect(
+      createProvider({
+        provider: "bedrock",
+        timeout: 30000,
+        maxRetries: 2,
+      }),
+    ).rejects.toBeInstanceOf(EvalConfigError);
+  });
+
+  it("falls back to AWS env vars for credentials", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-access-key";
+    process.env.AWS_SECRET_ACCESS_KEY = "env-secret-key";
+    const provider = await createProvider({
+      provider: "bedrock",
+      timeout: 30000,
+      maxRetries: 2,
+    });
+    expect(provider).toBeInstanceOf(BedrockProvider);
+  });
+
+  it("uses explicit region when provided", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-access-key";
+    process.env.AWS_SECRET_ACCESS_KEY = "env-secret-key";
+    const provider = await createProvider({
+      provider: "bedrock",
+      region: "eu-west-1",
+      timeout: 30000,
+      maxRetries: 2,
+    });
+    expect(provider).toBeInstanceOf(BedrockProvider);
+  });
+
+  it("falls back to AWS_REGION env var for region", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-access-key";
+    process.env.AWS_SECRET_ACCESS_KEY = "env-secret-key";
+    process.env.AWS_REGION = "ap-southeast-1";
+    const provider = await createProvider({
+      provider: "bedrock",
+      timeout: 30000,
+      maxRetries: 2,
+    });
+    expect(provider).toBeInstanceOf(BedrockProvider);
+  });
+
+  it("uses default Bedrock model when model not specified", async () => {
+    process.env.AWS_ACCESS_KEY_ID = "env-access-key";
+    process.env.AWS_SECRET_ACCESS_KEY = "env-secret-key";
+    const provider = await createProvider({
+      provider: "bedrock",
+      timeout: 30000,
+      maxRetries: 2,
+    });
+    expect(provider).toBeInstanceOf(BedrockProvider);
   });
 });

--- a/makefile
+++ b/makefile
@@ -3,8 +3,8 @@
 MD_LINT_CLI_IMAGE := "ghcr.io/igorshubovych/markdownlint-cli:v0.31.1"
 
 markdownlint:
-	docker run -v $(CURDIR):/workdir --rm  $(MD_LINT_CLI_IMAGE)  "**/*.md"
+	docker run -v $(CURDIR):/workdir --rm  $(MD_LINT_CLI_IMAGE)  "**/*.md" --ignore "**/CHANGELOG.md"
 
 markdownlint-fix:
-	docker run -v $(CURDIR):/workdir --rm  $(MD_LINT_CLI_IMAGE)  "**/*.md" --fix
+	docker run -v $(CURDIR):/workdir --rm  $(MD_LINT_CLI_IMAGE)  "**/*.md" --ignore "**/CHANGELOG.md" --fix
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     },
     "dt-eval-cli": {
       "name": "@dynatrace-oss/dt-eval",
-      "version": "0.1.0-alpha-1",
+      "version": "0.1.1-alpha",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
@@ -85,10 +85,11 @@
     },
     "dt-eval-lib": {
       "name": "@dynatrace-oss/dt-eval-lib",
-      "version": "0.0.1-alpha",
+      "version": "0.0.1-alpha1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1031.0",
         "@biomejs/biome": "2.4.9",
         "@google/genai": "^1.0.0",
         "dotenv": "^17.3.1",
@@ -103,11 +104,15 @@
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.0.0",
         "@google/genai": "^1.0.0",
         "openai": "^4.73.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@aws-sdk/client-bedrock-runtime": {
           "optional": true
         },
         "@google/genai": {
@@ -267,6 +272,740 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1031.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1031.0.tgz",
+      "integrity": "sha512-ZgiSo2wslPXlv7wK4m2ULu2VfimbVRRlho0DqXhlvZGEqvtC209cMOxfPZWJ79Fz9sf0IzmWFkDtvMYjnwyLfw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/credential-provider-node": "^3.972.31",
+        "@aws-sdk/eventstream-handler-node": "^3.972.14",
+        "@aws-sdk/middleware-eventstream": "^3.972.10",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/middleware-websocket": "^3.972.16",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/token-providers": "3.1031.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.16",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.0.tgz",
+      "integrity": "sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.18",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.26.tgz",
+      "integrity": "sha512-WBHAMxyPdgeJY6ZGLvq9mJwzZ+GaNUROQbfdVshtMsDVBrZTj5ZuFjKclSjSHvKSHJ4Y4O2yvI/aA/hrJbYfng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.28.tgz",
+      "integrity": "sha512-+1DwCjjpo1WoiZTN08yGitI3nUwZUSQWVWFrW4C46HqZwACjcUQ7C66tnKPBTVxrEYYDOP11A6Afmu1L6ylt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.30.tgz",
+      "integrity": "sha512-Fg1oJcoijwOZjTxdbx+ubqbQl8YEQ4Cwhjw6TWzQjuDEvQYNhnCXW2pN7eKtdTrdE4a6+5TVKGSm2I+i2BKIQg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/credential-provider-env": "^3.972.26",
+        "@aws-sdk/credential-provider-http": "^3.972.28",
+        "@aws-sdk/credential-provider-login": "^3.972.30",
+        "@aws-sdk/credential-provider-process": "^3.972.26",
+        "@aws-sdk/credential-provider-sso": "^3.972.30",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.30",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.30.tgz",
+      "integrity": "sha512-nchIrrI/7dgjG1bW/DEWOJc00K9n+kkl6B8Mk0KO6d4GfWBOXlVr9uHp7CJR9FIrjmov5SGjHXG2q9XAtkRw6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.31.tgz",
+      "integrity": "sha512-99OHVQ6eZ5DTxiOWgHdjBMvLqv7xoY4jLK6nZ1NcNSQbAnYZkQNIHi/VqInc9fnmg7of9si/z+waE6YL9OQIlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.26",
+        "@aws-sdk/credential-provider-http": "^3.972.28",
+        "@aws-sdk/credential-provider-ini": "^3.972.30",
+        "@aws-sdk/credential-provider-process": "^3.972.26",
+        "@aws-sdk/credential-provider-sso": "^3.972.30",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.30",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.26.tgz",
+      "integrity": "sha512-jibxNld3m+vbmQwn98hcQ+fLIVrx3cQuhZlSs1/hix48SjDS5/pjMLwpmtLD/lFnd6ve1AL4o1bZg3X1WRa2SQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.30.tgz",
+      "integrity": "sha512-honYIM17F/+QSWJRE84T4u//ofqEi7rLbnwmIpu7fgFX5PML78wbtdSAy5Xwyve3TLpE9/f9zQx0aBVxSjAOPw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/token-providers": "3.1031.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.30.tgz",
+      "integrity": "sha512-CyL4oWUlONQRN2SsYMVrA9Z3i3QfLWTQctI8tuKbjNGCVVDCnJf/yMbSJCOZgpPFRtxh7dgQwvpqwmJm+iytmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
+      "integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
+      "integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.30.tgz",
+      "integrity": "sha512-lCz6JfelhjD6Eco1urXM2rOYRaxROSqeoY6IEKx+soegFJOajmIBCMHTAWuJl25Wf9IAST+i0/yOk9G3rMV26A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
+      "integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.20.tgz",
+      "integrity": "sha512-bzPdsNQnCh6TvvUmTHLZlL8qgyME6mNiUErcRMyJPywIl1BEu2VZRShel3mUoSh89bOBEXEWtjocDMolFxd/9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.16",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
+      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1031.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1031.0.tgz",
+      "integrity": "sha512-zj/PvnbQK/2KJNln5K2QRI9HSsy+B4emz2gbQyUHkk6l7Lidu83P/9tfmC2cJXkcC3vdmyKH2DP3Iw/FDfKQuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
+      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.16.tgz",
+      "integrity": "sha512-ccvu0FNCI0C6OqmxI/tWn7BD8qGooWuURssiIM+6vbksFO8opXR4JOGtGYPj8QYzN/vfwNYrcK344PPbYuvzRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@biomejs/biome": {
       "version": "2.4.9",
@@ -438,40 +1177,6 @@
     "node_modules/@dynatrace-oss/dt-eval-lib": {
       "resolved": "dt-eval-lib",
       "link": true
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -2029,6 +2734,688 @@
         "win32"
       ]
     },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
+      "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.15",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
+      "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
+      "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
+      "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
+      "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
+      "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
+      "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
+      "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
+      "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.52",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
+      "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
+      "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
+      "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
+      "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2091,6 +3478,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2333,6 +3721,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -2669,6 +4064,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2740,6 +4136,43 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3224,7 +4657,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3246,7 +4678,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3268,7 +4699,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3290,7 +4720,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3312,7 +4741,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3334,7 +4762,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3356,7 +4783,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3378,7 +4804,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3400,7 +4825,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3422,7 +4846,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3444,7 +4867,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3723,6 +5145,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/pathe": {
@@ -4109,6 +5547,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -4258,8 +5709,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -4375,6 +5825,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5637,6 +7088,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Summary
- Adds `AzureOpenAIProvider` to `dt-eval-lib` — first-class provider using the OpenAI SDK's `AzureOpenAI` class; requires explicit `baseUrl`, `apiKey`, and `apiVersion` (no defaults)
- Adds `BedrockProvider` to `dt-eval-lib` — uses AWS SDK `ConverseCommand`; credentials via `apiKey` (access key ID) + `secretKey`; supports cross-region inference model IDs
- Cleans up `dt-eval-cli` runner to be a pure pass-through — no provider-specific mapping logic
- Updates `ProviderOptions` / `ProviderConfig` types to include `apiVersion`, `region`, `secretKey`

## Test plan
- [ ] Azure OpenAI: configure `judge.provider: azure-openai` with `baseUrl`, `apiKey`, `apiVersion`, `model` in `.dt-eval.yaml` and run `dt-eval run`
- [ ] Bedrock: configure `judge.provider: bedrock` with `apiKey`, `secretKey`, optional `region` and run `dt-eval run`
- [ ] Verify `gen_ai.evaluation.result` bizevents appear in Dynatrace with correct `gen_ai.provider.name` and `gen_ai.request.model`
- [ ] Confirm missing `apiVersion` for azure-openai throws a clear config error
- [ ] Confirm missing credentials for bedrock throws a clear config error

