### PR TITLE
feat!: rename CLI to dt-evals and resolve tsc strict-mode errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 End-to-end LLM evaluation toolkit for Dynatrace AI Observability.
 
-`dt-eval` is the main interface. It pulls live `gen_ai.*` spans from your Dynatrace environment, masks sensitive data in memory, scores real production interactions with an LLM judge, and writes structured evaluation results back to Dynatrace as business events — keeping evals, traces, metrics, alerts, and dashboards in one place.
+`dt-evals` is the main interface. It pulls live `gen_ai.*` spans from your Dynatrace environment, masks sensitive data in memory, scores real production interactions with an LLM judge, and writes structured evaluation results back to Dynatrace as business events — keeping evals, traces, metrics, alerts, and dashboards in one place.
 
 ![dt-evals welcome](assets/dt-evals-welcome.png)
 
@@ -10,7 +10,7 @@ End-to-end LLM evaluation toolkit for Dynatrace AI Observability.
 
 | Package | Description |
 |---------|-------------|
-| [`dt-eval`](dt-eval-cli) | CLI — configure, run, schedule, inspect, and deploy evals |
+| [`dt-evals`](dt-eval-cli) | CLI — configure, run, schedule, inspect, and deploy evals |
 | [`dt-eval-lib`](dt-eval-lib) | TypeScript library — run judge-based evals in code, tests, and CI |
 | [`dt-eval-deploy`](dt-eval-deploy) | Deployment resources — Docker image and serverless runners |
 
@@ -40,13 +40,13 @@ npx github:dynatrace-oss/dt-evals <command>
 ```bash
 # 1. Run the doctor — authenticates via dtctl (browser OAuth), checks permissions,
 #    generates a platform token, and writes it to your .env
-dt-eval doctor
+dt-evals doctor
 
 # 2. Configure your service and judge provider
-dt-eval configure
+dt-evals configure
 
 # 3. Run evals on the last hour of traces
-dt-eval run --since 1h --sample 10
+dt-evals run --since 1h --sample 10
 ```
 
 ---
@@ -59,23 +59,23 @@ Diagnose your environment end-to-end. Uses `dtctl` for browser-based OAuth, chec
 
 ```bash
 # Full interactive check (recommended for first-time setup)
-dt-eval doctor
+dt-evals doctor
 
 # Generate a platform token only (skips the full health check)
-dt-eval doctor create-token
+dt-evals doctor create-token
 
 # Use an existing dtctl context
-dt-eval doctor --context my-env
-dt-eval doctor create-token --context my-env
+dt-evals doctor --context my-env
+dt-evals doctor create-token --context my-env
 
 # Point at a specific environment URL
-dt-eval doctor --env-url https://abc12345.apps.dynatrace.com
+dt-evals doctor --env-url https://abc12345.apps.dynatrace.com
 
 # Skip token generation (if you already have DT_API_TOKEN set)
-dt-eval doctor --skip-token
+dt-evals doctor --skip-token
 
 # Config, provider, and run history only — no dtctl auth required
-dt-eval doctor --skip-auth
+dt-evals doctor --skip-auth
 ```
 
 **What it checks:**
@@ -99,10 +99,10 @@ Set up Dynatrace and judge provider credentials. Writes to `.dt-eval.yaml` in th
 
 ```bash
 # Interactive wizard
-dt-eval configure
+dt-evals configure
 
 # Non-interactive
-dt-eval configure \
+dt-evals configure \
   --env-url https://your-env.live.dynatrace.com \
   --api-token "$DT_API_TOKEN" \
   --provider openai \
@@ -110,7 +110,7 @@ dt-eval configure \
   --model gpt-4.1
 
 # Show resolved config with secrets redacted
-dt-eval configure --show
+dt-evals configure --show
 ```
 
 ---
@@ -120,7 +120,7 @@ dt-eval configure --show
 Check config schema, Dynatrace connectivity, and judge provider reachability before running.
 
 ```bash
-dt-eval validate
+dt-evals validate
 ```
 
 ---
@@ -131,19 +131,19 @@ Evaluate recent GenAI traces from Dynatrace.
 
 ```bash
 # Run all enabled evaluators over the last 2 hours, 20% sample
-dt-eval run --since 2h --sample 20
+dt-evals run --since 2h --sample 20
 
 # Run a single evaluator
-dt-eval run --since 6h --metric faithfulness
+dt-evals run --since 6h --metric faithfulness
 
 # Preview what would run — no judge calls, no result writes
-dt-eval run --since 1h --sample 5 --dry-run
+dt-evals run --since 1h --sample 5 --dry-run
 
 # CI mode — JSON output, exit 1 on threshold breach
-dt-eval run --since 6h --metric relevance --ci
+dt-evals run --since 6h --metric relevance --ci
 
 # Parallel workers for faster throughput
-dt-eval run --since 2h --sample 20 --concurrency 8 --debug
+dt-evals run --since 2h --sample 20 --concurrency 8 --debug
 ```
 
 **Flags:**
