### PR TITLE
chore: bump @dynatrace-oss/dt-eval-lib to ^0.0.13-alpha

### DIFF
--- a/dt-eval-cli/package-lock.json
+++ b/dt-eval-cli/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.3-alpha",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dynatrace-oss/dt-eval-lib": "^0.0.12-alpha",
+        "@dynatrace-oss/dt-eval-lib": "^0.0.13-alpha",
         "@inquirer/prompts": "^7.10.1",
         "@types/figlet": "^1.7.0",
         "commander": "^12.0.0",
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@dynatrace-oss/dt-eval-lib": {
-      "version": "0.0.12-alpha",
-      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.12-alpha.tgz",
-      "integrity": "sha512-MK75Ayy+/iR5c2/sqBTA4RrnSxTPsNA4gCDBeHgU8Oka2L24d/KiQfE0UtuiUWVBAs/OkV2fXHfWBDxBUAqCIQ==",
+      "version": "0.0.13-alpha",
+      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.13-alpha.tgz",
+      "integrity": "sha512-7KsSb96oY5H2L/0HrEo1zXt6k6OQgsT9T/F28mJHmpAV0dRk1eOHehcWoBD+wQGxU9d9qdRnN4Kp5+o3bTC3WQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -38,7 +38,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@types/figlet": "^1.7.0",
     "commander": "^12.0.0",
-    "@dynatrace-oss/dt-eval-lib": "^0.0.12-alpha",
+    "@dynatrace-oss/dt-eval-lib": "^0.0.13-alpha",
     "figlet": "^1.11.0",
     "picocolors": "^1.1.1",
     "yaml": "^2.4.0"


### PR DESCRIPTION
## Summary

- Bumps `@dynatrace-oss/dt-eval-lib` in `dt-eval-cli` from `^0.0.12-alpha` to `^0.0.13-alpha`.
- Refreshes `dt-eval-cli/package-lock.json` to resolve `0.0.13-alpha` from the npm registry.

Required between the lib release (#50, merged) and the CLI release (#57) so the CLI ships against the matching lib version.

## Test plan

- [x] `npm install` resolves `@dynatrace-oss/dt-eval-lib@0.0.13-alpha` from the npm registry.
- [x] `npm run build` succeeds (tsup ESM + DTS).
- [x] `node ./dist/index.js doctor --skip-auth` runs end-to-end (validates the lib loads and the `doctor` command still works post-bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)