### PR TITLE
feat(dt-eval-cli): make judge concurrency configurable in yaml

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -23,9 +23,11 @@ The repository also includes `dt-eval-lib`, a reusable TypeScript evaluation eng
 ```bash
 npx @dynatrace-oss/dt-evals configure
 npx @dynatrace-oss/dt-evals validate
-npx @dynatrace-oss/dt-evals run --since 1h --sample 10
+npx @dynatrace-oss/dt-evals run --since 1h --sample 10 --concurrency 10
 npx @dynatrace-oss/dt-evals deploy --provider aws
 ```
+
+Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many judge calls run in parallel — bump it for faster runs, drop it if the provider rate-limits you. Default is 5.
 
 ## Why Teams Use It
 
@@ -261,7 +263,7 @@ Global flags:
 --metric <name>        Run only one evaluator
 --dry-run              Do not call the judge or write results
 --ci                   JSON result output and exit 1 on threshold breach
---concurrency <n>      Number of parallel evaluation workers
+--concurrency <n>      Parallel judge calls (overrides judge.concurrency in the config; default 5)
 --debug                Per-step timing logs
 ```
 
@@ -292,6 +294,7 @@ judge:
   model: gpt-4.1
   timeout: 30000
   maxRetries: 2
+  concurrency: 5         # parallel judge calls; --concurrency overrides this
 
 scope:
   service: travel-assistant

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -45,6 +45,11 @@ judge:
   # Number of retries on transient failures (default: 2).
   maxRetries: 2
 
+  # Number of judge calls to run in parallel (default: 5).
+  # Bump this to speed up large runs; lower it if you hit provider rate limits.
+  # Overridable per-invocation with `--concurrency`.
+  concurrency: 5
+
 # ---------------------------------------------------------------------------
 # Scope — which spans to evaluate
 # ---------------------------------------------------------------------------

--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -80,7 +80,7 @@ export function createRunCommand(): Command {
   cmd.option('--metric <name>', 'Run a specific evaluator only');
   cmd.option('--dry-run', 'Fetch and transform traces, print payloads, do not send');
   cmd.option('--ci', 'Non-interactive mode: JSON stdout, exit 1 on threshold breach');
-  cmd.option('--concurrency <n>', 'Number of parallel evaluation workers', (v) => parseInt(v, 10), 5);
+  cmd.option('--concurrency <n>', 'Number of parallel evaluation workers (overrides judge.concurrency in the config; default 5)', (v) => parseInt(v, 10));
   cmd.option('--debug', 'Enable debug logging with per-step timing');
 
   cmd.action(async (configArg: string | undefined, options: {
@@ -90,7 +90,7 @@ export function createRunCommand(): Command {
     metric?: string;
     dryRun?: boolean;
     ci?: boolean;
-    concurrency: number;
+    concurrency?: number;
     debug?: boolean;
   }) => {
     if (options.debug) {
@@ -145,7 +145,7 @@ export function createRunCommand(): Command {
         metrics: options.metric ? [options.metric] : undefined,
         dryRun: options.dryRun,
         ci: options.ci,
-        concurrency: options.concurrency,
+        concurrency: options.concurrency ?? config.judge.concurrency,
         onProgress,
       });
 

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -33,6 +33,7 @@ export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {
     provider: 'openai',
     timeout: 30000,
     maxRetries: 2,
+    concurrency: 5,
   },
   scope: {
     since: '1h',

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -140,6 +140,7 @@ export function resolveEffectiveConfig(partial: Partial<DtEvalConfig>): DtEvalCo
       provider: DEFAULT_CONFIG.judge.provider ?? 'openai',
       timeout: DEFAULT_CONFIG.judge.timeout,
       maxRetries: DEFAULT_CONFIG.judge.maxRetries,
+      concurrency: DEFAULT_CONFIG.judge.concurrency,
     },
     scope: { ...DEFAULT_CONFIG.scope },
     metrics: { ...DEFAULT_CONFIG.metrics },
@@ -200,6 +201,13 @@ export function validateConfig(config: DtEvalConfig): void {
     issues.push('judge.provider is required');
   } else if (!['openai', 'anthropic', 'azure-openai', 'gemini', 'bedrock'].includes(config.judge.provider)) {
     issues.push(`judge.provider must be one of: openai, anthropic, azure-openai, gemini, bedrock (got "${config.judge.provider}")`);
+  }
+
+  if (config.judge?.concurrency !== undefined) {
+    const c = config.judge.concurrency;
+    if (!Number.isInteger(c) || c < 1) {
+      issues.push(`judge.concurrency must be a positive integer (got ${JSON.stringify(c)})`);
+    }
   }
 
   if (!config.scope?.since) {

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -203,7 +203,7 @@ export function validateConfig(config: DtEvalConfig): void {
     issues.push(`judge.provider must be one of: openai, anthropic, azure-openai, gemini, bedrock (got "${config.judge.provider}")`);
   }
 
-  if (config.judge?.concurrency !== undefined) {
+  if (config.judge?.concurrency) {
     const c = config.judge.concurrency;
     if (!Number.isInteger(c) || c < 1) {
       issues.push(`judge.concurrency must be a positive integer (got ${JSON.stringify(c)})`);

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -33,6 +33,12 @@ export interface JudgeConfig {
   model?: string;
   timeout?: number;
   maxRetries?: number;
+  /**
+   * Number of judge calls to run in parallel. Higher values speed up large runs
+   * but increase pressure on the provider's rate limits. Default: 5.
+   * Overridable per-invocation with `--concurrency`.
+   */
+  concurrency?: number;
   /** For Bedrock: AWS region (e.g. us-east-1). Falls back to AWS_DEFAULT_REGION / AWS_REGION env vars. */
   region?: string;
 }


### PR DESCRIPTION
## Summary

- Add `judge.concurrency` to the CLI yaml schema (validated as a positive integer, default `5`)
- `--concurrency` now overrides the yaml value instead of being the only knob
- Document the new field in `example.dt-eval.yaml` and bump its visibility in the README (hero block + Example config + flag reference)

## Motivation

Concurrency materially affects run wall-clock time, but today it's a CLI-only flag with a hardcoded default of `5` — invisible in the yaml schema and easy to miss on a 100+ span run. Putting it in the config (next to `timeout` / `maxRetries`, which are the other judge-throughput knobs) lets teams persist a sensible value per project and surfaces it where users actually read about the tool.

## Test plan

- [x] `npm test` — 158/158 passing
- [x] `npx tsc --noEmit` — clean
- [ ] manual: run with `judge.concurrency: 10` in yaml, no `--concurrency` flag → 10 workers
- [ ] manual: run with `judge.concurrency: 10` in yaml + `--concurrency 20` → 20 workers
- [ ] manual: omit both → default 5 workers
- [ ] manual: set `judge.concurrency: 0` → validation error