### PR TITLE
fix(main): redact secretKey in configure --show output

### DIFF
--- a/dt-eval-cli/src/ui/format.ts
+++ b/dt-eval-cli/src/ui/format.ts
@@ -42,6 +42,7 @@ export function redactSecrets(config: DtEvalConfig): DtEvalConfig {
     judge: {
       ...config.judge,
       apiKey: config.judge.apiKey ? '***' : undefined,
+      secretKey: config.judge.secretKey ? '***' : undefined,
     },
   };
 }


### PR DESCRIPTION
## Summary

- AWS Bedrock `secretKey` (secret access key) was printed in plaintext when running `dt-eval configure --show`
- Added `secretKey` redaction to `redactSecrets()` in `src/ui/format.ts`, consistent with the existing `apiKey` redaction

## Test plan

- [ ] Run `dt-eval configure --show` with a Bedrock config that has `secretKey` set — confirm it displays `***`
- [ ] Confirm `apiKey` still redacts as before
