### PR TITLE
fix(dt-eval-lib): remove Node.js builtins via PromptStore DI

### DIFF
--- a/dt-eval-cli/src/index.ts
+++ b/dt-eval-cli/src/index.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env -S node --no-warnings
 
+import { registerPromptStore } from 'dt-eval-lib';
+import { FsPromptStore } from './prompts/fs-store.js';
+
+registerPromptStore(new FsPromptStore());
+
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/dt-eval-cli/src/prompts/fs-store.ts
+++ b/dt-eval-cli/src/prompts/fs-store.ts
@@ -1,0 +1,30 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { PromptDefinition, PromptStore } from "dt-eval-lib";
+
+const CUSTOM_PROMPTS_DIR = join(homedir(), ".config", "dt-eval");
+const CUSTOM_PROMPTS_FILE = join(CUSTOM_PROMPTS_DIR, "custom-prompts.json");
+
+export class FsPromptStore implements PromptStore {
+  read(): PromptDefinition[] {
+    try {
+      if (!existsSync(CUSTOM_PROMPTS_FILE)) return [];
+      const raw = readFileSync(CUSTOM_PROMPTS_FILE, "utf-8");
+      return JSON.parse(raw) as PromptDefinition[];
+    } catch {
+      return [];
+    }
+  }
+
+  write(prompts: PromptDefinition[]): void {
+    if (!existsSync(CUSTOM_PROMPTS_DIR)) {
+      mkdirSync(CUSTOM_PROMPTS_DIR, { recursive: true });
+    }
+    writeFileSync(
+      CUSTOM_PROMPTS_FILE,
+      JSON.stringify(prompts, null, 2),
+      "utf-8",
+    );
+  }
+}

--- a/dt-eval-lib/src/index.ts
+++ b/dt-eval-lib/src/index.ts
@@ -22,6 +22,7 @@ export {
   EvalResponseError,
   EvalTimeoutError,
 } from "./errors";
+export type { PromptDefinition, PromptStore } from "./prompts/index";
 // Prompt catalog
 export {
   BuiltInMetric,
@@ -30,8 +31,8 @@ export {
   deleteCustomPrompt,
   getPrompt,
   listPrompts,
+  registerPromptStore,
 } from "./prompts/index";
-export type { PromptDefinition } from "./prompts/types";
 // Scoring
 export { BINARY_SCALE, CONTINUOUS_SCALE, computeScore, LIKERT_SCALE } from "./scoring/index";
 // Types

--- a/dt-eval-lib/src/prompts/custom.ts
+++ b/dt-eval-lib/src/prompts/custom.ts
@@ -1,50 +1,39 @@
-/**
- * Custom prompt persistence — stores user-defined evaluators in
- * ~/.config/dt-eval/custom-prompts.json
- */
-
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { EvalMetricError } from "../errors";
+import { getPromptStore } from "./store";
 import type { PromptDefinition } from "./types";
 
-const CUSTOM_PROMPTS_DIR = join(homedir(), ".config", "dt-eval");
-const CUSTOM_PROMPTS_FILE = join(CUSTOM_PROMPTS_DIR, "custom-prompts.json");
-
 export function readCustomPrompts(): PromptDefinition[] {
-  try {
-    if (!existsSync(CUSTOM_PROMPTS_FILE)) return [];
-    const raw = readFileSync(CUSTOM_PROMPTS_FILE, "utf-8");
-    return JSON.parse(raw) as PromptDefinition[];
-  } catch {
-    return [];
-  }
-}
-
-function writeCustomPrompts(prompts: PromptDefinition[]): void {
-  if (!existsSync(CUSTOM_PROMPTS_DIR)) {
-    mkdirSync(CUSTOM_PROMPTS_DIR, { recursive: true });
-  }
-  writeFileSync(CUSTOM_PROMPTS_FILE, JSON.stringify(prompts, null, 2), "utf-8");
+  return getPromptStore()?.read() ?? [];
 }
 
 export function createCustomPrompt(prompt: PromptDefinition): void {
-  const existing = readCustomPrompts();
+  const store = getPromptStore();
+  if (!store) {
+    throw new EvalMetricError(
+      "No prompt store registered. Custom prompts require a storage backend.",
+    );
+  }
+  const existing = store.read();
   const idx = existing.findIndex((p) => p.id === prompt.id);
   if (idx >= 0) {
     existing[idx] = prompt;
   } else {
     existing.push(prompt);
   }
-  writeCustomPrompts(existing);
+  store.write(existing);
 }
 
 export function deleteCustomPrompt(id: string): void {
-  const existing = readCustomPrompts();
+  const store = getPromptStore();
+  if (!store) {
+    throw new EvalMetricError(
+      "No prompt store registered. Custom prompts require a storage backend.",
+    );
+  }
+  const existing = store.read();
   const updated = existing.filter((p) => p.id !== id);
   if (updated.length === existing.length) {
     throw new EvalMetricError(`Custom evaluator "${id}" not found`);
   }
-  writeCustomPrompts(updated);
+  store.write(updated);
 }

--- a/dt-eval-lib/src/prompts/index.ts
+++ b/dt-eval-lib/src/prompts/index.ts
@@ -1,4 +1,6 @@
 export { createCustomPrompt, deleteCustomPrompt } from "./custom";
 export { getPrompt, listPrompts } from "./lookup";
+export type { PromptStore } from "./store";
+export { registerPromptStore } from "./store";
 export type { PromptDefinition } from "./types";
 export { BuiltInMetric, DRIFT_METRIC_ID } from "./types";

--- a/dt-eval-lib/src/prompts/store.ts
+++ b/dt-eval-lib/src/prompts/store.ts
@@ -1,0 +1,16 @@
+import type { PromptDefinition } from "./types";
+
+export interface PromptStore {
+  read(): PromptDefinition[];
+  write(prompts: PromptDefinition[]): void;
+}
+
+let registeredStore: PromptStore | null = null;
+
+export function registerPromptStore(store: PromptStore): void {
+  registeredStore = store;
+}
+
+export function getPromptStore(): PromptStore | null {
+  return registeredStore;
+}


### PR DESCRIPTION
dt-eval-lib imported node:fs, node:os and node:path in custom.ts, preventing its use in Dynatrace frontend apps where these builtins are not available at bundle time.

- Add PromptStore interface and registerPromptStore() registry to dt-eval-lib
- Rewrite custom.ts to delegate to the registered store (no Node.js imports)
- listPrompts/getPrompt fall back gracefully (empty custom list) when no store registered
- createCustomPrompt/deleteCustomPrompt throw a clear error when no store registered
- Move filesystem logic into FsPromptStore class in dt-eval-cli
- Register FsPromptStore at CLI startup — existing CLI behavior unchanged