### PR TITLE
E2E integration test workflow, correct DT client ingest endpoint

### DIFF
--- a/.github/e2e/e2e.dt-eval.yaml
+++ b/.github/e2e/e2e.dt-eval.yaml
@@ -1,0 +1,28 @@
+schemaVersion: 1
+name: e2e-ci
+
+dynatrace:
+  environmentUrl: https://xbw95514.dev.apps.dynatracelabs.com/
+  # apiToken from DT_API_TOKEN env var (dt0s* platform token)
+  # dtctlContext routes DQL through dtctl (configured with set-credentials in CI)
+  dtctlContext: e2e
+
+judge:
+  provider: anthropic
+  # apiKey from ANTHROPIC_API_KEY env var
+  model: claude-haiku-4-5-20251001
+  timeout: 60000
+  maxRetries: 2
+
+scope:
+  service: ai-travel-advisor-agent-test
+  since: 6h
+  sampling:
+    strategy: latest
+    count: 3
+
+metrics:
+  enabled:
+    - relevance
+    - toxicity
+    - helpfulness

--- a/.github/e2e/validate.ts
+++ b/.github/e2e/validate.ts
@@ -1,0 +1,107 @@
+/**
+ * Validate that bizevents for a dt-eval run landed in Dynatrace.
+ * Usage: npx tsx .github/e2e/validate.ts <bearer_token> <env_url> <run_id>
+ *
+ * Polls until records appear or the timeout is reached — no fixed sleep needed.
+ */
+
+const [, , token, envUrl, runId] = process.argv;
+
+if (!token || !envUrl || !runId) {
+  console.error('Usage: validate.ts <api_token> <env_url> <run_id>');
+  process.exit(1);
+}
+
+const BASE = envUrl.replace(/\/$/, '');
+const PROPAGATION_TIMEOUT_MS = 2 * 60_000; // 2 min max wait for bizevent propagation
+const RETRY_INTERVAL_MS = 5_000;
+
+interface DqlResponse {
+  state?: string;
+  requestToken?: string;
+  result?: { records: Record<string, unknown>[] };
+}
+
+async function dqlExecute(query: string): Promise<Record<string, unknown>[]> {
+  const res = await fetch(`${BASE}/platform/storage/query/v1/query:execute`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, requestTimeoutMilliseconds: 30_000 }),
+  });
+
+  if (!res.ok) throw new Error(`DQL execute failed (${res.status}): ${await res.text()}`);
+  const data = (await res.json()) as DqlResponse;
+
+  if (data.state === 'RUNNING' && data.requestToken) {
+    return pollDql(data.requestToken);
+  }
+  return data.result?.records ?? [];
+}
+
+async function pollDql(requestToken: string): Promise<Record<string, unknown>[]> {
+  const url = `${BASE}/platform/storage/query/v1/query:poll?requestToken=${encodeURIComponent(requestToken)}`;
+  for (let i = 0; i < 60; i++) {
+    await new Promise(r => setTimeout(r, 1000));
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) throw new Error(`DQL poll failed (${res.status}): ${await res.text()}`);
+    const data = (await res.json()) as DqlResponse;
+    if (data.state === 'SUCCEEDED') return data.result?.records ?? [];
+    if (data.state === 'FAILED') throw new Error('DQL query failed on server');
+  }
+  throw new Error('DQL poll timed out');
+}
+
+async function waitForBizevents(query: string): Promise<Record<string, unknown>[]> {
+  const deadline = Date.now() + PROPAGATION_TIMEOUT_MS;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    attempt++;
+    const records = await dqlExecute(query);
+    if (records.length > 0) {
+      console.log(`Found ${records.length} bizevent(s) after ${attempt} attempt(s)`);
+      return records;
+    }
+    const remaining = Math.round((deadline - Date.now()) / 1000);
+    console.log(`Attempt ${attempt}: no records yet, retrying in ${RETRY_INTERVAL_MS / 1000}s (${remaining}s remaining)...`);
+    await new Promise(r => setTimeout(r, RETRY_INTERVAL_MS));
+  }
+  throw new Error(`No bizevents found for runId=${runId} after ${PROPAGATION_TIMEOUT_MS / 1000}s`);
+}
+
+async function main() {
+  const query = `
+    fetch bizevents
+    | filter event.type == "gen_ai.evaluation.result"
+      and \`dt.eval.run_id\` == "${runId}"
+    | fields \`dt.eval.run_id\`, \`gen_ai.evaluation.name\`, \`gen_ai.evaluation.score.value\`, \`gen_ai.provider.name\`, timestamp
+    | sort timestamp desc
+  `.trim();
+
+  console.log(`Waiting for bizevents (runId=${runId}, timeout=${PROPAGATION_TIMEOUT_MS / 1000}s)...`);
+  const records = await waitForBizevents(query);
+
+  const required = ['gen_ai.evaluation.name', 'gen_ai.evaluation.score.value', 'dt.eval.run_id'];
+  const now = Date.now();
+
+  for (const r of records) {
+    for (const field of required) {
+      if (!(field in r)) {
+        console.error(`FAIL: Missing field '${field}' in bizevent: ${JSON.stringify(r)}`);
+        process.exit(1);
+      }
+    }
+    const ts = r['timestamp'] as string | undefined;
+    if (ts) {
+      const ageMin = (now - new Date(ts).getTime()) / 60_000;
+      if (ageMin > 15) {
+        console.error(`FAIL: Bizevent is ${ageMin.toFixed(1)} min old (expected < 15): ${ts}`);
+        process.exit(1);
+      }
+    }
+  }
+
+  console.log('All field and freshness checks passed.');
+  console.log(`Sample record:\n${JSON.stringify(records[0], null, 2)}`);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,84 @@
+name: E2E — Integration Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "dt-eval-cli/**"
+      - "dt-eval-lib/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "dt-eval-cli/**"
+      - "dt-eval-lib/**"
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-24.04
+    name: Fetch → Evaluate → Ingest → Validate
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dt-eval-lib
+        working-directory: dt-eval-lib
+        run: npm run build
+
+      - name: Build dt-eval-cli
+        working-directory: dt-eval-cli
+        run: npm run build
+
+      - name: Install dtctl
+        run: |
+          # TODO: replace with official dtctl install URL or GitHub Action when available
+          # curl -sSL <dtctl-install-url> | sh
+          echo "dtctl must be pre-installed on the runner or installed here"
+          dtctl version
+
+      - name: Configure dtctl context
+        env:
+          E2E_DT_API_TOKEN: ${{ secrets.E2E_DT_API_TOKEN }}
+        run: |
+          dtctl config set-context e2e \
+            --environment https://xbw95514.dev.apps.dynatracelabs.com \
+            --token-ref e2e
+          dtctl config set-credentials e2e --token "$E2E_DT_API_TOKEN"
+          dtctl config use-context e2e
+
+      - name: Run evaluations
+        id: run
+        env:
+          DT_API_TOKEN: ${{ secrets.E2E_DT_API_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.E2E_ANTHROPIC_API_KEY }}
+        run: |
+          node dt-eval-cli/dist/index.js run \
+            --config .github/e2e/e2e.dt-eval.yaml \
+            --ci 2>/dev/null | tee /tmp/run-result.json
+
+          RUN_ID=$(python3 -c "import json; print(json.load(open('/tmp/run-result.json'))['runId'])")
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "Eval run complete: runId=$RUN_ID"
+
+          RESULTS_WRITTEN=$(python3 -c "import json; print(json.load(open('/tmp/run-result.json'))['resultsWritten'])")
+          if [ "$RESULTS_WRITTEN" -eq 0 ]; then
+            echo "ERROR: No results written — all evaluations failed"
+            cat /tmp/run-result.json
+            exit 1
+          fi
+          echo "Results written: $RESULTS_WRITTEN"
+
+      - name: Validate bizevents in Dynatrace
+        run: |
+          npx tsx .github/e2e/validate.ts \
+            "${{ secrets.E2E_DT_API_TOKEN }}" \
+            "https://xbw95514.dev.apps.dynatracelabs.com" \
+            "${{ steps.run.outputs.run_id }}"

--- a/dt-eval-cli/src/dt/client.ts
+++ b/dt-eval-cli/src/dt/client.ts
@@ -7,7 +7,7 @@ const execFileAsync = promisify(execFile);
 export interface DynatraceClientConfig {
   environmentUrl: string;
   apiToken?: string;
-  /** dtctl context name — when set, Bearer auth is obtained from dtctl for all requests. */
+  /** dtctl context name — when set, DQL queries are routed through `dtctl query`. */
   dtctlContext?: string;
 }
 
