### PR TITLE
fix(dt-eval-cli): use explicit DQL timeframe so --since over 2h returns data

### DIFF
--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -45,13 +45,12 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
   const { app, since, limit = 1000, errorsOnly = false, spanFields } = opts;
   const fields = resolveFields(spanFields);
 
-  const lines: string[] = ['fetch spans'];
+  // Use explicit from:/to: timeframe — a filter alone leaves Grail's default
+  // ~2h analysis window in effect even when the filter asks for longer.
+  const lines: string[] = [`fetch spans, from:now() - ${since}, to:now()`];
 
   // Support both OTel GenAI semconv (gen_ai.system) and OpenLLMetry (gen_ai.provider.name)
   lines.push('| filter isNotNull(gen_ai.system) or isNotNull(gen_ai.provider.name)');
-
-  // Spans use start_time, not timestamp
-  lines.push(`| filter start_time > now() - ${since}`);
 
   if (app) {
     // Match by either service.name (OTel GenAI semconv) or dt.service.name

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -2,17 +2,21 @@ import { describe, it, expect } from 'vitest';
 import { buildGenAiSpanQuery, parseSpanResults } from '../../src/dt/dql.js';
 
 describe('buildGenAiSpanQuery', () => {
-  it('includes start_time filter with the given since value', () => {
+  it('uses explicit from:/to: timeframe (not a filter clause) for the given since value', () => {
     const query = buildGenAiSpanQuery({ since: '1h' });
-    expect(query).toContain('start_time > now() - 1h');
+    expect(query).toContain('fetch spans, from:now() - 1h, to:now()');
+    // The filter-based form leaves Grail's default ~2h scan window in place
+    // regardless of the since value — guard against the old shape being
+    // reintroduced.
+    expect(query).not.toContain('filter start_time');
   });
 
-  it('uses the correct since duration in filter', () => {
+  it('uses the correct since duration in the timeframe clause', () => {
     const query24h = buildGenAiSpanQuery({ since: '24h' });
-    expect(query24h).toContain('start_time > now() - 24h');
+    expect(query24h).toContain('from:now() - 24h, to:now()');
 
     const query6h = buildGenAiSpanQuery({ since: '6h' });
-    expect(query6h).toContain('start_time > now() - 6h');
+    expect(query6h).toContain('from:now() - 6h, to:now()');
   });
 
   it('filters on both gen_ai.system and gen_ai.provider.name', () => {


### PR DESCRIPTION
## Summary

The GenAI span DQL query emitted by the CLI uses a `filter` clause to constrain the time range:

```dql
fetch spans
| filter isNotNull(gen_ai.system) or isNotNull(gen_ai.provider.name)
| filter start_time > now() - <since>
| filter service.name == "<svc>" or dt.service.name == "<svc>"
| fields ...
| limit 1000
```

Grail decides the scan window *before* applying filters. With no explicit `from:/to:` clause it defaults to **~2 h** regardless of what the `filter start_time` line says. So any `--since` longer than ~2 h silently returns zero spans even when matching data plainly exists.

## Reproduction (live tenant)

Service with 1,691 GenAI spans in the last 7 days:

```bash
# Old shape — returns 0
dt-evals run my.dt-eval.yaml --since 7d --sample 5 --debug
# [debug] DQL query:
#   fetch spans
#   | filter isNotNull(gen_ai.system) or isNotNull(gen_ai.provider.name)
#   | filter start_time > now() - 7d
#   ...
# → 0 spans

# Same query with explicit from:/to: (verified by raw POST) — returns 25
fetch spans, from:now() - 7d, to:now()
| filter isNotNull(gen_ai.system) or isNotNull(gen_ai.provider.name)
| filter service.name == "pydantic-ai-music-agent" or dt.service.name == "pydantic-ai-music-agent"
| limit 5
```

The `metadata.grail.analysisTimeframe` on the broken response is a 2-hour window even though the query asked for 7 days — proof that the filter doesn't widen the scan.

## Fix

`src/dt/dql.ts` — emit the timeframe as part of `fetch spans, from:..., to:...` and drop the redundant `filter start_time` clause. The set of spans visible to downstream filters is identical; only the scan window changes.

```diff
- const lines: string[] = ['fetch spans'];
+ const lines: string[] = [\`fetch spans, from:now() - \${since}, to:now()\`];
  lines.push('| filter isNotNull(gen_ai.system) or isNotNull(gen_ai.provider.name)');
- // Spans use start_time, not timestamp
- lines.push(\`| filter start_time > now() - \${since}\`);
```

## Test plan

- [x] Tests updated: assert the new `fetch spans, from:..., to:now()` shape and guard against `filter start_time` being reintroduced
- [x] `npm test` — 158/158 passing
- [x] `npx tsc --noEmit` clean
- [x] Live smoke test against a real tenant: switched from 0 spans → 25 spans returned with `--since 7d`, eval run completed end-to-end (55 results written to Dynatrace, ~48 s)

## Impact

This unblocks every user trying to evaluate over a window longer than ~2 h. Practically that's every CI cadence (nightly runs use `--since 24h`), all backfill / catch-up flows, and any drift detection (`--since 7d` baseline). The fix is a single-line code change plus a comment.

## Affected versions

All published CLI versions on the alpha track. Worth flagging in the next release notes as a behavior change — runs that historically returned 0 will now return real data, which may surface latent issues (judge cost spikes, content-filter rejections from real production data, etc.).