### PR TITLE
fix(dt-eval-cli): persist eval errors + probe real model in doctor/validate

### DIFF
--- a/dt-eval-cli/src/cli/commands/doctor.ts
+++ b/dt-eval-cli/src/cli/commands/doctor.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import pc from 'picocolors';
 import { Spinner } from '../../ui/spinner.js';
 import { loadConfig, validateConfig } from '../../config/index.js';
-import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
+import { probeProvider } from '../../probe/provider.js';
 import * as dtctl from '../../dtctl/index.js';
 import { printDoctorBanner } from '../../ui/banner.js';
 
@@ -77,60 +77,26 @@ async function getPackageVersion(pkgName: string): Promise<string | null> {
   }
 }
 
+// `testAiProvider` is now a thin shim around the shared `probeProvider` helper
+// so doctor and validate report the same model+key+region failures the runtime
+// will hit. The helper sends a real 1-token inference request, so wrong model
+// ids (e.g. `sonnet` → 404 `model: sonnet`) and bad regions surface as the
+// actual upstream error instead of "API reachable".
 async function testAiProvider(
   provider: string,
   apiKey?: string,
   model?: string,
-  opts?: { baseUrl?: string; region?: string },
+  opts?: { baseUrl?: string; region?: string; apiVersion?: string; secretKey?: string },
 ): Promise<{ ok: boolean; model: string; error?: string }> {
-  const resolvedModel = model ?? DEFAULT_JUDGE_MODELS[provider] ?? 'unknown';
-  try {
-    if (provider === 'openai') {
-      const key = apiKey ?? process.env['OPENAI_API_KEY'];
-      if (!key) return { ok: false, model: resolvedModel, error: 'No API key configured' };
-      const r = await fetch('https://api.openai.com/v1/models', {
-        headers: { Authorization: `Bearer ${key}` },
-        signal: AbortSignal.timeout(8000),
-      });
-      return { ok: r.ok, model: resolvedModel };
-    }
-    if (provider === 'anthropic') {
-      const key = apiKey ?? process.env['ANTHROPIC_API_KEY'];
-      if (!key) return { ok: false, model: resolvedModel, error: 'No API key configured' };
-      const r = await fetch('https://api.anthropic.com/v1/models', {
-        headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01' },
-        signal: AbortSignal.timeout(8000),
-      });
-      return { ok: r.ok, model: resolvedModel };
-    }
-    if (provider === 'azure-openai') {
-      const key = apiKey ?? process.env['AZURE_OPENAI_API_KEY'];
-      const endpoint = opts?.baseUrl ?? process.env['AZURE_OPENAI_ENDPOINT'];
-      if (!key || !endpoint) return { ok: false, model: resolvedModel, error: 'API key or endpoint not configured' };
-      const url = `${endpoint.replace(/\/$/, '')}/openai/models?api-version=2024-02-01`;
-      const r = await fetch(url, { headers: { 'api-key': key }, signal: AbortSignal.timeout(8000) });
-      return { ok: r.ok, model: resolvedModel };
-    }
-    if (provider === 'gemini') {
-      const key = apiKey ?? process.env['GEMINI_API_KEY'] ?? process.env['GOOGLE_API_KEY'];
-      if (!key) return { ok: false, model: resolvedModel, error: 'No API key configured' };
-      const r = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models?key=${key}`,
-        { signal: AbortSignal.timeout(8000) },
-      );
-      return { ok: r.ok, model: resolvedModel };
-    }
-    if (provider === 'bedrock') {
-      const hasCredentials =
-        !!(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY']) ||
-        !!process.env['AWS_ROLE_ARN'] ||
-        !!(opts?.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION']);
-      return { ok: hasCredentials, model: resolvedModel, error: hasCredentials ? undefined : 'AWS credentials not found in environment' };
-    }
-    return { ok: false, model: resolvedModel, error: `Unknown provider: ${provider}` };
-  } catch (err) {
-    return { ok: false, model: resolvedModel, error: (err as Error).message };
-  }
+  return probeProvider({
+    provider,
+    apiKey,
+    model,
+    baseUrl: opts?.baseUrl,
+    region: opts?.region,
+    apiVersion: opts?.apiVersion,
+    secretKey: opts?.secretKey,
+  });
 }
 
 function analyzeRunHistory(runsPath: string): {
@@ -605,16 +571,21 @@ export function createDoctorCommand(): Command {
         providerConfig.provider,
         providerConfig.apiKey,
         providerConfig.model,
-        { baseUrl: providerConfig.baseUrl, region: providerConfig.region },
+        {
+          baseUrl: providerConfig.baseUrl,
+          region: providerConfig.region,
+          apiVersion: providerConfig.apiVersion,
+          secretKey: providerConfig.secretKey,
+        },
       );
 
       console.log(`  Provider: ${providerConfig.provider} / ${model}`);
 
       if (providerOk) {
-        ok(`${providerConfig.provider} API reachable`);
+        ok(`${providerConfig.provider} inference probe succeeded`);
         ok(`Model: ${model}`);
       } else {
-        fail(`${providerConfig.provider} API unreachable or API key invalid`);
+        fail(`${providerConfig.provider} inference probe failed  (model: ${model})`);
         if (providerError) info(providerError);
 
         const envVarHints: Record<string, string> = {

--- a/dt-eval-cli/src/cli/commands/runs.ts
+++ b/dt-eval-cli/src/cli/commands/runs.ts
@@ -76,6 +76,12 @@ export function createRunsCommand(): Command {
     console.log(`Errors:              ${record.errors}`);
     console.log(`Threshold breaches:  ${record.thresholdBreaches}`);
     console.log(`Duration:            ${formatDuration(record.durationMs)}`);
+    if (record.errorSamples && record.errorSamples.length > 0) {
+      console.log(`\nSample errors:`);
+      for (const msg of record.errorSamples) {
+        console.log(`  • ${msg}`);
+      }
+    }
   });
 
   // runs export

--- a/dt-eval-cli/src/cli/commands/validate.ts
+++ b/dt-eval-cli/src/cli/commands/validate.ts
@@ -1,10 +1,10 @@
 import { Command } from 'commander';
 import { loadConfig, validateConfig } from '../../config/index.js';
-import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
 import { DynatraceClient } from '../../dt/client.js';
 import { resolveEndpoints } from '../../config/schema.js';
 import { listPrompts } from '@dynatrace-oss/dt-eval-lib';
 import { logger } from '../../logger/index.js';
+import { probeProvider } from '../../probe/provider.js';
 
 async function testDynatraceConnection(environmentUrl: string, apiToken: string): Promise<boolean> {
   try {
@@ -28,64 +28,24 @@ async function probeOriginSpansRead(
   }
 }
 
+// Thin wrapper around the shared probe so validate and doctor agree on what
+// "provider reachable" means: a real 1-token inference call with the configured
+// model, so wrong model ids / wrong regions surface here instead of at runtime.
 async function testAiProvider(
   provider: string,
   apiKey?: string,
   model?: string,
-  options?: { baseUrl?: string; region?: string },
-): Promise<{ ok: boolean; model?: string }> {
-  const resolvedModel = model ?? DEFAULT_JUDGE_MODELS[provider] ?? 'unknown';
-  try {
-    if (provider === 'openai') {
-      const key = apiKey ?? process.env['OPENAI_API_KEY'];
-      if (!key) return { ok: false };
-      const response = await fetch('https://api.openai.com/v1/models', {
-        headers: { Authorization: `Bearer ${key}` },
-        signal: AbortSignal.timeout(8000),
-      });
-      return { ok: response.ok, model: resolvedModel };
-    } else if (provider === 'anthropic') {
-      const key = apiKey ?? process.env['ANTHROPIC_API_KEY'];
-      if (!key) return { ok: false };
-      const response = await fetch('https://api.anthropic.com/v1/models', {
-        headers: {
-          'x-api-key': key,
-          'anthropic-version': '2023-06-01',
-        },
-        signal: AbortSignal.timeout(8000),
-      });
-      return { ok: response.ok, model: resolvedModel };
-    } else if (provider === 'azure-openai') {
-      const key = apiKey ?? process.env['AZURE_OPENAI_API_KEY'];
-      const endpoint = options?.baseUrl ?? process.env['AZURE_OPENAI_ENDPOINT'];
-      if (!key || !endpoint) return { ok: false };
-      // Probe the Azure OpenAI models list endpoint
-      const url = `${endpoint.replace(/\/$/, '')}/openai/models?api-version=2024-02-01`;
-      const response = await fetch(url, {
-        headers: { 'api-key': key },
-        signal: AbortSignal.timeout(8000),
-      });
-      return { ok: response.ok, model: resolvedModel };
-    } else if (provider === 'gemini') {
-      const key = apiKey ?? process.env['GEMINI_API_KEY'] ?? process.env['GOOGLE_API_KEY'];
-      if (!key) return { ok: false };
-      const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models?key=${key}`,
-        { signal: AbortSignal.timeout(8000) },
-      );
-      return { ok: response.ok, model: resolvedModel };
-    } else if (provider === 'bedrock') {
-      // Cannot probe Bedrock without the SDK + signing — just check AWS env vars are set
-      const hasCredentials =
-        !!(process.env['AWS_ACCESS_KEY_ID'] && process.env['AWS_SECRET_ACCESS_KEY']) ||
-        !!(process.env['AWS_ROLE_ARN']) ||
-        !!(options?.region ?? process.env['AWS_REGION']);
-      return { ok: hasCredentials, model: resolvedModel };
-    }
-    return { ok: false };
-  } catch {
-    return { ok: false };
-  }
+  options?: { baseUrl?: string; region?: string; apiVersion?: string; secretKey?: string },
+): Promise<{ ok: boolean; model: string; error?: string }> {
+  return probeProvider({
+    provider,
+    apiKey,
+    model,
+    baseUrl: options?.baseUrl,
+    region: options?.region,
+    apiVersion: options?.apiVersion,
+    secretKey: options?.secretKey,
+  });
 }
 
 export function createValidateCommand(): Command {
@@ -149,17 +109,24 @@ export function createValidateCommand(): Command {
       }
     }
 
