### PR TITLE
fix(dt-eval-cli): validate counts all failures and warns on default fallback

### DIFF
--- a/dt-eval-cli/src/cli/commands/validate.ts
+++ b/dt-eval-cli/src/cli/commands/validate.ts
@@ -1,4 +1,7 @@
 import { Command } from 'commander';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { loadConfig, validateConfig } from '../../config/index.js';
 import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
 import { DynatraceClient } from '../../dt/client.js';
@@ -98,18 +101,42 @@ export function createValidateCommand(): Command {
   cmd.action(async (configArg: string | undefined, options: { config?: string }) => {
     console.log('Running pre-flight checks...\n');
 
-    const configPath = configArg ?? options.config;
+    const explicitConfigPath = configArg ?? options.config;
+
+    // 0. Surface the no-config-found case loudly. loadConfig() silently
+    //    falls back to built-in defaults, which makes the rest of the report
+    //    look like "wrong provider configured" when the real issue is "no
+    //    config picked up at all". When the user passes an explicit path,
+    //    error out instead — they clearly meant *that* file.
+    let failures = 0;
+    if (explicitConfigPath) {
+      if (!existsSync(explicitConfigPath)) {
+        logger.error(`Config file not found: ${explicitConfigPath}`);
+        process.exit(1);
+      }
+    } else {
+      const projectConfigPath = join(process.cwd(), '.dt-eval.yaml');
+      const globalConfigPath = join(homedir(), '.dt-eval', 'config.yaml');
+      const usingDefaults = !existsSync(projectConfigPath) && !existsSync(globalConfigPath);
+      if (usingDefaults) {
+        logger.warn(
+          `No .dt-eval.yaml in ${process.cwd()} and no ${globalConfigPath} — ` +
+          `running checks against built-in defaults (probably not what you want). ` +
+          `Pass a config path: dt-evals validate <my-service.dt-eval.yaml>`,
+        );
+      }
+    }
+
     let config;
-    let configValid = false;
 
     // 1. Schema validation
     try {
-      config = loadConfig(configPath ? { projectFile: configPath } : undefined);
+      config = loadConfig(explicitConfigPath ? { projectFile: explicitConfigPath } : undefined);
       validateConfig(config);
-      configValid = true;
       logger.success('Config schema valid');
     } catch (err) {
       logger.error(`Config schema invalid: ${(err as Error).message}`);
+      failures++;
     }
 
     if (!config) {
@@ -126,6 +153,7 @@ export function createValidateCommand(): Command {
     for (const [label, side] of sides) {
       if (!side.apiToken) {
         logger.error(`${label} API token not set  (${side.environmentUrl || 'no url'})`);
+        failures++;
         continue;
       }
       const dtOk = await testDynatraceConnection(side.environmentUrl, side.apiToken);
@@ -133,6 +161,7 @@ export function createValidateCommand(): Command {
         logger.success(`${label} connection  (${side.environmentUrl})`);
       } else {
         logger.error(`${label} connection failed  (${side.environmentUrl})`);
+        failures++;
         continue;
       }
 
@@ -145,6 +174,7 @@ export function createValidateCommand(): Command {
         } else {
           logger.error(`origin cannot read spans bucket: ${probe.reason}`);
           logger.error(`  → token needs storage:spans:read (and storage:buckets:read)`);
+          failures++;
         }
       }
     }
@@ -160,6 +190,7 @@ export function createValidateCommand(): Command {
       logger.success(`Evaluator provider reachable  (${config.judge.provider}, model: ${aiModel ?? 'unknown'})`);
     } else {
       logger.error(`Evaluator provider unreachable or API key invalid  (${config.judge.provider})`);
+      failures++;
     }
 
     // 4. Evaluators
@@ -171,12 +202,13 @@ export function createValidateCommand(): Command {
       logger.success(`${custom.length} custom evaluators loaded`);
     } catch (err) {
       logger.error(`Failed to load evaluators: ${(err as Error).message}`);
+      failures++;
     }
 
-    if (configValid) {
+    if (failures === 0) {
       console.log('\nAll checks passed. Ready to run evaluations.');
     } else {
-      console.log('\nSome checks failed. Run "dt-evals configure" to fix issues.');
+      console.log(`\n${failures} check${failures === 1 ? '' : 's'} failed. Run "dt-evals configure" to fix issues.`);
       process.exit(1);
     }
   });


### PR DESCRIPTION
## Summary

Two related defects in `dt-evals validate` that together make the command misleading:

### Bug 1 — final summary ignores every check except schema

The exit decision looked only at `configValid` (the schema-validity flag). So a run like:

```
✓ Config schema valid
✖ origin connection failed
✖ destination connection failed
✖ Evaluator provider unreachable or API key invalid (openai)
✓ 14 built-in evaluators available

All checks passed. Ready to run evaluations.    ← reported by old code
```

…prints "All checks passed" while listing four ✖ lines immediately above. Misleading, and worse, the process exits 0 — CI gates pass when they shouldn't.

### Bug 2 — silent fallback to built-in defaults

`loadConfig()` returns `DEFAULT_CONFIG` when no `./.dt-eval.yaml` and no `~/.dt-eval/config.yaml` are found. `validate` then probes an imaginary config — typically `judge.provider: openai` with no `apiKey` — which makes the failure look like a misconfigured provider when the real issue is "the intended config wasn't picked up at all."

Hit reliably by users with multiple named configs in one directory (`service-a.dt-eval.yaml`, `service-b.dt-eval.yaml`, …) — none of those are the default name, so `validate` reports against thin air.

## Fix

`src/cli/commands/validate.ts`:

1. Replace the single `configValid` flag with a `failures` counter that every check site increments on error.
2. Final summary uses the actual failure count and exits 1 when `> 0`:
   ```
   4 checks failed. Run "dt-evals configure" to fix issues.
   ```
3. Before any check runs, detect the silent-default-fallback case (neither project nor global config exists) and emit a loud warning:
   ```
   ⚠ No .dt-eval.yaml in <cwd> and no ~/.dt-eval/config.yaml — running checks
     against built-in defaults (probably not what you want).
     Pass a config path: dt-evals validate <my-service.dt-eval.yaml>
   ```

## Smoke test against an empty directory

**Before:**
```
Running pre-flight checks...
✖ Config schema invalid: dynatrace.origin.environmentUrl is required ...
✖ origin API token not set
✖ destination API token not set
✖ Evaluator provider unreachable or API key invalid  (openai)
✓ 14 built-in evaluators available

All checks passed. Ready to run evaluations.        ← wrong, exit 0
```

**After:**
```
Running pre-flight checks...

⚠ No .dt-eval.yaml in /tmp/foo and no ~/.dt-eval/config.yaml — running
  checks against built-in defaults (probably not what you want).
  Pass a config path: dt-evals validate <my-service.dt-eval.yaml>
✖ Config schema invalid: dynatrace.origin.environmentUrl is required ...
✖ origin API token not set
✖ destination API token not set
✖ Evaluator provider unreachable or API key invalid  (openai)
✓ 14 built-in evaluators available

4 checks failed. Run "dt-evals configure" to fix issues.     ← exit 1
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 158/158 passing
- [x] Live smoke in an empty dir — see "After" above; exit code 1
- [x] Live smoke in a real eval-config dir with valid token + provider — silent (no warning), all checks pass, exit 0

## Related PRs (separate, can land in any order)

* PR #84 — `fix(dql)`: `--since > ~2h` returns 0 spans because of a `filter` vs `from:/to:` mismatch
* PR #85 — `feat(validate)`: accept config path as positional arg / `--config` flag. Lands the *ability* to point validate at a specific file; this PR fixes what happens *when no file is found at all*. They compose: with both merged, the warning in this PR will only fire when neither an explicit path nor an implicit one resolves.

## Behavior change for CI

Anyone whose CI does `dt-evals validate` against a directory without a default `.dt-eval.yaml` will start seeing exit 1 with this change. That's intentional — the previous behavior of exit 0 was wrong. Worth mentioning in release notes.