@@ -163,7 +163,7 @@ dt-eval run --since 2h --sample 20 --concurrency 8 --debug
 
 ```yaml
 - name: Run LLM eval gate
-  run: npx dt-eval run --since 6h --metric faithfulness --ci
+  run: npx @dynatrace-oss/dt-evals run --since 6h --metric faithfulness --ci
   env:
     DT_ENV_URL: ${{ secrets.DT_ENV_URL }}
     DT_API_TOKEN: ${{ secrets.DT_API_TOKEN }}
@@ -178,19 +178,19 @@ Inspect, test, and manage built-in and custom evaluators.
 
 ```bash
 # List all available evaluators
-dt-eval evaluators list
+dt-evals evaluators list
 
 # Show details for one evaluator (prompt, required fields, scoring scale)
-dt-eval evaluators show faithfulness
+dt-evals evaluators show faithfulness
 
 # Send a test trace through the judge for an evaluator
-dt-eval evaluators test relevance
+dt-evals evaluators test relevance
 
 # Add a custom evaluator interactively
-dt-eval evaluators add
+dt-evals evaluators add
 
 # Remove a custom evaluator
-dt-eval evaluators delete my-custom-eval
+dt-evals evaluators delete my-custom-eval
 ```
 
 ---
@@ -201,14 +201,14 @@ View and export local run history from `~/.dt-eval/runs.json`.
 
 ```bash
 # List recent runs
-dt-eval runs list --limit 20
+dt-evals runs list --limit 20
 
 # Inspect a single run in detail
-dt-eval runs show run-2026-04-10T12-00-00-ab12cd34
+dt-evals runs show run-2026-04-10T12-00-00-ab12cd34
 
 # Export run history
-dt-eval runs export --format csv --output runs.csv
-dt-eval runs export --format json --output runs.json
+dt-evals runs export --format csv --output runs.csv
+dt-evals runs export --format json --output runs.json
 ```
 
 ---
@@ -219,20 +219,20 @@ Configure recurring evaluation runs stored in `~/.dt-eval/schedules.json`.
 
 ```bash
 # Create a schedule
-dt-eval schedule add --name hourly-rag --cron "0 * * * *" --since 1h --sample 10
+dt-evals schedule add --name hourly-rag --cron "0 * * * *" --since 1h --sample 10
 
 # List schedules
-dt-eval schedule list
+dt-evals schedule list
 
 # Trigger a schedule immediately
-dt-eval schedule run <schedule-id>
+dt-evals schedule run <schedule-id>
 
 # Pause or resume
-dt-eval schedule disable <schedule-id>
-dt-eval schedule enable <schedule-id>
+dt-evals schedule disable <schedule-id>
+dt-evals schedule enable <schedule-id>
 
 # Remove
-dt-eval schedule delete <schedule-id>
+dt-evals schedule delete <schedule-id>
 ```
 
 ---
@@ -242,7 +242,7 @@ dt-eval schedule delete <schedule-id>
 Show resolved config, connectivity state, and last run summary.
 
 ```bash
-dt-eval status
+dt-evals status
 ```
 
 ---
@@ -252,10 +252,10 @@ dt-eval status
 Package and deploy the eval runner as a serverless function for continuous scheduled evaluation.
 
 ```bash
-dt-eval deploy --provider aws      # AWS Lambda
-dt-eval deploy --provider gcp      # Google Cloud Run
-dt-eval deploy --provider azure    # Azure Functions
-dt-eval deploy --teardown          # Destroy deployed resources
+dt-evals deploy --provider aws      # AWS Lambda
+dt-evals deploy --provider gcp      # Google Cloud Run
+dt-evals deploy --provider azure    # Azure Functions
+dt-evals deploy --teardown          # Destroy deployed resources
 ```
 
 See [`dt-eval-deploy`](dt-eval-deploy) for Docker-based deployment.
@@ -264,18 +264,18 @@ See [`dt-eval-deploy`](dt-eval-deploy) for Docker-based deployment.
 
 ## Required Dynatrace Permissions
 
-### dt-eval CLI
+### dt-evals CLI
 
 The platform token (or OAuth scope) used by the CLI needs the following permissions:
 
 | Scope | Required for | Notes |
 |-------|-------------|-------|
-| `storage:spans:read` | `dt-eval run` | Fetches GenAI OTel spans via DQL (`fetch spans`) |
-| `storage:events:read` | `dt-eval run` with drift | Reads historical evaluation results for drift baseline (`fetch bizevents`) |
-| `storage:events:write` | `dt-eval run` | Writes evaluation results back as business events |
+| `storage:spans:read` | `dt-evals run` | Fetches GenAI OTel spans via DQL (`fetch spans`) |
+| `storage:events:read` | `dt-evals run` with drift | Reads historical evaluation results for drift baseline (`fetch bizevents`) |
+| `storage:events:write` | `dt-evals run` | Writes evaluation results back as business events |
 | `metrics:ingest` | Optional | Writes evaluation metrics to Dynatrace metrics API |
 
-Run `dt-eval doctor create-token` to generate a token with exactly these scopes via OAuth.
+Run `dt-evals doctor create-token` to generate a token with exactly these scopes via OAuth.
 
 **Manually create a token** in Dynatrace → Settings → Access Tokens with the scopes above, then set:
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -1,12 +1,12 @@
-# dt-eval - Dynatrace Evaluation CLI tool
+# dt-evals - Dynatrace Evaluation CLI tool
 
 **Open source continuous evals for LLM applications, with production prompt traces as the dataset.**
 
-[![npm version](https://img.shields.io/npm/v/dt-eval)](https://www.npmjs.com/package/dt-eval)
+[![npm version](https://img.shields.io/npm/v/@dynatrace-oss/dt-evals)](https://www.npmjs.com/package/@dynatrace-oss/dt-evals)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
 [![CI](https://github.com/dynatrace-oss/dt-evals/actions/workflows/ci.yml/badge.svg)](https://github.com/dynatrace-oss/dt-evals/actions)
 
-`dt-eval` is for teams shipping chat, RAG, copilots, and agent workflows who want evals to run on real traffic, not just curated test sets.
+`dt-evals` is for teams shipping chat, RAG, copilots, and agent workflows who want evals to run on real traffic, not just curated test sets.
 
 Today, the CLI uses Dynatrace as both the trace source and the evaluation result store. It pulls gen_ai.* spans from your live environment, masks sensitive data in memory, scores real production interactions with an LLM judge, detects score drift over time, and writes structured evaluation results back to Dynatrace as business events.
 
@@ -17,10 +17,10 @@ In practice, this gives AI engineers a closed loop for evaluation, observability
 The repository also includes `dt-eval-lib`, a reusable TypeScript evaluation engine for running the same judge-based metrics directly in code, using either the built-in evaluator catalog or your own custom prompt definitions. It also fits cleanly into broader evaluation workflows and observability stacks such as Ragas, MLflow, or Langfuse when you want to orchestrate or track evals in those systems alongside this library.
 
 ```bash
