### PR TITLE
ci: add nightly evals workflow for pydantic-ai-music-agent

### DIFF
--- a/.github/workflows/evals-pydantic-ai-music-agent.yml
+++ b/.github/workflows/evals-pydantic-ai-music-agent.yml
@@ -1,0 +1,58 @@
+---
+name: Evals — pydantic-ai-music-agent
+
+on:
+  schedule:
+    - cron: "0 6 * * *"           # 06:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Time window (e.g. 1h, 6h, 24h)"
+        required: false
+        default: "24h"
+      sample:
+        description: "Sample percentage (overrides config)"
+        required: false
+      dry_run:
+        description: "Run without writing bizevents"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  run-evals:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      DT_ENV_URL: ${{ secrets.DT_ENV_URL }}
+      DT_API_TOKEN: ${{ secrets.DT_API_TOKEN }}
+      AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+      AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: "20"
+
+      - name: Install @dynatrace-oss/dt-evals
+        run: npm install -g "@dynatrace-oss/dt-evals@alpha"
+
+      - name: Run evaluations
+        run: |
+          set -euo pipefail
+          ARGS=(run \
+            --config evals/pydantic-ai-music-agent.dt-eval.yaml \
+            --since "${{ inputs.since || '24h' }}" \
+            --ci)
+          if [[ -n "${{ inputs.sample }}" ]]; then
+            ARGS+=(--sample "${{ inputs.sample }}")
+          fi
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            ARGS+=(--dry-run)
+          fi
+          dt-evals "${ARGS[@]}"

--- a/evals/pydantic-ai-music-agent.dt-eval.yaml
+++ b/evals/pydantic-ai-music-agent.dt-eval.yaml
@@ -1,0 +1,32 @@
+# Used by .github/workflows/evals-pydantic-ai-music-agent.yml.
+
+schemaVersion: 2
+name: pydantic-ai-music-agent
+
+dynatrace: {}
+
+judge:
+  provider: azure-openai
+  model: gpt-5.4-mini
+  apiVersion: 2025-04-01-preview
+  timeout: 60000
+  maxRetries: 2
+
+scope:
+  service: pydantic-ai-music-agent
+  sampling:
+    strategy: random
+    percent: 100
+  spanFields:
+    # Some Bedrock / Vertex SDK emitters serialize the assistant turn(s) under
+    # the plural attribute name; route output reads through it.
+    output: gen_ai.output.messages
+
+metrics:
+  enabled:
+    - fluency
+    - toxicity
+    - relevance
+    - user-frustration
+    - prompt-injection
+    - bias


### PR DESCRIPTION
## Summary

Adds a nightly GitHub Actions workflow that runs continuous LLM-as-a-judge evals against the `pydantic-ai-music-agent` service via the just-published `@dynatrace-oss/dt-evals` CLI, writing the results back to Dynatrace as bizevents.

**Two new files:**

- `evals/pydantic-ai-music-agent.dt-eval.yaml` — eval config (no secrets, no tenant URLs)
- `.github/workflows/evals-pydantic-ai-music-agent.yml` — cron + workflow_dispatch trigger

**Metrics evaluated:** `fluency`, `toxicity`, `relevance`, `user-frustration`, `prompt-injection`, `bias`.

**Cadence:** `0 6 * * *` UTC daily, plus manual `workflow_dispatch` with overridable `since` / `sample` / `dry_run` inputs.

## Security posture

The config file deliberately **does not** check in any of:

- Dynatrace tenant URL
- Azure OpenAI endpoint
- Any API token or key

All four are loaded via env vars at runtime by the CLI's config loader (`dt-eval-cli/src/config/index.ts:84-122`), which substitutes:

| Env var | Field |
|---|---|


## Required setup before merge

All four secrets must exist as **GitHub Actions repository secrets** (or environment secrets if hardening with the `evals-prod` environment):


## Test plan

- [ ] All four secrets configured under repo Settings → Secrets
- [ ] Trigger via Actions tab on this branch (`workflow_dispatch`) with `since=1h`, `sample=5`, `dry_run=true` — verifies env wiring without writing bizevents
- [ ] Trigger again with `dry_run=false`, `sample=5` — verifies write path
- [ ] Confirm bizevents in DT via DQL: `fetch bizevents | filter event.provider == "dt-eval-cli" | filter dt.service.name == "pydantic-ai-music-agent" | sort timestamp desc | limit 20`
- [ ] Merge to main
- [ ] First scheduled run on `06:00 UTC` next day completes green

## Notes

- The cron only fires from the **default branch**, so the schedule activates only after merge. Until then, use `workflow_dispatch` against this branch for testing.
- Action versions are pinned by SHA, matching the existing CI workflows' security posture.
- Sample is set to `100%` in the config; CI runs use the default unless overridden via the `sample` workflow input. Worth revisiting once we see span volume in production.

