### PR TITLE
docs: link the public dt-evals playground dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ End-to-end LLM evaluation toolkit for Dynatrace AI Observability.
 
 ![dt-evals welcome](assets/dt-evals-welcome.gif)
 
+> 🎮 **Try it without installing anything** — explore a live `dt-evals` dashboard on our public playground tenant:
+> [**Open the dt-evals playground dashboard →**](http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8)
+>
+> Shows real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, and click-through to the originating trace.
+
 ## Packages
 
 | Package | Description |

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -29,6 +29,8 @@ npx @dynatrace-oss/dt-evals deploy --provider aws
 
 Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many judge calls run in parallel — bump it for faster runs, drop it if the provider rate-limits you. Default is 5.
 
+> 🎮 **See it live before installing** — [**open the dt-evals playground dashboard**](http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8) on our public Dynatrace tenant. Real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, click-through to the originating trace.
+
 ## Why Teams Use It
 
 - Run evals on real production traces, not static test sets


### PR DESCRIPTION
Adds a one-line callout right under the welcome GIF in both the root README and the dt-eval-cli README pointing readers at a live `dt-evals` dashboard on the `wkf10640` playground tenant:

http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8

The pitch: someone evaluating the tool can see what an eval run actually looks like in Dynatrace — score per metric, drift over time, threshold breaches, click-through to the originating trace — without installing anything first.

> 🎮 **Try it without installing anything** — explore a live `dt-evals` dashboard on our public playground tenant:
> [**Open the dt-evals playground dashboard →**](http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8)

## Note on the URL

The dashboard URL is `http://` not `https://` — that's how I was given the link. Worth double-checking before merge that the playground tenant doesn't auto-redirect to https or 404 on http.

## Test plan

- [ ] Visual check: GIF then callout then "## Packages" reads cleanly on github.com/dynatrace-oss/dt-evals
- [ ] Same on the npm package page (which renders dt-eval-cli/README.md)
- [ ] Link resolves to the dashboard for an unauthenticated visitor (i.e. tenant allows anonymous read on this dashboard) — confirm before merge