### PR TITLE
ci: align release-please + PR-title config with dt-evals rename

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -40,6 +40,7 @@ jobs:
             main
             dt-ai-ingest
             dt-eval-lib
+            dt-eval-cli
           # Configure that a scope must always be provided.
           requireScope: false
           # When using "Squash and merge" on a PR with only one commit, GitHub

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ End-to-end LLM evaluation toolkit for Dynatrace AI Observability.
 ## Install
 
 ```bash
-npm install -g github:dynatrace-oss/dt-evals
+npm install -g @dynatrace-oss/dt-evals
 ```
 
 Or run without installing:
 
 ```bash
-npx github:dynatrace-oss/dt-evals <command>
+npx @dynatrace-oss/dt-evals <command>
 ```
 
 ## Quick Start

--- a/dt-eval-lib/README.md
+++ b/dt-eval-lib/README.md
@@ -5,7 +5,7 @@ Minimal TypeScript library for running LLM-as-a-judge evaluations.
 ## Install
 
 ```bash
-npm install
+npm install @dynatrace-oss/dt-eval-lib
 ```
 
 ## Build
@@ -23,7 +23,7 @@ npm test
 ## Quick Usage
 
 ```ts
-import { evaluate, BuiltInMetric } from "dt-eval-lib";
+import { evaluate, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
 
 const result = await evaluate(
   BuiltInMetric.Toxicity,
@@ -148,7 +148,7 @@ await evaluate(BuiltInMetric.Toxicity, input, {
 Metrics are identified by the `BuiltInMetric` enum. You can also pass a custom `PromptDefinition` object directly:
 
 ```ts
-import { evaluate, BuiltInMetric } from "dt-eval-lib";
+import { evaluate, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
 
 await evaluate(BuiltInMetric.Toxicity, input, config);   // built-in metric via enum
 await evaluate(myCustomPrompt, input, config);             // custom PromptDefinition object
@@ -157,7 +157,7 @@ await evaluate(myCustomPrompt, input, config);             // custom PromptDefin
 Use `listPrompts()` and `getPrompt()` to discover available metrics:
 
 ```ts
-import { listPrompts, getPrompt, BuiltInMetric } from "dt-eval-lib";
+import { listPrompts, getPrompt, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
 
 const all = listPrompts();                        // all 13 built-in metrics
 const tox = getPrompt(BuiltInMetric.Toxicity);    // single metric by ID
@@ -166,7 +166,7 @@ const tox = getPrompt(BuiltInMetric.Toxicity);    // single metric by ID
 ## Configuration
 
 ```ts
-import type { EvalConfig } from "dt-eval-lib";
+import type { EvalConfig } from "@dynatrace-oss/dt-eval-lib";
 
 const config: EvalConfig = {
   provider: {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,10 +6,10 @@
     "pull-request-title-pattern": "chore: release${component} ${version}",
     "packages": {
         "dt-eval-cli": {
-            "package-name": "dt-eval",
+            "package-name": "dt-evals",
             "changelog-path": "CHANGELOG.md",
             "release-type": "node",
-            "monorepo-tags": "dt-eval",
+            "monorepo-tags": "dt-evals",
             "prerelease": true,
             "prerelease-type": "alpha",
             "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

Follow-up to #65 (the package rename). Pure config — no source.

### release-please-config.json

For the `dt-eval-cli` package entry:
- `package-name`: `dt-eval` → `dt-evals`
- `monorepo-tags`: `dt-eval` → `dt-evals`

Without this, the changelog header release-please writes on the next CLI release would still say "dt-eval 0.1.5-alpha" while the published npm artifact is `@dynatrace-oss/dt-evals` — the rename was already merged in #65.

### .github/workflows/validate-pr-title.yaml

Adds `dt-eval-cli` to the allowed scope list. The other workspaces (`dt-ai-ingest`, `dt-eval-lib`) are already there; this was an existing inconsistency that the rename surfaced. PRs can now use `feat(dt-eval-cli):` or `fix(dt-eval-cli):` scoped titles. `requireScope: false` still applies, so this is opt-in.

## Out of scope

- Renaming the folder `dt-eval-cli/` itself — large blast radius, no functional gain (`@dynatrace-oss/dt-evals` is happy to live in a folder named `dt-eval-cli/`).
- Manifest / release.yml keys that match the folder path — internally consistent.

## Pre-merge notes

- npm trusted publisher for `@dynatrace-oss/dt-evals` is configured pointing at this repo + `release.yml` + `release` environment. CI publishes via OIDC after the next release-please cycle.
- Manual `@dynatrace-oss/dt-evals@0.1.4-alpha` was published from a workstation to bootstrap the new package name on npm.

## Test plan

- [ ] CI pipelines pass (no source code touched — should be a no-op for build/test)
- [ ] After merging, watch release-please open the `0.1.5-alpha` PR
- [ ] Confirm the CHANGELOG entry header in that PR shows `dt-evals` (not `dt-eval`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)