### PR TITLE
ci: work around #69 by installing dt-evals + openai SDK as siblings

### DIFF
--- a/.github/workflows/evals-pydantic-ai-music-agent.yml
+++ b/.github/workflows/evals-pydantic-ai-music-agent.yml
@@ -39,8 +39,17 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install @dynatrace-oss/dt-evals
-        run: npm install -g "@dynatrace-oss/dt-evals@alpha"
+      # Workaround for dynatrace-oss/dt-evals#69: the CLI's lib code
+      # imports the openai SDK lazily for the azure-openai/openai providers,
+      # but the SDK is declared as an optional peer dep on the lib and
+      # nothing in the CLI's own dependencies pulls it in. Install both
+      # packages locally so they hoist as siblings → resolution works.
+      - name: Install @dynatrace-oss/dt-evals + Azure OpenAI SDK
+        run: |
+          npm init -y --silent >/dev/null
+          npm install \
+            "@dynatrace-oss/dt-evals@alpha" \
+            "openai@^4.73.0"
 
       - name: Run evaluations
         run: |
@@ -55,4 +64,4 @@ jobs:
           if [[ "${{ inputs.dry_run }}" == "true" ]]; then
             ARGS+=(--dry-run)
           fi
-          dt-evals "${ARGS[@]}"
+          ./node_modules/.bin/dt-evals "${ARGS[@]}"


### PR DESCRIPTION
## Summary

Follow-up to #68 (the nightly evals workflow). The first scheduled-style run of that workflow failed because the published CLI doesn't ship the LLM provider SDKs — full diagnosis in **#69**.

Until #69 is fixed and a new CLI release is published, this PR patches the music-agent workflow to install both `@dynatrace-oss/dt-evals` and `openai` as siblings in a local `node_modules`. Node's resolution then finds `openai` from inside the dt-eval-lib chunk.

## Diff

`.github/workflows/evals-pydantic-ai-music-agent.yml`:

```diff
- - name: Install @dynatrace-oss/dt-evals
-   run: npm install -g "@dynatrace-oss/dt-evals@alpha"
+ # Workaround for #69: the CLI's lib code imports the openai SDK
+ # lazily, but the SDK isn't in the CLI's dependency tree. Install
+ # both packages locally so they hoist as siblings → resolution works.
+ - name: Install @dynatrace-oss/dt-evals + Azure OpenAI SDK
+   run: |
+     npm init -y --silent >/dev/null
+     npm install "@dynatrace-oss/dt-evals@alpha" "openai@^4.73.0"

   - name: Run evaluations
     run: |
       ...
-       dt-evals "${ARGS[@]}"
+       ./node_modules/.bin/dt-evals "${ARGS[@]}"
```

## Test plan

- [ ] After merge: trigger workflow via Actions tab with `since=1h`, `sample=5`, `dry_run=true` — expect all 6 metrics to actually score without `Cannot find package 'openai'`
- [ ] Same with `dry_run=false` — confirm bizevents in DT
- [ ] Once #69 is fixed and released: revert this PR (or open a follow-up that restores the global install)

## Reverting later

When the proper fix in #69 ships:

```bash
git revert <this-commit-sha>
```

…then a one-line diff goes back to `npm install -g @dynatrace-oss/dt-evals@alpha` + `dt-evals run ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)