-npx dt-eval configure
-npx dt-eval validate
-npx dt-eval run --since 1h --sample 10
-npx dt-eval deploy --provider aws
+npx @dynatrace-oss/dt-evals configure
+npx @dynatrace-oss/dt-evals validate
+npx @dynatrace-oss/dt-evals run --since 1h --sample 10
+npx @dynatrace-oss/dt-evals deploy --provider aws
 ```
 
 ## Why Teams Use It
@@ -39,7 +39,7 @@ npx dt-eval deploy --provider aws
 
 | Package | What it is for |
 |---------|-----------------|
-| `dt-eval` | Continuous evaluation runs against production GenAI traces in Dynatrace |
+| `dt-evals` | Continuous evaluation runs against production GenAI traces in Dynatrace |
 | `dt-eval-lib` | TypeScript library for judge-based evals inside tests, scripts, and app code |
 | `dt-eval-engine` | Core runtime for deployed eval workers and serverless runners |
 
@@ -79,13 +79,13 @@ The current CLI path is Dynatrace specific. The product positioning is broader: 
 ## Install
 
 ```bash
-npm install -g dt-eval
+npm install -g @dynatrace-oss/dt-evals
 ```
 
 Or run without installing:
 
 ```bash
-npx dt-eval <command>
+npx @dynatrace-oss/dt-evals <command>
 ```
 
 The CLI also auto-loads a local `.env` file from the current working directory.
@@ -97,13 +97,13 @@ The CLI also auto-loads a local `.env` file from the current working directory.
 Interactive setup:
 
 ```bash
-dt-eval configure
+dt-evals configure
 ```
 
 Non-interactive setup:
 
 ```bash
-dt-eval configure \
+dt-evals configure \
   --env-url https://your-env.live.dynatrace.com \
   --api-token "$DT_API_TOKEN" \
   --provider openai \
@@ -116,7 +116,7 @@ dt-eval configure \
 ### 2. Validate the setup
 
 ```bash
-dt-eval validate
+dt-evals validate
 ```
 
 This checks:
@@ -129,19 +129,19 @@ This checks:
 ### 3. Run evals on recent traces
 
 ```bash
-dt-eval run --since 1h --sample 10 --concurrency 5
+dt-evals run --since 1h --sample 10 --concurrency 5
 ```
 
 Run only one evaluator:
 
 ```bash
-dt-eval run --since 6h --metric faithfulness
+dt-evals run --since 6h --metric faithfulness
 ```
 
 Preview the work without calling the judge or writing results:
 
 ```bash
-dt-eval run --since 1h --sample 5 --dry-run
+dt-evals run --since 1h --sample 5 --dry-run
 ```
 
 ## CLI Workflows
@@ -149,7 +149,7 @@ dt-eval run --since 1h --sample 5 --dry-run
 ### Production eval run
 
 ```bash
-dt-eval run \
+dt-evals run \
   --since 2h \
   --sample 20 \
   --concurrency 8 \
@@ -159,7 +159,7 @@ dt-eval run \
 ### CI gate on quality regressions
 
 ```bash
-dt-eval run --since 6h --metric relevance --ci
+dt-evals run --since 6h --metric relevance --ci
 ```
 
 - exit code `0`: no threshold breaches
@@ -169,7 +169,7 @@ Example GitHub Actions step:
 
 ```yaml
 - name: Run LLM eval gate