@@ -28,16 +28,11 @@ interface DqlPollResponse {
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 60_000;
-// Cache the Bearer token for 5 min to avoid a dtctl subprocess on every call
-const TOKEN_TTL_MS = 5 * 60 * 1000;
 
 export class DynatraceClient {
   private readonly environmentUrl: string;
   private readonly apiToken?: string;
   private readonly dtctlContext?: string;
-
-  private cachedToken?: string;
-  private tokenExpiresAt = 0;
 
   constructor(config: DynatraceClientConfig) {
     this.environmentUrl = config.environmentUrl.replace(/\/$/, '');
@@ -45,43 +40,12 @@ export class DynatraceClient {
     this.dtctlContext = config.dtctlContext;
   }
 
-  /** Resolve auth headers — Bearer via dtctl when available, Api-Token otherwise. */
-  private async authHeaders(): Promise<Record<string, string>> {
-    if (this.dtctlContext) {
-      const token = await this.getBearerToken();
-      return {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      };
-    }
+  private authHeaders(): Record<string, string> {
     return {
       Authorization: `Api-Token ${this.apiToken ?? ''}`,
       'Content-Type': 'application/json',
       Accept: 'application/json',
     };
-  }
-
-  private async getBearerToken(): Promise<string> {
-    if (this.cachedToken && Date.now() < this.tokenExpiresAt) {
-      return this.cachedToken;
-    }
-    const args = ['token', '--context', this.dtctlContext!];
-    logger.debug(`Fetching Bearer token via dtctl context=${this.dtctlContext}`);
-    const { stdout } = await execFileAsync('dtctl', args, { timeout: 10_000 });
-    const raw = stdout.trim();
-    // dtctl may return JSON or a plain token string
-    let token: string;
-    try {
-      const parsed = JSON.parse(raw) as { access_token?: string; token?: string };
-      token = parsed.access_token ?? parsed.token ?? raw;
-    } catch {
-      token = raw;
-    }
-    if (!token) throw new Error('dtctl returned an empty token');
-    this.cachedToken = token;
-    this.tokenExpiresAt = Date.now() + TOKEN_TTL_MS;
-    return token;
   }
 
   async executeDql(query: string): Promise<unknown> {
@@ -112,7 +76,7 @@ export class DynatraceClient {
 
     const response = await fetch(url, {
       method: 'POST',
-      headers: await this.authHeaders(),
+      headers: this.authHeaders(),
       body,
     });
 
@@ -134,11 +98,16 @@ export class DynatraceClient {
     throw new Error(`Unexpected DQL response state: ${data.state}`);
   }
 
+  /** Ingest base URL uses the classic domain (no `.apps.`), not the apps platform domain. */
+  private ingestBaseUrl(): string {
+    return this.environmentUrl.replace('.apps.dynatracelabs.com', '.dynatracelabs.com');
+  }
+
   async ingestBizevents(events: object[]): Promise<void> {
-    const url = `${this.environmentUrl}/platform/ingest/v1/bizevents`;
+    const url = `${this.ingestBaseUrl()}/api/v2/bizevents/ingest`;
     const response = await fetch(url, {
       method: 'POST',
-      headers: await this.authHeaders(),
+      headers: this.authHeaders(),
       body: JSON.stringify(events),
     });
 
@@ -149,8 +118,8 @@ export class DynatraceClient {
   }
 
   async ingestMetrics(lines: string): Promise<void> {
-    const url = `${this.environmentUrl}/api/v2/metrics/ingest`;
-    const headers = await this.authHeaders();
+    const url = `${this.ingestBaseUrl()}/api/v2/metrics/ingest`;
+    const headers = this.authHeaders();
     const response = await fetch(url, {
       method: 'POST',
       headers: { ...headers, 'Content-Type': 'text/plain' },
@@ -175,7 +144,7 @@ export class DynatraceClient {
       const t0 = Date.now();
       const response = await fetch(url, {
         method: 'GET',
-        headers: await this.authHeaders(),
+        headers: this.authHeaders(),
       });
 
       if (!response.ok) {

--- a/dt-eval-cli/tests/dt/client.test.ts
+++ b/dt-eval-cli/tests/dt/client.test.ts
@@ -149,7 +149,7 @@ describe('DynatraceClient', () => {
 
     expect(mockFetch).toHaveBeenCalledOnce();
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe('https://test.live.dynatrace.com/platform/ingest/v1/bizevents');
+    expect(url).toBe('https://test.live.dynatrace.com/api/v2/bizevents/ingest');
     expect(JSON.parse(init.body as string)).toEqual(events);
   });
 


### PR DESCRIPTION
## Summary
- Fix `DynatraceClient` auth: remove broken `dtctl token` dependency (removed in dtctl v0.24+); `authHeaders()` now uses `Api-Token` directly from config
- Fix bizevent ingest URL: strip `.apps.` from domain and use `/api/v2/bizevents/ingest` — the platform `/platform/ingest/v1/bizevents` path returns 404
- Fix `server.dt-eval.yaml`: split combined `model + apiVersion` field into separate fields
- Add E2E integration test workflow (`.github/workflows/e2e.yml`) triggered on push/PR to `main` for `dt-eval-cli` or `dt-eval-lib` changes
- Add `.github/e2e/e2e.dt-eval.yaml` test config targeting the `xbw95514` dev tenant
- Add `.github/e2e/validate.ts` DQL validation script — polls up to 2 min for bizevent propagation, validates required fields and timestamp freshness

## Required secrets
- `E2E_DT_API_TOKEN` — `dt0s*` platform token with DQL read + bizevent ingest scopes
- `E2E_ANTHROPIC_API_KEY` — judge provider key

## Test plan
- [ ] Add the two GitHub secrets above to the repo
- [ ] Fill in the dtctl install step in the workflow for `ubuntu-24.04`
- [ ] Trigger `workflow_dispatch` to verify fetch → evaluate → ingest → validate loop end-to-end