### PR TITLE
feat(main): prompt to run eval immediately after setup wizard

### DIFF
--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { spawnSync } from 'node:child_process';
 import { join, basename } from 'node:path';
 import { loadConfig, saveConfig, validateConfig } from '../../config/index.js';
 import type { DtEvalConfig } from '../../config/schema.js';
@@ -164,7 +165,7 @@ export function createConfigureCommand(): Command {
         process.exit(1);
       }
 
-      const { input, password, select, checkbox } = inquirer;
+      const { input, password, select, checkbox, confirm } = inquirer;
 
       console.log('\n  dt-eval-cli setup wizard');
       console.log('  ' + '─'.repeat(30) + '\n');
@@ -372,8 +373,18 @@ export function createConfigureCommand(): Command {
         updated.judge.model ?? DEFAULT_JUDGE_MODELS[updated.judge.provider] ?? 'gpt-4o',
       );
 
-      console.log(`  Copy this to run the newly created config:`);
-      console.log(`  dt-eval run ${basename(outputPath)}\n`);
+      const runNow = await confirm({
+        message: 'Would you like to run this right now?',
+        default: true,
+      });
+
+      if (runNow) {
+        console.log(`\n  Running: dt-eval run ${basename(outputPath)}\n`);
+        spawnSync(process.execPath, [process.argv[1], 'run', outputPath], { stdio: 'inherit' });
+      } else {
+        console.log(`  Copy this to run the newly created config:`);
+        console.log(`  dt-eval run ${basename(outputPath)}\n`);
+      }
 
       return;
     }


### PR DESCRIPTION
## Summary

- After the setup wizard saves the `.yaml` config file and prints the cost estimate, the user is now asked **"Would you like to run this right now?"** (default: yes)
- Selecting **yes** immediately runs `dt-eval run <config>` with full terminal output streamed live
- Selecting **no** prints the existing copy-paste hint as before

## Test plan

- [ ] Run `dt-eval configure` through the interactive wizard
- [ ] Verify the prompt appears after the cost estimate
- [ ] Confirm "yes" launches the run and output streams to the terminal
- [ ] Confirm "no" prints the copy-paste hint and exits cleanly
- [ ] Verify flag-only mode (`dt-eval configure --env-url ... --provider ...`) is unaffected