-  run: npx dt-eval run --since 6h --metric faithfulness --ci
+  run: npx @dynatrace-oss/dt-evals run --since 6h --metric faithfulness --ci
   env:
     DT_ENV_URL: ${{ secrets.DT_ENV_URL }}
     DT_API_TOKEN: ${{ secrets.DT_API_TOKEN }}
@@ -179,7 +179,7 @@ Example GitHub Actions step:
 ### Run drift detection only
 
 ```bash
-dt-eval run --metric drift --since 24h
+dt-evals run --metric drift --since 24h
 ```
 
 This uses prior evaluation results already written to Dynatrace and compares the recent window against a 7 day baseline.
@@ -187,24 +187,24 @@ This uses prior evaluation results already written to Dynatrace and compares the
 ### Inspect available evaluators
 
 ```bash
-dt-eval evaluators list
-dt-eval evaluators show faithfulness
-dt-eval evaluators test relevance
+dt-evals evaluators list
+dt-evals evaluators show faithfulness
+dt-evals evaluators test relevance
 ```
 
 Create or remove a custom evaluator:
 
 ```bash
-dt-eval evaluators add
-dt-eval evaluators delete my-custom-eval
+dt-evals evaluators add
+dt-evals evaluators delete my-custom-eval
 ```
 
 ### Manage run history
 
 ```bash
-dt-eval runs list --limit 20
-dt-eval runs show run-2026-04-10T12-00-00-ab12cd34
-dt-eval runs export --format csv --output runs.csv
+dt-evals runs list --limit 20
+dt-evals runs show run-2026-04-10T12-00-00-ab12cd34
+dt-evals runs export --format csv --output runs.csv
 ```
 
 Run records are stored locally in `~/.dt-eval/runs.json`.
@@ -212,12 +212,12 @@ Run records are stored locally in `~/.dt-eval/runs.json`.
 ### Schedule recurring runs
 
 ```bash
-dt-eval schedule add --name hourly-rag --cron "0 * * * *" --since 1h --sample 10
-dt-eval schedule list
-dt-eval schedule run <schedule-id>
-dt-eval schedule disable <schedule-id>
-dt-eval schedule enable <schedule-id>
-dt-eval schedule delete <schedule-id>
+dt-evals schedule add --name hourly-rag --cron "0 * * * *" --since 1h --sample 10
+dt-evals schedule list
+dt-evals schedule run <schedule-id>
+dt-evals schedule disable <schedule-id>
+dt-evals schedule enable <schedule-id>
+dt-evals schedule delete <schedule-id>
 ```
 
 Schedules are stored locally in `~/.dt-eval/schedules.json`.
@@ -225,8 +225,8 @@ Schedules are stored locally in `~/.dt-eval/schedules.json`.
 ### Check current status
 
 ```bash
-dt-eval status
-dt-eval configure --show
+dt-evals status
+dt-evals configure --show
 ```
 
 ## Commands
