### PR TITLE
feat(dt-eval-cli): validate accepts a config file path argument

### DIFF
--- a/dt-eval-cli/src/cli/commands/validate.ts
+++ b/dt-eval-cli/src/cli/commands/validate.ts
@@ -92,15 +92,19 @@ export function createValidateCommand(): Command {
   const cmd = new Command('validate');
   cmd.description('Run pre-flight checks on config, connectivity, and evaluator keys');
 
-  cmd.action(async () => {
+  cmd.argument('[config]', 'Path to eval config file (e.g. my-service.dt-eval.yaml)');
+  cmd.option('--config <path>', 'Path to eval config file (alias for positional argument)');
+
+  cmd.action(async (configArg: string | undefined, options: { config?: string }) => {
     console.log('Running pre-flight checks...\n');
 
+    const configPath = configArg ?? options.config;
     let config;
     let configValid = false;
 
     // 1. Schema validation
     try {
-      config = loadConfig();
+      config = loadConfig(configPath ? { projectFile: configPath } : undefined);
       validateConfig(config);
       configValid = true;
       logger.success('Config schema valid');


### PR DESCRIPTION
## Summary

`dt-evals run` accepts a config path two ways:

```bash
dt-evals run my-service.dt-eval.yaml          # positional
dt-evals run --config path/to/file            # flag
```

`dt-evals validate` accepts neither. So users who keep multiple configs in one directory (`service-a.dt-eval.yaml`, `service-b.dt-eval.yaml`) can't validate any of them without first symlinking or renaming to `.dt-eval.yaml`. Worse, when no `.dt-eval.yaml` exists in cwd and no global `~/.dt-eval/config.yaml` is set, `loadConfig()` silently falls back to built-in defaults — validate then validates an imaginary config with `judge.provider: openai`, which makes it look like a configuration problem when the user's actual configs are perfectly fine.

This PR adds the same signature to `validate` as `run` already has.

## Behavior after this PR

```bash
dt-evals validate                              # default lookup (cwd → global → defaults)
dt-evals validate my-service.dt-eval.yaml      # positional
dt-evals validate --config path/to/file        # flag alias
```

Pass-through to `loadConfig({ projectFile })` is identical to how `run` already wires this — no new code paths in the config loader.

## What this does NOT fix

A related defect (out of scope for this PR — separate PR follows):
* `validate` prints `All checks passed. Ready to run evaluations.` even when connectivity / provider checks failed, because the exit decision only looks at the schema-validity flag. That's a failure-tracking bug, not a config-loading bug. Fixing it requires touching all the check sites, which is a bigger change worth reviewing on its own.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 158/158 passing (no test changes needed; commander adds the new option declaratively)
- [x] `dt-evals validate --help` lists both `[config]` arg and `--config <path>` option
- [x] `dt-evals validate ./demo.dt-eval.yaml` loads the demo config (verified locally)