-    // 3. AI provider
-    const { ok: aiOk, model: aiModel } = await testAiProvider(
+    // 3. AI provider — real inference probe so a wrong model id or region
+    //    surfaces as the actual upstream error, not "API reachable".
+    const { ok: aiOk, model: aiModel, error: aiError } = await testAiProvider(
       config.judge.provider,
       config.judge.apiKey,
       config.judge.model,
-      { baseUrl: config.judge.baseUrl, region: config.judge.region },
+      {
+        baseUrl: config.judge.baseUrl,
+        region: config.judge.region,
+        apiVersion: config.judge.apiVersion,
+        secretKey: config.judge.secretKey,
+      },
     );
     if (aiOk) {
-      logger.success(`Evaluator provider reachable  (${config.judge.provider}, model: ${aiModel ?? 'unknown'})`);
+      logger.success(`Evaluator provider reachable  (${config.judge.provider}, model: ${aiModel})`);
     } else {
-      logger.error(`Evaluator provider unreachable or API key invalid  (${config.judge.provider})`);
+      logger.error(`Evaluator provider check failed  (${config.judge.provider}, model: ${aiModel})`);
+      if (aiError) logger.error(`  ${aiError}`);
     }
 
     // 4. Evaluators

--- a/dt-eval-cli/src/probe/provider.ts
+++ b/dt-eval-cli/src/probe/provider.ts
@@ -1,0 +1,153 @@
+/**
+ * End-to-end probe of a judge provider + model + credentials combination.
+ *
+ * Unlike the older "list models" / "is the API base URL reachable" check,
+ * this fires a real minimal inference request with the configured model so
+ * issues like a bogus model id (e.g. `sonnet` instead of `claude-sonnet-4-6`),
+ * a wrong region for Bedrock, or a deployment name that doesn't exist on the
+ * Azure OpenAI endpoint surface as the actual upstream error string.
+ *
+ * Used by both `dt-evals doctor` and `dt-evals validate`.
+ */
+
+import { DEFAULT_JUDGE_MODELS } from '../config/defaults.js';
+
+export interface ProbeResult {
+  ok: boolean;
+  /** The model id the probe used (resolved from input or DEFAULT_JUDGE_MODELS). */
+  model: string;
+  /** Verbatim error string from the provider when ok=false; undefined on success. */
+  error?: string;
+}
+
+export interface ProbeOptions {
+  provider: string;
+  apiKey?: string;
+  /** AWS secret access key (Bedrock only). */
+  secretKey?: string;
+  model?: string;
+  /** Azure OpenAI endpoint, custom OpenAI/Anthropic gateway, etc. */
+  baseUrl?: string;
+  /** Azure OpenAI api-version. */
+  apiVersion?: string;
+  /** AWS region (Bedrock only). */
+  region?: string;
+  /** Per-request timeout. Default 12s — long enough for cold-start cases. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT = 12_000;
+
+/**
+ * Trim a long provider error response to a single readable line so it fits
+ * tidily in the doctor/validate output (and later in `runs show`). Strips
+ * leading/trailing JSON whitespace, collapses newlines, caps at 280 chars.
+ */
+function compactError(input: string): string {
+  return input.replace(/\s+/g, ' ').trim().slice(0, 280);
+}
+
+async function readErrorBody(r: Response): Promise<string> {
+  try {
+    return compactError(await r.text());
+  } catch {
+    return `${r.status} ${r.statusText}`;
+  }
+}
+
+export async function probeProvider(opts: ProbeOptions): Promise<ProbeResult> {
+  const provider = opts.provider;
+  const model = opts.model ?? DEFAULT_JUDGE_MODELS[provider] ?? 'unknown';
+  const timeout = opts.timeoutMs ?? DEFAULT_TIMEOUT;
+
+  try {
+    if (provider === 'openai') {
+      const key = opts.apiKey ?? process.env['OPENAI_API_KEY'];
+      if (!key) return { ok: false, model, error: 'No API key configured (set OPENAI_API_KEY or judge.apiKey)' };
+      const base = (opts.baseUrl ?? 'https://api.openai.com').replace(/\/$/, '');
+      const r = await fetch(`${base}/v1/chat/completions`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model, messages: [{ role: 'user', content: 'ok' }], max_tokens: 1 }),
+        signal: AbortSignal.timeout(timeout),
+      });
+      if (r.ok) return { ok: true, model };
+      return { ok: false, model, error: `${r.status} ${await readErrorBody(r)}` };
+    }
+
+    if (provider === 'anthropic') {
+      const key = opts.apiKey ?? process.env['ANTHROPIC_API_KEY'];
+      if (!key) return { ok: false, model, error: 'No API key configured (set ANTHROPIC_API_KEY or judge.apiKey)' };
+      const base = (opts.baseUrl ?? 'https://api.anthropic.com').replace(/\/$/, '');
+      const r = await fetch(`${base}/v1/messages`, {
+        method: 'POST',
+        headers: { 'x-api-key': key, 'anthropic-version': '2023-06-01', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model, max_tokens: 1, messages: [{ role: 'user', content: 'ok' }] }),
+        signal: AbortSignal.timeout(timeout),
+      });
+      if (r.ok) return { ok: true, model };
+      return { ok: false, model, error: `${r.status} ${await readErrorBody(r)}` };
+    }
+
+    if (provider === 'azure-openai') {
+      const key = opts.apiKey ?? process.env['AZURE_OPENAI_API_KEY'];
+      const endpoint = opts.baseUrl ?? process.env['AZURE_OPENAI_ENDPOINT'];
+      const apiVersion = opts.apiVersion ?? process.env['AZURE_OPENAI_API_VERSION'] ?? '2024-02-01';
+      if (!key || !endpoint) return { ok: false, model, error: 'API key or endpoint not configured' };
+      const url = `${endpoint.replace(/\/$/, '')}/openai/deployments/${encodeURIComponent(model)}/chat/completions?api-version=${apiVersion}`;
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: { 'api-key': key, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: [{ role: 'user', content: 'ok' }], max_tokens: 1 }),
+        signal: AbortSignal.timeout(timeout),
+      });
+      if (r.ok) return { ok: true, model };
+      return { ok: false, model, error: `${r.status} ${await readErrorBody(r)}` };
+    }
+
+    if (provider === 'gemini') {
+      const key = opts.apiKey ?? process.env['GEMINI_API_KEY'] ?? process.env['GOOGLE_API_KEY'];
+      if (!key) return { ok: false, model, error: 'No API key configured (set GEMINI_API_KEY or judge.apiKey)' };
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${encodeURIComponent(key)}`;
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ parts: [{ text: 'ok' }] }], generationConfig: { maxOutputTokens: 1 } }),
+        signal: AbortSignal.timeout(timeout),
+      });
+      if (r.ok) return { ok: true, model };
+      return { ok: false, model, error: `${r.status} ${await readErrorBody(r)}` };
+    }
+
+    if (provider === 'bedrock') {
+      const accessKeyId = opts.apiKey ?? process.env['AWS_ACCESS_KEY_ID'];
+      const secretAccessKey = opts.secretKey ?? process.env['AWS_SECRET_ACCESS_KEY'];
+      const region = opts.region ?? process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'] ?? 'us-east-1';
+      // Lazy-import so non-Bedrock users don't pay the SDK init cost on every doctor/validate run.
+      const { BedrockRuntimeClient, ConverseCommand } = await import('@aws-sdk/client-bedrock-runtime');
+      const client = new BedrockRuntimeClient({
+        region,
+        credentials: accessKeyId && secretAccessKey
+          ? { accessKeyId, secretAccessKey }
+          : undefined,
+      });
+      try {
+        await client.send(
+          new ConverseCommand({
+            modelId: model,
+            messages: [{ role: 'user', content: [{ text: 'ok' }] }],
+            inferenceConfig: { maxTokens: 1, temperature: 0 },
+          }),
+          { abortSignal: AbortSignal.timeout(timeout) },
+        );
+        return { ok: true, model };
+      } catch (err) {
+        return { ok: false, model, error: compactError((err as Error).message ?? String(err)) };
+      }
+    }
+
+    return { ok: false, model, error: `Unknown provider: ${provider}` };
+  } catch (err) {
+    return { ok: false, model, error: compactError((err as Error).message ?? String(err)) };
+  }
+}

--- a/dt-eval-cli/src/runner/checkpoint.ts
+++ b/dt-eval-cli/src/runner/checkpoint.ts
@@ -12,6 +12,14 @@ export interface RunRecord {
   durationMs: number;
   metrics: string[];
   since: string;
+  /**
+   * Top distinct error messages from failed evals on this run. Persisted so
+   * `dt-evals runs show <runId>` can surface them after the fact, not only
+   * during the live `dt-evals run` output. Capped to a few entries with
+   * `(×N)` suffix when duplicates collapse. Optional for back-compat with
+   * records written by older CLI versions.
+   */
+  errorSamples?: string[];
 }
 
 const DEFAULT_STORAGE_DIR = join(homedir(), '.dt-eval');

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -358,6 +358,7 @@ export async function runEvals(
     durationMs: result.durationMs,
     metrics: metricIds,
     since,
+    errorSamples: result.errorSamples.length > 0 ? result.errorSamples : undefined,
   });
 
   return result;

--- a/dt-eval-cli/tests/probe/provider.test.ts
+++ b/dt-eval-cli/tests/probe/provider.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { probeProvider } from '../../src/probe/provider.js';
+
+describe('probeProvider', () => {
+  const originalFetch = global.fetch;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clean slate for env vars the probe consults as fallbacks.
+    delete process.env['OPENAI_API_KEY'];
+    delete process.env['ANTHROPIC_API_KEY'];
+    delete process.env['AZURE_OPENAI_API_KEY'];
+    delete process.env['AZURE_OPENAI_ENDPOINT'];
+    delete process.env['GEMINI_API_KEY'];
+    delete process.env['GOOGLE_API_KEY'];
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('returns error when API key is not set', async () => {
+    const r = await probeProvider({ provider: 'openai', model: 'gpt-4.1' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/API key/);
+    expect(r.model).toBe('gpt-4.1');
+  });
+
+  it('anthropic: 404 model-not-found bubbles up verbatim', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () => '{"type":"error","error":{"type":"not_found_error","message":"model: sonnet"}}',
+    } as unknown as Response);
+
+    const r = await probeProvider({ provider: 'anthropic', apiKey: 'sk-test', model: 'sonnet' });
+    expect(r.ok).toBe(false);
+    expect(r.model).toBe('sonnet');
+    expect(r.error).toContain('404');
+    expect(r.error).toContain('model: sonnet');
+  });
+
+  it('openai: 200 success returns ok=true', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => '',
+    } as unknown as Response);
+
+    const r = await probeProvider({ provider: 'openai', apiKey: 'sk-test', model: 'gpt-4.1' });
+    expect(r.ok).toBe(true);
+    expect(r.error).toBeUndefined();
+    expect(r.model).toBe('gpt-4.1');
+  });
+
+  it('openai: POSTs to /v1/chat/completions, not /v1/models', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '' } as unknown as Response);
+    global.fetch = fetchMock;
+
+    await probeProvider({ provider: 'openai', apiKey: 'sk-test', model: 'gpt-4.1' });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/chat/completions');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string) as { model: string; max_tokens: number };
+    expect(body.model).toBe('gpt-4.1');
+    expect(body.max_tokens).toBe(1);
+  });
+
+  it('gemini: encodes model into URL path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '' } as unknown as Response);
+    global.fetch = fetchMock;
+
+    await probeProvider({ provider: 'gemini', apiKey: 'k', model: 'gemini-2.5-flash' });
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/models/gemini-2.5-flash:generateContent');
+    expect(url).toContain('key=k');
+  });
+
+  it('azure-openai: builds deployment URL from baseUrl + model', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '' } as unknown as Response);
+    global.fetch = fetchMock;
+
+    await probeProvider({
+      provider: 'azure-openai',
+      apiKey: 'k',
+      model: 'my-deployment',
+      baseUrl: 'https://my-resource.openai.azure.com/',
+      apiVersion: '2024-02-01',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://my-resource.openai.azure.com/openai/deployments/my-deployment/chat/completions?api-version=2024-02-01');
+    expect((init.headers as Record<string, string>)['api-key']).toBe('k');
+  });
+
+  it('unknown provider returns ok=false with descriptive error', async () => {
+    const r = await probeProvider({ provider: 'something-else', apiKey: 'k', model: 'foo' });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/Unknown provider/);
+  });
+
+  it('falls back to DEFAULT_JUDGE_MODELS when model is unset', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200, text: async () => '' } as unknown as Response);
+    global.fetch = fetchMock;
+
+    const r = await probeProvider({ provider: 'anthropic', apiKey: 'k' });
+    expect(r.model).not.toBe('unknown');
+    expect(r.model).toMatch(/claude/i);
+  });
+});

--- a/dt-eval-cli/tests/runner/checkpoint.test.ts
+++ b/dt-eval-cli/tests/runner/checkpoint.test.ts
@@ -69,6 +69,32 @@ describe('checkpoint', () => {
     expect(records[0]!.spansEvaluated).toBe(42);
   });
 
+  it('round-trips errorSamples when set on the record', async () => {
+    const r = makeRecord({
+      runId: 'run-with-errors',
+      errors: 27,
+      errorSamples: [
+        '404 model: sonnet (×9)',
+        "Cannot find package '@anthropic-ai/sdk' (×18)",
+      ],
+    });
+    await appendRunRecord(r, TEST_DIR);
+
+    const records = await readRunRecords(TEST_DIR);
+    expect(records[0]!.errorSamples).toEqual([
+      '404 model: sonnet (×9)',
+      "Cannot find package '@anthropic-ai/sdk' (×18)",
+    ]);
+  });
+
+  it('errorSamples is undefined for older records that omit it', async () => {
+    const r = makeRecord({ runId: 'run-legacy' });
+    await appendRunRecord(r, TEST_DIR);
+
+    const records = await readRunRecords(TEST_DIR);
+    expect(records[0]!.errorSamples).toBeUndefined();
+  });
+
   it('limits to 100 most recent records when appending', async () => {
     // Append 105 records
     for (let i = 0; i < 105; i++) {


### PR DESCRIPTION
Two related fixes for users hitting "100% of evals failed but I can't see why" — reported on Slack today, and visible in #89's screenshot too.

## 1. Persist eval errors on the run record

Today the "Sample errors:" block only prints during the live \`dt-evals run\` output. \`runs list\` shows only counts and \`runs show <id>\` doesn't print error messages either, so once you scroll past the live output the failure context is lost.

Add \`errorSamples?: string[]\` to \`RunRecord\` (\`runner/checkpoint.ts\`), fill it from \`result.errorSamples\` in \`runner/index.ts\`, print it in \`runs show\`. Optional field for back-compat with older records on disk.

After:

\`\`\`
$ dt-evals runs show run-2026-05-21T15-07-47-bcb8a1ce
Run ID:              run-2026-05-21T15-07-47-bcb8a1ce
...
Errors:              4326
...

Sample errors:
  • 404 model: sonnet (×4326)
\`\`\`

## 2. Real model probe in doctor + validate

The AI Provider section in \`dt-evals doctor\` currently shows:

\`\`\`
[5/6] AI Provider (Evaluator)
  Provider: anthropic / sonnet
  ✓ anthropic API reachable
  ✓ Model: sonnet
\`\`\`

…even though every actual eval call later returns \`404 model: sonnet\`. The check was just GETting \`/v1/models\` (or, for Bedrock, checking env vars existed) — that proves the API base URL is reachable and the API key is valid, but says nothing about whether the configured \`model\` value works.

Replace it with a shared \`probeProvider\` helper (new \`src/probe/provider.ts\`) that fires a real **1-token inference request** with the configured model id. Now doctor and validate fail upfront with the actual upstream error string:

\`\`\`
[5/6] AI Provider (Evaluator)
  Provider: anthropic / sonnet
  ✗ anthropic inference probe failed  (model: sonnet)
    404 {"type":"error","error":{"type":"not_found_error","message":"model: sonnet"}}
\`\`\`

Both \`doctor.ts\` and \`validate.ts\` call the shared helper so they stay in sync.

Bedrock lazy-imports \`@aws-sdk/client-bedrock-runtime\` so non-Bedrock users don't pay the SDK init cost on every \`doctor\`/\`validate\` run.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 170/170 (was 160, +10 new):
  - Probe: 404 model-not-found error string passes through verbatim
  - Probe: openai POSTs to \`/v1/chat/completions\` (not \`/v1/models\`)
  - Probe: gemini encodes model into URL path
  - Probe: azure-openai builds deployment URL from \`baseUrl\` + \`model\`
  - Probe: missing API key returns descriptive error
  - Probe: unknown provider returns ok=false
  - Probe: falls back to \`DEFAULT_JUDGE_MODELS\` when model is unset
  - Probe: 200 success returns ok=true
  - Checkpoint: \`errorSamples\` round-trips on disk
  - Checkpoint: \`errorSamples\` undefined for legacy records that omit it
- [ ] manual: \`dt-evals validate\` with a bad model → see verbatim 404
- [ ] manual: \`dt-evals doctor\` with a bad model → see verbatim 404 in section 5
- [ ] manual: kick a run that fails 100%, then \`dt-evals runs show <id>\` → see the "Sample errors:" block

## Out of scope

- Smarter error grouping in \`runs list\` (icon when a run has stored errors). Easy follow-up if useful.
- Bedrock probe currently uses temporary in-process AWS credentials only; it doesn't pick up IAM role / SSO flows. Same behavior as the runtime client, so consistent — but if we ever broaden the runtime to support more auth modes, the probe should too.