@@ -514,7 +514,7 @@ Drift results are written back as the same event type with `gen_ai.evaluation.ty
 
 ## Built-in Evaluators
 
-`dt-eval` ships with 13 built-in LLM judge evaluators, plus drift detection as a separate statistical metric.
+`dt-evals` ships with 13 built-in LLM judge evaluators, plus drift detection as a separate statistical metric.
 
 | Evaluator | Measures | Required fields |
 |-----------|----------|-----------------|

--- a/dt-eval-cli/package-lock.json
+++ b/dt-eval-cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@dynatrace-oss/dt-eval",
+  "name": "@dynatrace-oss/dt-evals",
   "version": "0.1.4-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@dynatrace-oss/dt-eval",
+      "name": "@dynatrace-oss/dt-evals",
       "version": "0.1.4-alpha",
       "license": "Apache-2.0",
       "dependencies": {
@@ -18,7 +18,7 @@
         "yaml": "^2.4.0"
       },
       "bin": {
-        "dt-eval": "dist/index.js"
+        "dt-evals": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@dynatrace-oss/dt-eval",
+  "name": "@dynatrace-oss/dt-evals",
   "version": "0.1.4-alpha",
   "description": "Evaluation CLI for AI Observability on Dynatrace",
   "type": "module",
   "bin": {
-    "dt-eval": "./dist/index.js"
+    "dt-evals": "./dist/index.js"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -372,11 +372,11 @@ export function createConfigureCommand(): Command {
       });
 
       if (runNow) {
-        console.log(`\n  Running: dt-eval run ${basename(outputPath)}\n`);
+        console.log(`\n  Running: dt-evals run ${basename(outputPath)}\n`);
         spawnSync(process.execPath, [process.argv[1], 'run', outputPath], { stdio: 'inherit' });
       } else {
         console.log(`  Copy this to run the newly created config:`);
-        console.log(`  dt-eval run ${basename(outputPath)}\n`);
+        console.log(`  dt-evals run ${basename(outputPath)}\n`);
       }
 
       return;
@@ -413,14 +413,14 @@ export function createConfigureCommand(): Command {
       validateConfig(updated);
     } catch (err) {
       console.warn(`Warning: config has validation issues — ${(err as Error).message}`);
-      console.warn('Config saved anyway. Run "dt-eval-cli validate" to check.');
+      console.warn('Config saved anyway. Run "dt-evals validate" to check.');
     }
 
     try {
       saveConfig(updated, outputPath);
       console.log(`Config saved to ${outputPath}`);
       console.log(`\n  Copy this to run the newly created config:`);
-      console.log(`  dt-eval run ${basename(outputPath)}\n`);
+      console.log(`  dt-evals run ${basename(outputPath)}\n`);
     } catch (err) {
       console.error(`Failed to save config: ${(err as Error).message}`);
       process.exit(1);

--- a/dt-eval-cli/src/cli/commands/doctor.ts
+++ b/dt-eval-cli/src/cli/commands/doctor.ts
@@ -1,13 +1,17 @@
 import { Command } from 'commander';
+import { execFile } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { promisify } from 'node:util';
 import pc from 'picocolors';
 import { Spinner } from '../../ui/spinner.js';
 import { loadConfig, validateConfig } from '../../config/index.js';
 import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
 import * as dtctl from '../../dtctl/index.js';
 import { printDoctorBanner } from '../../ui/banner.js';
+
+const execFileAsync = promisify(execFile);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -278,7 +282,7 @@ export function createDoctorCommand(): Command {
         console.log(`  Found ${contexts.length} context${contexts.length !== 1 ? 's' : ''}:`);
         contexts.forEach((c, i) => {
           const label = c.environmentUrl ? `${c.name}  (${c.environmentUrl})` : c.name;
-          const marker = c.isDefault ? pc.dim(' [default]') : '';
+          const marker = c.isCurrent ? pc.dim(' [current]') : '';
           console.log(`    ${i + 1}. ${label}${marker}`);
         });
       }
@@ -466,8 +470,8 @@ export function createDoctorCommand(): Command {
         }
       }
 
-      // Count GenAI spans
-      if (dqlCheck.ok) {
+      // Count GenAI spans (only when the spans-read scope is granted)
+      if (spansCheck.ok) {
         const spanSpinner = new Spinner('Querying GenAI spans (last 24h)...');
         spanSpinner.start();
         const service = existingConfig?.scope?.service;
@@ -904,7 +908,7 @@ function createDoctorCreateCommand(): Command {
 
     // Foundational scopes that aren't probed individually but are required
     // by the runtime — included unconditionally so a doctor-minted token
-    // can actually pass `dt-eval validate` and run end-to-end:
+    // can actually pass `dt-evals validate` and run end-to-end:
     //   - storage:buckets:read: Grail prerequisite for any storage table
     //     read; without it `fetch spans|logs|bizevents` returns
     //     SUCCEEDED-with-empty-records (silent failure).

--- a/dt-eval-cli/src/cli/commands/evaluators.ts
+++ b/dt-eval-cli/src/cli/commands/evaluators.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { listPrompts, getPrompt, createCustomPrompt, deleteCustomPrompt, evaluate } from '@dynatrace-oss/dt-eval-lib';
-import type { EvalConfig } from '@dynatrace-oss/dt-eval-lib';
+import type { EvalConfig, Provider } from '@dynatrace-oss/dt-eval-lib';
 import { loadConfig } from '../../config/index.js';
 import { renderTable } from '../../ui/table.js';
 import { Spinner } from '../../ui/spinner.js';
@@ -50,9 +50,7 @@ export function createEvaluatorsCommand(): Command {
       console.log(`Description: ${prompt.description}`);
       console.log(`Required Fields: ${prompt.requiredFields.join(', ')}`);
       console.log(`Scoring Scale: ${prompt.scoring.type}`);
-      if ('threshold' in prompt.scoring) {
-        console.log(`Pass Threshold: ${(prompt.scoring as Record<string, unknown>)['threshold']}`);
-      }
+      console.log(`Pass Threshold: ${prompt.scoring.threshold}`);
       console.log(`\nPrompt Template:\n${prompt.prompt}`);
     } catch (err) {
       logger.error((err as Error).message);
@@ -82,7 +80,7 @@ export function createEvaluatorsCommand(): Command {
       { name: 'input', value: 'input' as const, checked: true },
       { name: 'output', value: 'output' as const, checked: true },
       { name: 'context', value: 'context' as const, checked: false },
-      { name: 'expected_output', value: 'expected_output' as const, checked: false },
+      { name: 'expectedOutput', value: 'expectedOutput' as const, checked: false },
     ];
 
     const requiredFields = await checkbox({
@@ -109,10 +107,11 @@ export function createEvaluatorsCommand(): Command {
     try {
       await createCustomPrompt({
         id,
+        version: '1',
         name,
         description: description || name,
         prompt: template,
-        requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expected_output')[],
+        requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expectedOutput')[],
         scoring: {
           type: scoringType as 'continuous' | 'binary' | 'likert',
           threshold,
@@ -161,8 +160,9 @@ export function createEvaluatorsCommand(): Command {
   testCmd.argument('<id>', 'Evaluator ID');
 
   testCmd.action(async (id: string) => {
+    let prompt;
     try {
-      await getPrompt(id);
+      prompt = await getPrompt(id);
     } catch (err) {
       logger.error((err as Error).message);
       process.exit(1);
@@ -191,18 +191,24 @@ export function createEvaluatorsCommand(): Command {
     }
 
     const libConfig: EvalConfig = {
-      provider: config.judge.provider,
-      apiKey: config.judge.apiKey,
-      model: config.judge.model,
-      timeout: config.judge.timeout,
-      maxRetries: config.judge.maxRetries,
+      provider: {
+        provider: config.judge.provider as Provider,
+        apiKey: config.judge.apiKey,
+        baseUrl: config.judge.baseUrl,
+        apiVersion: config.judge.apiVersion,
+        region: config.judge.region,
+        secretKey: config.judge.secretKey,
+        model: config.judge.model,
+        timeout: config.judge.timeout,
+        maxRetries: config.judge.maxRetries,
+      },
     };
 
     const spinner = new Spinner(`Running evaluation with ${config.judge.provider}/${config.judge.model ?? 'default'}...`);
     spinner.start();
 
     try {
-      const result = await evaluate(id, {
+      const result = await evaluate(prompt, {
         input: inputText,
         output: outputText,
         context: contextText || undefined,

--- a/dt-eval-cli/src/cli/commands/prompts.ts
+++ b/dt-eval-cli/src/cli/commands/prompts.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { listPrompts, getPrompt, createCustomPrompt, deleteCustomPrompt, evaluate } from '@dynatrace-oss/dt-eval-lib';
-import type { EvalConfig } from '@dynatrace-oss/dt-eval-lib';
+import type { EvalConfig, Provider } from '@dynatrace-oss/dt-eval-lib';
 import { loadConfig } from '../../config/index.js';
 import { renderTable } from '../../ui/table.js';
 import { Spinner } from '../../ui/spinner.js';
@@ -50,9 +50,7 @@ export function createPromptsCommand(): Command {
       console.log(`Description: ${prompt.description}`);
       console.log(`Required Fields: ${prompt.requiredFields.join(', ')}`);
       console.log(`Scoring Scale: ${prompt.scoring.type}`);
-      if ('threshold' in prompt.scoring) {
-        console.log(`Pass Threshold: ${(prompt.scoring as Record<string, unknown>)['threshold']}`);
-      }
+      console.log(`Pass Threshold: ${prompt.scoring.threshold}`);
       console.log(`\nPrompt Template:\n${prompt.prompt}`);
     } catch (err) {
       logger.error((err as Error).message);
@@ -82,7 +80,7 @@ export function createPromptsCommand(): Command {
       { name: 'input', value: 'input' as const, checked: true },
       { name: 'output', value: 'output' as const, checked: true },
       { name: 'context', value: 'context' as const, checked: false },
-      { name: 'expected_output', value: 'expected_output' as const, checked: false },
+      { name: 'expectedOutput', value: 'expectedOutput' as const, checked: false },
     ];
 
     const requiredFields = await checkbox({
@@ -109,10 +107,11 @@ export function createPromptsCommand(): Command {
     try {
       await createCustomPrompt({
         id,
+        version: '1',
         name,
         description: description || name,
         prompt: template,
-        requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expected_output')[],
+        requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expectedOutput')[],
         scoring: {
           type: scoringType as 'continuous' | 'binary' | 'likert',
           threshold,
@@ -161,9 +160,9 @@ export function createPromptsCommand(): Command {
   testCmd.argument('<id>', 'Prompt ID');
 
   testCmd.action(async (id: string) => {
-    // Verify prompt exists
+    let prompt;
     try {
-      await getPrompt(id);
+      prompt = await getPrompt(id);
     } catch (err) {
       logger.error((err as Error).message);
       process.exit(1);
@@ -192,18 +191,24 @@ export function createPromptsCommand(): Command {
     }
 
     const libConfig: EvalConfig = {
-      provider: config.judge.provider,
-      apiKey: config.judge.apiKey,
-      model: config.judge.model,
-      timeout: config.judge.timeout,
-      maxRetries: config.judge.maxRetries,
+      provider: {
+        provider: config.judge.provider as Provider,
+        apiKey: config.judge.apiKey,
+        baseUrl: config.judge.baseUrl,
+        apiVersion: config.judge.apiVersion,
+        region: config.judge.region,
+        secretKey: config.judge.secretKey,
+        model: config.judge.model,
+        timeout: config.judge.timeout,
+        maxRetries: config.judge.maxRetries,
+      },
     };
 
     const spinner = new Spinner(`Evaluating with ${config.judge.provider}/${config.judge.model ?? 'default'}...`);
     spinner.start();
 
     try {
-      const result = await evaluate(id, {
+      const result = await evaluate(prompt, {
         input: inputText,
         output: outputText,
         context: contextText || undefined,

--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -63,7 +63,7 @@ export function createRunCommand(): Command {
         process.exit(1);
       }
       logger.error(`Config error: ${(err as Error).message}`);
-      logger.error('Run "dt-eval-cli configure" to set up your configuration.');
+      logger.error('Run "dt-evals configure" to set up your configuration.');
       process.exit(1);
     }
 

--- a/dt-eval-cli/src/cli/commands/status.ts
+++ b/dt-eval-cli/src/cli/commands/status.ts
@@ -68,7 +68,7 @@ export function createStatusCommand(): Command {
     } catch (err) {
       console.log('Status: config not found or invalid');
       console.log(`  Error: ${(err as Error).message}`);
-      console.log('  Run "dt-eval-cli configure" to set up your configuration.');
+      console.log('  Run "dt-evals configure" to set up your configuration.');
       return;
     }
 

--- a/dt-eval-cli/src/cli/commands/validate.ts
+++ b/dt-eval-cli/src/cli/commands/validate.ts
@@ -161,8 +161,8 @@ export function createValidateCommand(): Command {
     // 4. Evaluators
     try {
       const prompts = await listPrompts();
-      const builtIn = prompts.filter(p => !((p as Record<string, unknown>)['custom']));
-      const custom = prompts.filter(p => (p as Record<string, unknown>)['custom']);
+      const builtIn = prompts.filter(p => !((p as unknown as Record<string, unknown>)['custom']));
+      const custom = prompts.filter(p => (p as unknown as Record<string, unknown>)['custom']);
       logger.success(`${builtIn.length} built-in evaluators available`);
       logger.success(`${custom.length} custom evaluators loaded`);
     } catch (err) {
@@ -172,7 +172,7 @@ export function createValidateCommand(): Command {
     if (configValid) {
       console.log('\nAll checks passed. Ready to run evaluations.');
     } else {
-      console.log('\nSome checks failed. Run "dt-eval-cli configure" to fix issues.');
+      console.log('\nSome checks failed. Run "dt-evals configure" to fix issues.');
       process.exit(1);
     }
   });

--- a/dt-eval-cli/src/cli/index.ts
+++ b/dt-eval-cli/src/cli/index.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import { Command } from 'commander';
 import { createConfigureCommand } from './commands/configure.js';
 import { createRunCommand } from './commands/run.js';
@@ -10,13 +11,26 @@ import { createDoctorCommand } from './commands/doctor.js';
 import { configureLogger } from '../logger/index.js';
 import { printBanner } from '../ui/banner.js';
 
+declare const __CLIENT_VERSION__: string | undefined;
+
+// __CLIENT_VERSION__ is replaced at build time by tsup; fall back to package.json in dev/tsx.
+function resolveVersion(): string {
+  try {
+    if (typeof __CLIENT_VERSION__ !== 'undefined') return __CLIENT_VERSION__;
+  } catch { /* not defined in dev/tsx */ }
+  try {
+    const require = createRequire(import.meta.url);
+    return (require('../../package.json') as { version: string }).version;
+  } catch { return 'dev'; }
+}
+
 export function createCli(): Command {
   const program = new Command();
 
   program
-    .name('dt-eval-cli')
+    .name('dt-evals')
     .description('Run evaluations on your GenAI traces in Dynatrace')
-    .version('0.1.0');
+    .version(resolveVersion());
 
   // Show banner before the help text
   program.addHelpText('beforeAll', () => {

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -18,7 +18,7 @@ export const ALL_METRICS = [
   'conciseness',
 ];
 
-// Sensible starter set — users can expand via dt-eval configure
+// Sensible starter set — users can expand via dt-evals configure
 export const DEFAULT_METRICS = ['toxicity', 'relevance', 'faithfulness'];
 
 export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {

--- a/dt-eval-cli/src/logger/index.ts
+++ b/dt-eval-cli/src/logger/index.ts
@@ -5,7 +5,7 @@ export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug';
 export interface LoggerOptions {
   level?: LogLevel;   // default 'info'
   json?: boolean;     // structured JSON output (for --ci/--json)
-  prefix?: string;    // e.g. '[dt-eval]'
+  prefix?: string;    // e.g. '[dt-evals]'
 }
 
 const LEVEL_PRIORITY: Record<LogLevel, number> = {

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { evaluate, type EvalConfig, type EvalInput, type EvalResult } from '@dynatrace-oss/dt-eval-lib';
+import { evaluate, getPrompt, type EvalConfig, type EvalInput, type EvalResult } from '@dynatrace-oss/dt-eval-lib';
 import type { DynatraceClient } from '../dt/client.js';
 import type { DtEvalConfig, MetricEntry, MetricInputs, CanonicalSpanField } from '../config/schema.js';
 import { metricId, metricInputs } from '../config/schema.js';
@@ -184,7 +184,7 @@ export async function runEvals(
     async task => {
       const t0 = Date.now();
       const input: EvalInput = buildEvalInput(task.span, task.inputs);
-      const evalResult = await evaluate(task.metric, input, libConfig);
+      const evalResult = await evaluate(getPrompt(task.metric), input, libConfig);
       evalCount++;
       logger.debug(`eval [${evalCount}/${tasks.length}] ${task.metric} trace=${task.span.traceId.slice(0, 8)}… ${Date.now() - t0}ms score=${evalResult.score.value}`);
       return { span: task.span, metric: task.metric, evalResult, evalInput: input };

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -8,6 +8,15 @@ vi.mock('@dynatrace-oss/dt-eval-lib', () => ({
     score: { value: 0.9, label: 'pass' },
     explanation: { summary: 'Looks good', reasoning: 'No issues' },
   }),
+  getPrompt: vi.fn((id: string) => ({
+    id,
+    name: id,
+    version: '1',
+    description: '',
+    prompt: '',
+    requiredFields: ['input', 'output'],
+    scoring: { type: 'continuous', range: [0, 1], threshold: 0.7 },
+  })),
   DRIFT_METRIC_ID: 'drift',
 }));
 
@@ -297,7 +306,7 @@ describe('runEvals', () => {
 
     expect(evaluate).toHaveBeenCalledOnce();
     const callArgs = evaluate.mock.calls[0] as unknown[];
-    expect(callArgs[0]).toBe('user-frustration');
+    expect((callArgs[0] as { id: string }).id).toBe('user-frustration');
     const evalInput = callArgs[1] as { input: string };
     expect(evalInput.input).toBe('i am angry');
   });
@@ -324,7 +333,7 @@ describe('runEvals', () => {
     const calls = evaluate.mock.calls as unknown[][];
     const byMetric: Record<string, { input: string }> = {};
     for (const c of calls) {
-      byMetric[c[0] as string] = c[1] as { input: string };
+      byMetric[(c[0] as { id: string }).id] = c[1] as { input: string };
     }
     expect(byMetric['toxicity']!.input).toBe(span.input);
     expect(byMetric['user-frustration']!.input).toBe('just the user turn');


### PR DESCRIPTION
## Summary

Two related cleanups in one PR (both pure quality work, no new features):

### 1. Rename `dt-eval` → `dt-evals` (BREAKING)

The CLI is renamed from `@dynatrace-oss/dt-eval` to `@dynatrace-oss/dt-evals`, bin from `dt-eval` to `dt-evals`. Half of the codebase already used the plural form in user-facing messages (the `doctor` command for example); this aligns the package name, bin, READMEs, and the remaining command strings to one consistent convention.

**In scope:**
- `package.json`: name + bin
- `package-lock.json`: refreshed under the new name
- Local `README.md` and root `README.md`: all command examples, npm install instructions, npx invocations, badges, headings
- `src/cli/commands/{run,status,validate,configure}.ts`: remaining singular hints in error paths
- `src/cli/commands/configure.ts`: "Running: dt-eval run …" and the copyable next-step
- Comment alignment in `doctor.ts`, `defaults.ts`, `logger/index.ts`

**Out of scope (follow-up PR with migration path):**
- `.dt-eval.yaml` project config file extension
- `~/.dt-eval/` global config / runs / schedules directory
- `~/.config/dt-eval/` custom prompts directory
- Sibling package names (`dt-eval-lib`, `dt-eval-deploy`)

Renaming those would orphan existing alpha users' configs and is a separate migration concern.

**Migration for users:**
```
npm uninstall -g @dynatrace-oss/dt-eval
npm install -g @dynatrace-oss/dt-evals
```
After this PR ships and release-please publishes 0.1.5-alpha, we should `npm deprecate '@dynatrace-oss/dt-eval@*' "renamed to @dynatrace-oss/dt-evals"` so anyone running the old name sees the redirect.

### 2. Resolve 15 pre-existing tsc --noEmit strict-mode errors

`tsup` compiles fine but `npx tsc --noEmit` reported 15 errors on `main`. CI doesn't gate on them today, but they break editors, downstream consumers using strict TS, and any future move to `--noEmit` in CI.

- **doctor.ts**: import `execFile`/`promisify`, define `execFileAsync`; rename `isDefault` → `isCurrent` (matches `DtctlContext`); replace undefined `dqlCheck` with `spansCheck.ok`
- **evaluators.ts + prompts.ts**: `expected_output` → `expectedOutput` (matches lib type); pass full `PromptDefinition` (not bare id string) to `evaluate`; wrap `libConfig` with nested `provider` block; include the required `version` field on `createCustomPrompt` payload
- **validate.ts**: cast through `unknown` first before `Record<string, unknown>` (the `custom` flag is a runtime-only property on `PromptDefinition`)
- **runner/index.ts**: import `getPrompt`; pass `getPrompt(task.metric)` to `evaluate` instead of the raw metric id string
- **tests/runner/index.test.ts**: mock `getPrompt`; update 2 call-args assertions that compared the first arg of `evaluate` to a string

## Test plan

- [x] `npx tsc --noEmit` clean (was 15 errors)
- [x] `npm run build` succeeds
- [x] `npm test` — 158/158 passing
- [x] `node ./dist/index.js doctor --skip-auth` runs end-to-end
- [x] `package-lock.json` resolves the lib from npm registry under the new name
- [ ] Reviewer: confirm `.dt-eval.yaml` and `~/.dt-eval/` are intentionally untouched (follow-up migration)

## Out of scope / follow-ups

- Migration for `.dt-eval.yaml` → `.dt-evals.yaml` and `~/.dt-eval/` → `~/.dt-evals/` with a one-time auto-rename on first run.
- `npm deprecate` on the old `@dynatrace-oss/dt-eval` package once 0.1.5-alpha ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)