### PR TITLE
fix(dt-eval-cli): doctor uses paste-back platform token instead of dtctl OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ End-to-end LLM evaluation toolkit for Dynatrace AI Observability.
 - Node.js `>=20` (dt-evals, dt-eval-lib, dt-eval-deploy)
 - Python `>=3.10` (dt-ai-ingest)
 - A Dynatrace environment with GenAI spans (`gen_ai.*` OTEL attributes)
-- [`dtctl`](https://docs.dynatrace.com/docs/deliver/dynatrace-cli) installed for first-time setup (OAuth token generation)
+- A Dynatrace platform token (generated at [myaccount.dynatrace.com/platformTokens](https://myaccount.dynatrace.com/platformTokens) — `dt-evals doctor` walks you through it)
 - Credentials for your judge provider (OpenAI, Anthropic, Google, AWS Bedrock, or Azure OpenAI)
 
 ## Install
@@ -47,8 +47,9 @@ npx @dynatrace-oss/dt-evals <command>
 ## Quick Start
 
 ```bash
-# 1. Run the doctor — authenticates via dtctl (browser OAuth), checks permissions,
-#    generates a platform token, and writes it to your .env
+# 1. Run the doctor — opens the Dynatrace platform-tokens page, waits for you
+#    to paste a scoped token, writes DT_API_TOKEN to your .env, and probes
+#    every permission the runtime needs.
 dt-evals doctor
 
 # 2. Configure your service and judge provider
@@ -64,26 +65,22 @@ dt-evals run --since 1h --sample 10
 
 ### `doctor`
 
-Diagnose your environment end-to-end. Uses `dtctl` for browser-based OAuth, checks all required Dynatrace permissions, generates a scoped platform token, and writes it to your `.env`. Run this once on first setup or whenever something breaks.
+Diagnose your environment end-to-end. Walks you through creating a scoped Dynatrace platform token (opens the token page in your browser, lists the exact scopes to grant, waits for you to paste the token back), writes it to your `.env`, then probes every permission the runtime needs. Run this once on first setup or whenever something breaks.
 
 ```bash
 # Full interactive check (recommended for first-time setup)
 dt-evals doctor
 
-# Generate a platform token only (skips the full health check)
+# Just walk through token creation (skips the full health check)
 dt-evals doctor create-token
-
-# Use an existing dtctl context
-dt-evals doctor --context my-env
-dt-evals doctor create-token --context my-env
 
 # Point at a specific environment URL
 dt-evals doctor --env-url https://abc12345.apps.dynatrace.com
 
-# Skip token generation (if you already have DT_API_TOKEN set)
+# Skip the token paste step (if you already have DT_API_TOKEN set)
 dt-evals doctor --skip-token
 
-# Config, provider, and run history only — no dtctl auth required
+# Config, provider, and run history only — no Dynatrace token required
 dt-evals doctor --skip-auth
 ```
 
@@ -91,11 +88,11 @@ dt-evals doctor --skip-auth
 
 | Section | Checks |
 |---------|--------|
-| Dependencies | Node.js ≥18, dtctl installed and version |
-| Authentication | dtctl context selection or creation, browser OAuth flow |
+| Dependencies | Node.js ≥20, optional `dtctl` for context discovery |
+| Authentication | Opens the platform-tokens page, accepts a pasted token, saves it to `.env` |
 | Permissions | DQL read, bizevent write, metrics ingest, GenAI span count (last 24h) |
-| Platform Token | Creates a scoped API token, writes `DT_API_TOKEN` and `DT_ENV_URL` to `.env` |
-| AI Provider | API key presence and provider reachability |
+| Platform Token | Confirms the token from Section 2 is stored and reachable |
+| AI Provider | API key presence + a real 1-token inference probe against the configured model |
 | Config & Runs | Config schema validation, last run status, failure rate over 7 days |
 
 Each section produces a pass/warn/fail result with actionable steps for anything that needs attention.

--- a/dt-eval-cli/src/cli/commands/doctor.ts
+++ b/dt-eval-cli/src/cli/commands/doctor.ts
@@ -331,7 +331,7 @@ export function createDoctorCommand(): Command {
             const t = v.trim();
             if (!t) return true; // empty = skip
             if (!pasteToken.looksLikePlatformToken(t)) {
-              return 'That does not look like a Dynatrace platform token (expected dt0c01.…).';
+              return 'That does not look like a Dynatrace platform token (expected dt0s16.…).';
             }
             return true;
           },
@@ -434,7 +434,7 @@ export function createDoctorCommand(): Command {
           issues.push({
             severity: 'warning',
             section: 'Permissions',
-            message: `Missing optional Dynatrace permission: ${check.scope}`,
+            message: `Missing optional Dynatrace permission: ${check.scope}. ${check.error}`,
             action: 'Metric ingestion will be unavailable. Request this scope from your Dynatrace admin if needed.',
           });
         }
@@ -744,7 +744,7 @@ function createDoctorCreateCommand(): Command {
         const t = v.trim();
         if (!t) return 'Token is required';
         if (!pasteToken.looksLikePlatformToken(t)) {
-          return 'That does not look like a Dynatrace platform token (expected dt0c01.…).';
+          return 'That does not look like a Dynatrace platform token (expected dt0s16.…).';
         }
         return true;
       },

--- a/dt-eval-cli/src/cli/commands/doctor.ts
+++ b/dt-eval-cli/src/cli/commands/doctor.ts
@@ -9,6 +9,7 @@ import { Spinner } from '../../ui/spinner.js';
 import { loadConfig, validateConfig } from '../../config/index.js';
 import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
 import * as dtctl from '../../dtctl/index.js';
+import * as pasteToken from '../../dtctl/paste-token.js';
 import { printDoctorBanner } from '../../ui/banner.js';
 
 const execFileAsync = promisify(execFile);
@@ -259,133 +260,102 @@ export function createDoctorCommand(): Command {
     }
 
     // ══════════════════════════════════════════════════════════════
-    // SECTION 2: Dynatrace Authentication via dtctl
+    // SECTION 2: Dynatrace Authentication via platform token
     // ══════════════════════════════════════════════════════════════
+    //
+    // History: this used to extract an OAuth bearer from `dtctl -vv auth
+    // whoami` debug output. dtctl 0.24+ redacts the Authorization header
+    // (#89), so that approach is dead and there's no public dtctl command
+    // to print the access token. We replace it with a simple paste-back
+    // flow: open the Dynatrace platform-tokens UI, let the user create a
+    // scoped token themselves, paste it back here. Same end state, one
+    // fewer moving part.
     sectionHeader(2, TOTAL_SECTIONS, 'Dynatrace Authentication');
 
     let bearerToken: string | null = null;
-    let resolvedContextName: string | null = options.context ?? null;
+    const envFilePath = join(process.cwd(), '.env');
+    const preExistingToken = existingConfig?.dynatrace.apiToken ?? process.env['DT_API_TOKEN'];
 
-    if (options.skipAuth || !dtctlInstalled) {
+    if (options.skipAuth) {
       info('Skipping dtctl authentication');
-      if (!options.skipAuth) {
-        info('Install dtctl to enable OAuth-based authentication and token generation');
+    } else if (options.skipToken && preExistingToken) {
+      ok(`DT_API_TOKEN already set (${preExistingToken.slice(0, 8)}...) — using existing token`);
+      bearerToken = preExistingToken;
+    } else if (preExistingToken && !options.skipToken && inquirer) {
+      const reuse = await inquirer.confirm({
+        message: `DT_API_TOKEN already set (${preExistingToken.slice(0, 8)}...). Reuse it?`,
+        default: true,
+      });
+      if (reuse) {
+        ok('Reusing existing DT_API_TOKEN');
+        bearerToken = preExistingToken;
       }
-    } else {
-      // List available contexts
-      const spinner = new Spinner('Fetching dtctl contexts...');
-      spinner.start();
-      const contexts = await dtctl.listContexts();
-      spinner.stop();
+    }
 
-      if (contexts.length > 0) {
-        console.log(`  Found ${contexts.length} context${contexts.length !== 1 ? 's' : ''}:`);
-        contexts.forEach((c, i) => {
-          const label = c.environmentUrl ? `${c.name}  (${c.environmentUrl})` : c.name;
-          const marker = c.isCurrent ? pc.dim(' [current]') : '';
-          console.log(`    ${i + 1}. ${label}${marker}`);
+    if (!bearerToken && !options.skipAuth) {
+      // ── Resolve the environment URL we'll point the user at ──
+      let envUrlForToken =
+        options.envUrl
+        ?? existingConfig?.dynatrace.environmentUrl
+        ?? process.env['DT_ENV_URL']
+        ?? '';
+      if (!envUrlForToken && inquirer) {
+        envUrlForToken = await inquirer.input({
+          message: 'Dynatrace environment URL  (e.g. https://abc12345.apps.dynatrace.com)',
+          validate: v => /^https?:\/\/.+/.test(v.trim()) ? true : 'Enter a valid URL',
         });
       }
+      if (envUrlForToken && !options.envUrl) {
+        options = { ...options, envUrl: envUrlForToken };
+      }
 
-      // ── Context selection ─────────────────────────────────────
-      let contextEnvUrl: string | undefined;
+      // ── Print scopes + URL, then wait for paste ──
+      console.log(`\n  Generate a scoped platform token at ${pc.cyan(pasteToken.PLATFORM_TOKENS_URL)}`);
+      console.log(`  ${pc.dim('Required scopes (select all of these on the token page):')}\n`);
+      console.log(pasteToken.formatScopes());
+      console.log('');
 
-      if (!resolvedContextName && inquirer) {
-        const { select, input } = inquirer;
-        const choices = [
-          ...contexts.map(c => ({
-            name: c.environmentUrl ? `${c.name}  (${c.environmentUrl})` : c.name,
-            value: c.name,
-            short: c.name,
-          })),
-          { name: pc.dim('+ Create new context (opens browser)'), value: '__new__', short: 'new' },
-        ];
-
-        if (contexts.length > 0) {
-          resolvedContextName = await select({
-            message: 'Select a dtctl context',
-            choices,
+      if (inquirer) {
+        const openNow = await inquirer.confirm({
+          message: 'Open the platform-tokens page in your browser now?',
+          default: true,
+        });
+        if (openNow) {
+          await pasteToken.openBrowser(pasteToken.PLATFORM_TOKENS_URL);
+          console.log(`  ${pc.dim('Opening browser…')}\n`);
+        }
+        const pasted = await inquirer.password({
+          message: 'Paste your Dynatrace platform token (or press Enter to skip)',
+          mask: '*',
+          validate: v => {
+            const t = v.trim();
+            if (!t) return true; // empty = skip
+            if (!pasteToken.looksLikePlatformToken(t)) {
+              return 'That does not look like a Dynatrace platform token (expected dt0c01.…).';
+            }
+            return true;
+          },
+        });
+        const trimmed = pasted.trim();
+        if (trimmed) {
+          bearerToken = trimmed;
+          updateEnvFile(envFilePath, {
+            DT_API_TOKEN: trimmed,
+            ...(envUrlForToken ? { DT_ENV_URL: envUrlForToken } : {}),
           });
+          ok(`Token saved to ${envFilePath}`);
+          if (envUrlForToken) ok(`Environment: ${envUrlForToken}`);
         } else {
-          resolvedContextName = '__new__';
-        }
-
-        if (resolvedContextName === '__new__') {
-          resolvedContextName = await input({
-            message: 'New context name',
-            default: 'dt-evals',
-            validate: v => v.trim().length > 0 ? true : 'Context name is required',
-          });
-          // Need env URL to create a new context
-          contextEnvUrl = options.envUrl ?? existingConfig?.dynatrace.environmentUrl ?? process.env['DT_ENV_URL'];
-          if (!contextEnvUrl) {
-            contextEnvUrl = await input({
-              message: 'Dynatrace environment URL  (e.g. https://abc12345.apps.dynatrace.com)',
-              validate: v => /^https?:\/\/.+/.test(v.trim()) ? true : 'Enter a valid URL',
-            });
-          }
-        }
-      } else if (!resolvedContextName) {
-        // Fall back to current dtctl context
-        resolvedContextName = (await dtctl.getCurrentContext()) ?? contexts[0]?.name ?? 'dt-evals';
-        info(`Using context: ${resolvedContextName}`);
-      }
-
-      // Resolve env URL from context list if not already set
-      if (!contextEnvUrl) {
-        contextEnvUrl = contexts.find(c => c.name === resolvedContextName)?.environmentUrl;
-      }
-      // Will be merged into resolvedEnvUrl in section 3
-
-      // ── Token check / login ───────────────────────────────────
-      const tokenSpinner = new Spinner(`Getting token for context "${resolvedContextName}"...`);
-      tokenSpinner.start();
-      try {
-        bearerToken = await dtctl.getBearerToken(resolvedContextName!);
-        tokenSpinner.succeed(`Authenticated via context "${resolvedContextName}"`);
-        if (contextEnvUrl) ok(`Environment: ${contextEnvUrl}`);
-      } catch {
-        tokenSpinner.stop();
-
-        // Need to authenticate — determine env URL first
-        if (!contextEnvUrl) {
-          if (inquirer) {
-            contextEnvUrl = await inquirer.input({
-              message: 'Dynatrace environment URL  (e.g. https://abc12345.apps.dynatrace.com)',
-              default: options.envUrl ?? existingConfig?.dynatrace.environmentUrl ?? process.env['DT_ENV_URL'] ?? '',
-              validate: v => /^https?:\/\/.+/.test(v.trim()) ? true : 'Enter a valid URL',
-            });
-          } else {
-            contextEnvUrl = options.envUrl ?? existingConfig?.dynatrace.environmentUrl ?? process.env['DT_ENV_URL'] ?? '';
-          }
-        }
-
-        console.log(`\n  ${pc.dim(`No active session for "${resolvedContextName}" — opening browser for OAuth...`)}\n`);
-        const authSpinner = new Spinner('Waiting for browser authentication...');
-        authSpinner.start();
-        try {
-          bearerToken = await dtctl.authenticateWithBrowser(
-            resolvedContextName!,
-            contextEnvUrl,
-            (elapsed) => authSpinner.update(`Waiting for browser authentication... (${elapsed}s)`),
-          );
-          authSpinner.succeed('Browser authentication complete');
-          ok(`Authenticated via context "${resolvedContextName}"`);
-        } catch (err) {
-          authSpinner.fail('Authentication failed');
-          fail((err as Error).message);
+          warn('No token provided — permission probes and run history checks will be skipped');
           issues.push({
-            severity: 'error',
+            severity: 'warning',
             section: 'Authentication',
-            message: `Failed to authenticate via dtctl: ${(err as Error).message}`,
-            action: `Run manually: dtctl auth login --context ${resolvedContextName} --environment <your-env-url>`,
+            message: 'No Dynatrace API token configured',
+            action: `Re-run "dt-evals doctor" and paste a token from ${pasteToken.PLATFORM_TOKENS_URL}`,
           });
         }
-      }
-
-      // Surface context env URL for section 3
-      if (contextEnvUrl && !options.envUrl) {
-        options = { ...options, envUrl: contextEnvUrl };
+      } else {
+        info(`Non-interactive mode — open ${pasteToken.PLATFORM_TOKENS_URL} and add DT_API_TOKEN to your .env manually`);
       }
     }
 
@@ -497,84 +467,21 @@ export function createDoctorCommand(): Command {
     }
 
     // ══════════════════════════════════════════════════════════════
-    // SECTION 4: Platform Token Generation
+    // SECTION 4: Platform Token Status
     // ══════════════════════════════════════════════════════════════
+    //
+    // Token acquisition now happens in Section 2 (user pastes a token they
+    // created themselves at myaccount.dynatrace.com/platformTokens). This
+    // section is a no-op confirmation so the 6-section structure stays
+    // stable for users following along.
     sectionHeader(4, TOTAL_SECTIONS, 'Platform Token');
 
-    const envFilePath = join(process.cwd(), '.env');
-    const existingToken = existingConfig?.dynatrace.apiToken ?? process.env['DT_API_TOKEN'];
-
-    if (existingToken && options.skipToken) {
-      ok(`DT_API_TOKEN already set (${existingToken.slice(0, 8)}...)  — skipping token generation`);
-    } else if (!bearerToken || !resolvedEnvUrl) {
-      info('Skipping token generation (no authenticated dtctl session)');
-      if (!existingToken) {
-        issues.push({
-          severity: 'error',
-          section: 'Platform Token',
-          message: 'No Dynatrace API token configured',
-          action: 'Run "dt-evals doctor" with dtctl installed, or manually set DT_API_TOKEN in your .env file',
-        });
-      }
+    if (bearerToken) {
+      ok(`Platform token configured (${bearerToken.slice(0, 8)}...)`);
+      info(`Stored in ${envFilePath}`);
     } else {
-      const scopesToGrant = grantedScopes.length > 0
-        ? grantedScopes
-        : [
-            // Origin reads (DQL fetch spans + Grail bucket prerequisite)
-            'storage:spans:read',
-            'storage:buckets:read',
-            // Destination reads + writes (eval bizevents, drift metrics)
-            'storage:events:read',
-            'storage:events:write',
-            'storage:metrics:write',
-            // validate's destination connectivity probe
-            'storage:logs:read',
-          ];
-
-      if (existingToken) {
-        console.log(`  Existing token found (${existingToken.slice(0, 8)}...)`);
-        let shouldRegenerate = false;
-        if (inquirer) {
-          shouldRegenerate = await inquirer.confirm({
-            message: 'Generate a new platform token and update .env?',
-            default: false,
-          });
-        }
-        if (!shouldRegenerate) {
-          ok('Keeping existing DT_API_TOKEN');
-        }
-      }
-
-      const shouldGenerate = !existingToken || inquirer === null;
-
-      if (shouldGenerate || (inquirer && !existingToken)) {
-        const tokenName = `dt-evals-${new Date().toISOString().slice(0, 10)}`;
-        const tokenSpinner = new Spinner(`Creating platform token "${tokenName}" with scopes: ${scopesToGrant.join(', ')}...`);
-        tokenSpinner.start();
-
-        try {
-          const created = await dtctl.createPlatformToken(resolvedEnvUrl, bearerToken, tokenName, scopesToGrant);
-          tokenSpinner.succeed(`Token created: ${created.token.slice(0, 12)}...`);
-
-          const envUpdates: Record<string, string> = {
-            DT_API_TOKEN: created.token,
-            DT_ENV_URL: resolvedEnvUrl,
-          };
-          updateEnvFile(envFilePath, envUpdates);
-          ok(`DT_API_TOKEN written to ${envFilePath}`);
-          ok(`DT_ENV_URL written to ${envFilePath}`);
-          info('Scopes granted: ' + scopesToGrant.join(', '));
-        } catch (err) {
-          tokenSpinner.fail('Token creation failed');
-          fail((err as Error).message);
-          issues.push({
-            severity: 'error',
-            section: 'Platform Token',
-            message: `Failed to create platform token: ${(err as Error).message}`,
-            action: 'Ensure your dtctl OAuth token has the "apiTokens:write" scope, or create the token manually in Dynatrace Settings → Access Tokens',
-          });
-        }
-      }
+      info('No platform token — Section 2 was skipped or no token was pasted.');
+      info(`Generate one at ${pasteToken.PLATFORM_TOKENS_URL} and re-run "dt-evals doctor"`);
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -778,13 +685,16 @@ export function createDoctorCommand(): Command {
 
 function createDoctorCreateCommand(): Command {
   const sub = new Command('create-token');
-  sub.description('Generate a scoped Dynatrace platform token via dtctl and write it to .env');
-  sub.option('--context <name>', 'dtctl context to use');
+  sub.description('Walk through creating a Dynatrace platform token and save it to .env');
   sub.option('--env-url <url>', 'Dynatrace environment URL (overrides config)');
 
-  sub.action(async (options: { context?: string; envUrl?: string }) => {
+  // dtctl 0.24+ redacts OAuth bearers, so we can't auto-mint a token anymore
+  // (#89). Instead: surface the required scopes, open the Dynatrace token UI
+  // for the user, and wait for them to paste a token back. Same end state,
+  // no broken bearer extraction.
+  sub.action(async (options: { envUrl?: string }) => {
     printDoctorBanner();
-    console.log(pc.bold('  Creating platform token via dtctl OAuth\n'));
+    console.log(pc.bold('  Set up a Dynatrace platform token for dt-evals\n'));
 
     // ── Resolve existing config ────────────────────────────────
     let existingConfig: ReturnType<typeof loadConfig> | null = null;
@@ -793,54 +703,9 @@ function createDoctorCreateCommand(): Command {
     let inquirer: typeof import('@inquirer/prompts') | null = null;
     try { inquirer = await import('@inquirer/prompts'); } catch { /* non-interactive */ }
 
-    // ── Check dtctl ────────────────────────────────────────────
-    const version = await dtctl.getDtctlVersion();
-    if (!version) {
-      fail('dtctl is not installed');
-      info('Install dtctl: https://docs.dynatrace.com/docs/deliver/dynatrace-cli');
-      process.exit(1);
-    }
-    ok(`dtctl found  (${version})`);
-
-    // ── Context selection ──────────────────────────────────────
-    const spinner = new Spinner('Fetching dtctl contexts...');
-    spinner.start();
-    const contexts = await dtctl.listContexts();
-    spinner.stop();
-
-    let resolvedContext = options.context ?? null;
-    let contextEnvUrl: string | undefined;
-
-    if (!resolvedContext && inquirer) {
-      const choices = [
-        ...contexts.map(c => ({
-          name: c.environmentUrl ? `${c.name}  (${c.environmentUrl})` : c.name,
-          value: c.name,
-          short: c.name,
-        })),
-        { name: pc.dim('+ Create new context (opens browser)'), value: '__new__', short: 'new' },
-      ];
-
-      resolvedContext = contexts.length > 0
-        ? await inquirer.select({ message: 'Select a dtctl context', choices })
-        : '__new__';
-
-      if (resolvedContext === '__new__') {
-        resolvedContext = await inquirer.input({
-          message: 'New context name',
-          default: 'dt-evals',
-          validate: v => v.trim().length > 0 ? true : 'Context name is required',
-        });
-      }
-    } else if (!resolvedContext) {
-      resolvedContext = (await dtctl.getCurrentContext()) ?? contexts[0]?.name ?? 'dt-evals';
-    }
-
-    contextEnvUrl = contexts.find(c => c.name === resolvedContext)?.environmentUrl;
-
     // ── Resolve env URL ────────────────────────────────────────
-    let resolvedEnvUrl = options.envUrl
-      ?? contextEnvUrl
+    let resolvedEnvUrl =
+      options.envUrl
       ?? existingConfig?.dynatrace.environmentUrl
       ?? process.env['DT_ENV_URL']
       ?? '';
@@ -852,100 +717,49 @@ function createDoctorCreateCommand(): Command {
       });
     }
 
-    // ── Authenticate ───────────────────────────────────────────
-    const authSpinner = new Spinner(`Getting token for context "${resolvedContext}"...`);
-    authSpinner.start();
-    let bearerToken: string;
-    try {
-      bearerToken = await dtctl.getBearerToken(resolvedContext!);
-      authSpinner.succeed(`Authenticated via "${resolvedContext}"`);
-    } catch {
-      authSpinner.stop();
-      console.log(`\n  ${pc.dim(`No active session — opening browser for "${resolvedContext}"...`)}\n`);
-      const loginSpinner = new Spinner('Waiting for browser authentication...');
-      loginSpinner.start();
-      try {
-        bearerToken = await dtctl.authenticateWithBrowser(
-          resolvedContext!,
-          resolvedEnvUrl,
-          (s) => loginSpinner.update(`Waiting for browser authentication... (${s}s)`),
-        );
-        loginSpinner.succeed('Authenticated');
-      } catch (err) {
-        loginSpinner.fail(`Authentication failed: ${(err as Error).message}`);
-        info(`Run manually: dtctl auth login --context ${resolvedContext} --environment ${resolvedEnvUrl}`);
-        process.exit(1);
-      }
-    }
-
-    // ── Check permissions ──────────────────────────────────────
+    // ── Show scopes + open browser ─────────────────────────────
+    console.log(`  Open ${pc.cyan(pasteToken.PLATFORM_TOKENS_URL)} and create a new platform token.`);
+    console.log(`  ${pc.dim('Select all the scopes below when the page prompts you:')}\n`);
+    console.log(pasteToken.formatScopes());
     console.log('');
-    const permSpinner = new Spinner('Checking Dynatrace permissions...');
-    permSpinner.start();
-    const [spansCheck, eventsReadCheck, bizeventCheck, metricsCheck] = await Promise.all([
-      dtctl.checkSpansPermission(resolvedEnvUrl, bearerToken),
-      dtctl.checkEventsReadPermission(resolvedEnvUrl, bearerToken),
-      dtctl.checkBizeventPermission(resolvedEnvUrl, bearerToken),
-      dtctl.checkMetricsPermission(resolvedEnvUrl, bearerToken),
-    ]);
-    permSpinner.stop();
 
-    const scopes: string[] = [];
-    for (const check of [spansCheck, eventsReadCheck, bizeventCheck]) {
-      if (check.ok) {
-        ok(check.label);
-        scopes.push(check.scope);
-      } else {
-        warn(`${check.label} — not available (required, token will be created without it)`);
-      }
-    }
-    if (metricsCheck.ok) {
-      ok(`${metricsCheck.label} ${pc.dim('(optional)')}`);
-      scopes.push(metricsCheck.scope);
-    } else {
-      info(`${metricsCheck.label} — not available (optional, skipping)`);
+    if (!inquirer) {
+      info('Non-interactive mode — open the URL above and add DT_API_TOKEN to your .env manually');
+      process.exit(0);
     }
 
-    // Foundational scopes that aren't probed individually but are required
-    // by the runtime — included unconditionally so a doctor-minted token
-    // can actually pass `dt-evals validate` and run end-to-end:
-    //   - storage:buckets:read: Grail prerequisite for any storage table
-    //     read; without it `fetch spans|logs|bizevents` returns
-    //     SUCCEEDED-with-empty-records (silent failure).
-    //   - storage:logs:read: validate's destination connectivity probe
-    //     issues `fetch logs | limit 1`; without it the destination check
-    //     fails even when writes work.
-    if (!scopes.includes('storage:buckets:read')) scopes.push('storage:buckets:read');
-    if (!scopes.includes('storage:logs:read')) scopes.push('storage:logs:read');
-
-    if (scopes.length === 0) {
-      fail('No permissions available — cannot create a usable token');
-      info('Ensure your dtctl OAuth session has access to this Dynatrace environment');
-      process.exit(1);
+    const openNow = await inquirer.confirm({
+      message: 'Open the platform-tokens page in your browser now?',
+      default: true,
+    });
+    if (openNow) {
+      await pasteToken.openBrowser(pasteToken.PLATFORM_TOKENS_URL);
+      console.log(`  ${pc.dim('Opening browser…')}\n`);
     }
 
-    // ── Create token ───────────────────────────────────────────
-    console.log('');
-    const tokenName = `dt-evals-${new Date().toISOString().slice(0, 10)}`;
-    const createSpinner = new Spinner(`Creating token "${tokenName}" with scopes: ${scopes.join(', ')}...`);
-    createSpinner.start();
+    const pasted = await inquirer.password({
+      message: 'Paste your Dynatrace platform token',
+      mask: '*',
+      validate: v => {
+        const t = v.trim();
+        if (!t) return 'Token is required';
+        if (!pasteToken.looksLikePlatformToken(t)) {
+          return 'That does not look like a Dynatrace platform token (expected dt0c01.…).';
+        }
+        return true;
+      },
+    });
 
-    try {
-      const created = await dtctl.createPlatformToken(resolvedEnvUrl, bearerToken, tokenName, scopes);
-      createSpinner.succeed(`Token created: ${created.token.slice(0, 12)}...`);
+    const token = pasted.trim();
+    const envFilePath = join(process.cwd(), '.env');
+    updateEnvFile(envFilePath, {
+      DT_API_TOKEN: token,
+      ...(resolvedEnvUrl ? { DT_ENV_URL: resolvedEnvUrl } : {}),
+    });
+    ok(`DT_API_TOKEN written to ${envFilePath}`);
+    if (resolvedEnvUrl) ok(`DT_ENV_URL written to ${envFilePath}`);
 
-      const envFilePath = join(process.cwd(), '.env');
-      updateEnvFile(envFilePath, { DT_API_TOKEN: created.token, DT_ENV_URL: resolvedEnvUrl });
-      ok(`DT_API_TOKEN written to ${envFilePath}`);
-      ok(`DT_ENV_URL written to ${envFilePath}`);
-
-      console.log(`\n  ${pc.bold('Done.')} Run ${pc.cyan('dt-evals doctor')} to verify your full setup.\n`);
-    } catch (err) {
-      createSpinner.fail(`Token creation failed: ${(err as Error).message}`);
-      info('Ensure your OAuth session has the "apiTokens:write" scope');
-      info('Or create the token manually in Dynatrace Settings → Access Tokens');
-      process.exit(1);
-    }
+    console.log(`\n  ${pc.bold('Done.')} Run ${pc.cyan('dt-evals doctor')} to verify your full setup.\n`);
   });
 
   return sub;

--- a/dt-eval-cli/src/cli/commands/doctor.ts
+++ b/dt-eval-cli/src/cli/commands/doctor.ts
@@ -312,7 +312,7 @@ export function createDoctorCommand(): Command {
       // ── Print scopes + URL, then wait for paste ──
       console.log(`\n  Generate a scoped platform token at ${pc.cyan(pasteToken.PLATFORM_TOKENS_URL)}`);
       console.log(`  ${pc.dim('Required scopes (select all of these on the token page):')}\n`);
-      console.log(pasteToken.formatScopes());
+      console.log(pasteToken.formatScopes(envUrlForToken));
       console.log('');
 
       if (inquirer) {
@@ -720,7 +720,7 @@ function createDoctorCreateCommand(): Command {
     // ── Show scopes + open browser ─────────────────────────────
     console.log(`  Open ${pc.cyan(pasteToken.PLATFORM_TOKENS_URL)} and create a new platform token.`);
     console.log(`  ${pc.dim('Select all the scopes below when the page prompts you:')}\n`);
-    console.log(pasteToken.formatScopes());
+    console.log(pasteToken.formatScopes(resolvedEnvUrl));
     console.log('');
 
     if (!inquirer) {

--- a/dt-eval-cli/src/cli/commands/doctor.ts
+++ b/dt-eval-cli/src/cli/commands/doctor.ts
@@ -279,11 +279,11 @@ export function createDoctorCommand(): Command {
     if (options.skipAuth) {
       info('Skipping dtctl authentication');
     } else if (options.skipToken && preExistingToken) {
-      ok(`DT_API_TOKEN already set (${preExistingToken.slice(0, 8)}...) — using existing token`);
+      ok('DT_API_TOKEN already set — using existing token');
       bearerToken = preExistingToken;
     } else if (preExistingToken && !options.skipToken && inquirer) {
       const reuse = await inquirer.confirm({
-        message: `DT_API_TOKEN already set (${preExistingToken.slice(0, 8)}...). Reuse it?`,
+        message: 'DT_API_TOKEN already set. Reuse it?',
         default: true,
       });
       if (reuse) {
@@ -477,7 +477,7 @@ export function createDoctorCommand(): Command {
     sectionHeader(4, TOTAL_SECTIONS, 'Platform Token');
 
     if (bearerToken) {
-      ok(`Platform token configured (${bearerToken.slice(0, 8)}...)`);
+      ok('Platform token configured');
       info(`Stored in ${envFilePath}`);
     } else {
       info('No platform token — Section 2 was skipped or no token was pasted.');

--- a/dt-eval-cli/src/dtctl/index.ts
+++ b/dt-eval-cli/src/dtctl/index.ts
@@ -309,6 +309,12 @@ export function liveSubdomain(url: string): string {
 }
 
 export async function checkBizeventPermission(environmentUrl: string, bearerToken: string): Promise<PermissionCheck> {
+  const isClassic = /\.apps\.dynatrace\.com(\/|$)/i.test(environmentUrl);
+  const scope = isClassic ? 'storage:events:write' : 'openpipeline:bizevents:ingest';
+  const label = isClassic
+    ? 'Bizevent write (storage:events:write)'
+    : 'Bizevent write (openpipeline:bizevents:ingest)';
+
   // Probe the same URL the runtime client posts to.
   const url = `${liveSubdomain(environmentUrl.replace(/\/$/, ''))}/api/v2/bizevents/ingest`;
   try {
@@ -318,15 +324,9 @@ export async function checkBizeventPermission(environmentUrl: string, bearerToke
       body: JSON.stringify([{ 'event.provider': 'dt-evals.doctor.probe', 'event.type': 'connectivity.check' }]),
       signal: AbortSignal.timeout(10_000),
     });
-    
-    return {
-      scope: 'openpipeline:bizevents:ingest',
-      label: 'Bizevent write (openpipeline:bizevents:ingest)',
-      ok: response.status !== 401 && response.status !== 403,
-      statusCode: response.status,
-    };
+    return { scope, label, ok: response.status !== 401 && response.status !== 403, statusCode: response.status };
   } catch (err) {
-    return { scope: 'openpipeline:bizevents:ingest', label: 'Bizevent write (openpipeline:bizevents:ingest)', ok: false, error: (err as Error).message };
+    return { scope, label, ok: false, error: (err as Error).message };
   }
 }
 

--- a/dt-eval-cli/src/dtctl/index.ts
+++ b/dt-eval-cli/src/dtctl/index.ts
@@ -190,9 +190,10 @@ export async function authenticateWithBrowser(
 // ─── Permission probes ────────────────────────────────────────────────────────
 //
 // Probes accept either:
-//   - a Dynatrace platform / classic API token (`dt0c01....` / `dt0c0...`),
-//     pasted by the user from https://myaccount.dynatrace.com/platformTokens, or
-//   - an OAuth bearer (`dt0s....`) obtained by some other flow.
+//   - a Dynatrace classic API token (`dt0c01....` / `dt0c0...`), or
+//   - an OAuth/Platform token (`dt0s....`) pasted by the user from
+//     https://myaccount.dynatrace.com/platformTokens
+//     See also: https://docs.dynatrace.com/docs/shortlink/platform-tokens#how-to-use-a-platform-token
 //
 // `authScheme` picks the right HTTP scheme so callers don't have to care.
 
@@ -234,8 +235,8 @@ export async function checkSpansPermission(environmentUrl: string, bearerToken: 
 export async function checkEventsReadPermission(environmentUrl: string, bearerToken: string): Promise<PermissionCheck> {
   return probeDql(environmentUrl, bearerToken,
     'fetch bizevents | limit 1',
-    'storage:events:read',
-    'Bizevent read (storage:events:read)',
+    'storage:bizevents:read',
+    'Bizevent read (storage:bizevents:read)',
   );
 }
 
@@ -275,7 +276,7 @@ export async function countGenAiSpans(
   const serviceFilter = service
     ? `| filter service.name == "${service}" or dt.smartscape.service == "${service}"\n`
     : '';
-  const query = `fetch spans\n${serviceFilter}| filter isNotNull(gen_ai.provider.name)\n| filter timestamp >= now() - duration("24h")\n| summarize count = count()`;
+  const query = `fetch spans, from: now()-24h\n${serviceFilter}| filter isNotNull(gen_ai.provider.name)\n| summarize count = count()`;
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -285,18 +286,26 @@ export async function countGenAiSpans(
     });
     if (!response.ok) return null;
     const data = await response.json() as { result?: { records?: Array<Record<string, unknown>> } };
+    
     const records = data.result?.records ?? [];
     const count = records[0]?.['count'];
-    return typeof count === 'number' ? count : null;
+    if (typeof count === 'number') return count;
+    if (typeof count === 'string') {
+      const parsed = parseInt(count, 10);
+      return isNaN(parsed) ? null : parsed;
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
 /** Translate `*.apps.dynatrace.com` → `*.live.dynatrace.com` for ingest probes;
- *  matches the runtime client. Idempotent on other hosts. */
-function liveSubdomain(url: string): string {
-  return url.replace(/^(https?:\/\/[^/]+?)\.apps\.dynatrace\.com/, '$1.live.dynatrace.com');
+ *  also handles `dynatracelabs.com` lab environments. Idempotent on other hosts. */
+export function liveSubdomain(url: string): string {
+  return url
+    .replace(/^(https?:\/\/[^/]+?)\.apps\.dynatrace\.com/, '$1.live.dynatrace.com')
+    .replace(/^(https?:\/\/[^/]+?)\.apps\.dynatracelabs\.com/, '$1.dynatracelabs.com');
 }
 
 export async function checkBizeventPermission(environmentUrl: string, bearerToken: string): Promise<PermissionCheck> {
@@ -309,14 +318,15 @@ export async function checkBizeventPermission(environmentUrl: string, bearerToke
       body: JSON.stringify([{ 'event.provider': 'dt-evals.doctor.probe', 'event.type': 'connectivity.check' }]),
       signal: AbortSignal.timeout(10_000),
     });
+    
     return {
-      scope: 'storage:events:write',
-      label: 'Bizevent write (storage:events:write)',
+      scope: 'openpipeline:bizevents:ingest',
+      label: 'Bizevent write (openpipeline:bizevents:ingest)',
       ok: response.status !== 401 && response.status !== 403,
       statusCode: response.status,
     };
   } catch (err) {
-    return { scope: 'storage:events:write', label: 'Bizevent write (storage:events:write)', ok: false, error: (err as Error).message };
+    return { scope: 'openpipeline:bizevents:ingest', label: 'Bizevent write (openpipeline:bizevents:ingest)', ok: false, error: (err as Error).message };
   }
 }
 

--- a/dt-eval-cli/src/dtctl/index.ts
+++ b/dt-eval-cli/src/dtctl/index.ts
@@ -187,7 +187,18 @@ export async function authenticateWithBrowser(
   });
 }
 
-// ─── Permission probes (use Bearer token obtained via dtctl) ──────────────────
+// ─── Permission probes ────────────────────────────────────────────────────────
+//
+// Probes accept either:
+//   - a Dynatrace platform / classic API token (`dt0c01....` / `dt0c0...`),
+//     pasted by the user from https://myaccount.dynatrace.com/platformTokens, or
+//   - an OAuth bearer (`dt0s....`) obtained by some other flow.
+//
+// `authScheme` picks the right HTTP scheme so callers don't have to care.
+
+function authScheme(token: string): string {
+  return token.startsWith('dt0c') ? `Api-Token ${token}` : `Bearer ${token}`;
+}
 
 async function probeDql(
   environmentUrl: string,
@@ -200,7 +211,7 @@ async function probeDql(
   try {
     const response = await fetch(url, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${bearerToken}`, 'Content-Type': 'application/json' },
+      headers: { Authorization: authScheme(bearerToken), 'Content-Type': 'application/json' },
       body: JSON.stringify({ query, requestTimeoutMilliseconds: 5000 }),
       signal: AbortSignal.timeout(12_000),
     });
@@ -268,7 +279,7 @@ export async function countGenAiSpans(
   try {
     const response = await fetch(url, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${bearerToken}`, 'Content-Type': 'application/json' },
+      headers: { Authorization: authScheme(bearerToken), 'Content-Type': 'application/json' },
       body: JSON.stringify({ query, requestTimeoutMilliseconds: 15000 }),
       signal: AbortSignal.timeout(20_000),
     });
@@ -294,7 +305,7 @@ export async function checkBizeventPermission(environmentUrl: string, bearerToke
   try {
     const response = await fetch(url, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${bearerToken}`, 'Content-Type': 'application/json' },
+      headers: { Authorization: authScheme(bearerToken), 'Content-Type': 'application/json' },
       body: JSON.stringify([{ 'event.provider': 'dt-evals.doctor.probe', 'event.type': 'connectivity.check' }]),
       signal: AbortSignal.timeout(10_000),
     });
@@ -314,7 +325,7 @@ export async function checkMetricsPermission(environmentUrl: string, bearerToken
   try {
     const response = await fetch(url, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${bearerToken}`, 'Content-Type': 'text/plain' },
+      headers: { Authorization: authScheme(bearerToken), 'Content-Type': 'text/plain' },
       body: 'dt.evals.doctor.probe,probe=true 1',
       signal: AbortSignal.timeout(10_000),
     });
@@ -338,7 +349,7 @@ export async function createPlatformToken(
   const url = `${environmentUrl.replace(/\/$/, '')}/api/v2/apiTokens`;
   const response = await fetch(url, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${bearerToken}`, 'Content-Type': 'application/json' },
+    headers: { Authorization: authScheme(bearerToken), 'Content-Type': 'application/json' },
     body: JSON.stringify({ name, scopes }),
     signal: AbortSignal.timeout(15_000),
   });

--- a/dt-eval-cli/src/dtctl/paste-token.ts
+++ b/dt-eval-cli/src/dtctl/paste-token.ts
@@ -28,12 +28,12 @@ export const PLATFORM_TOKENS_URL = 'https://myaccount.dynatrace.com/platformToke
  *   - read logs for the `validate` connectivity probe
  */
 export const REQUIRED_SCOPES: Array<{ scope: string; purpose: string; optional?: boolean }> = [
-  { scope: 'storage:spans:read', purpose: 'Read GenAI traces from Grail' },
+  { scope: 'openpipeline:bizevents:ingest', purpose: 'Write evaluation results back as bizevents' },
+  { scope: 'storage:bizevents:read', purpose: 'Read past evaluation bizevents — drift baseline' },
   { scope: 'storage:buckets:read', purpose: 'List Grail buckets (prerequisite for any read)' },
-  { scope: 'storage:events:read', purpose: 'Read past evaluation bizevents — drift baseline' },
-  { scope: 'storage:events:write', purpose: 'Write evaluation results back as bizevents' },
-  { scope: 'storage:metrics:write', purpose: 'Write evaluation metrics', optional: true },
   { scope: 'storage:logs:read', purpose: 'Connectivity probe used by `dt-evals validate`' },
+  { scope: 'storage:metrics:write', purpose: 'Write evaluation metrics', optional: true },
+  { scope: 'storage:spans:read', purpose: 'Read GenAI traces from Grail' },
 ];
 
 /** Format the scopes block as a copy/paste-friendly bullet list. */
@@ -63,12 +63,12 @@ export async function openBrowser(url: string): Promise<void> {
 }
 
 /**
- * Minimum heuristic for a Dynatrace API token: the `dt0c01.` family of
- * platform tokens. We deliberately don't tighten this further — Dynatrace
- * may issue other prefixes in future, and a too-strict regex would block
- * legitimate tokens. Length floor catches obvious paste mistakes.
+ * Minimum heuristic for a Dynatrace platform token: the `dt0s16.` prefix.
+ * We deliberately don't tighten this further — Dynatrace may issue other
+ * prefixes in future, and a too-strict regex would block legitimate tokens.
+ * Length floor catches obvious paste mistakes.
  */
 export function looksLikePlatformToken(value: string): boolean {
   const v = value.trim();
-  return /^dt0c0?\d\./i.test(v) && v.length >= 32;
+  return /^dt0s\d+\./i.test(v) && v.length >= 32;
 }

--- a/dt-eval-cli/src/dtctl/paste-token.ts
+++ b/dt-eval-cli/src/dtctl/paste-token.ts
@@ -36,10 +36,20 @@ export const REQUIRED_SCOPES: Array<{ scope: string; purpose: string; optional?:
   { scope: 'storage:spans:read', purpose: 'Read GenAI traces from Grail' },
 ];
 
-/** Format the scopes block as a copy/paste-friendly bullet list. */
-export function formatScopes(): string {
-  const widest = Math.max(...REQUIRED_SCOPES.map(s => s.scope.length));
-  return REQUIRED_SCOPES.map(s => {
+/** Format the scopes block as a copy/paste-friendly bullet list.
+ *  For classic *.apps.dynatrace.com tenants, `openpipeline:bizevents:ingest`
+ *  is replaced with `storage:events:write` (OpenPipeline ingest not available). */
+export function formatScopes(envUrl?: string): string {
+  const isClassic = envUrl ? /\.apps\.dynatrace\.com(\/|$)/i.test(envUrl) : false;
+  const scopes = isClassic
+    ? REQUIRED_SCOPES.map(s =>
+        s.scope === 'openpipeline:bizevents:ingest'
+          ? { ...s, scope: 'storage:events:write' }
+          : s,
+      )
+    : REQUIRED_SCOPES;
+  const widest = Math.max(...scopes.map(s => s.scope.length));
+  return scopes.map(s => {
     const pad = ' '.repeat(widest - s.scope.length);
     const tag = s.optional ? pc.dim('  (optional)') : '';
     return `    • ${pc.cyan(s.scope)}${pad}  — ${s.purpose}${tag}`;

--- a/dt-eval-cli/src/dtctl/paste-token.ts
+++ b/dt-eval-cli/src/dtctl/paste-token.ts
@@ -1,0 +1,74 @@
+/**
+ * Interactive "paste your Dynatrace platform token" flow.
+ *
+ * Why this exists:
+ * dtctl 0.24+ redacts the OAuth Bearer header in its debug output, so the
+ * old `getBearerToken()` trick can no longer extract a usable token. There's
+ * no public dtctl command to print the access token either. The most
+ * reliable replacement is to direct the user to the Dynatrace token UI,
+ * have them generate a scoped platform token themselves, and paste it back.
+ *
+ * This module isolates that flow so both `dt-evals doctor` and
+ * `dt-evals doctor create-token` can share it.
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import pc from 'picocolors';
+
+const execAsync = promisify(exec);
+
+export const PLATFORM_TOKENS_URL = 'https://myaccount.dynatrace.com/platformTokens';
+
+/**
+ * Scopes that need to be selected when creating the platform token.
+ * Mirrors what the runtime client needs end-to-end:
+ *   - read GenAI traces, list buckets, read past eval bizevents (drift baseline)
+ *   - write eval bizevents and (optionally) metrics
+ *   - read logs for the `validate` connectivity probe
+ */
+export const REQUIRED_SCOPES: Array<{ scope: string; purpose: string; optional?: boolean }> = [
+  { scope: 'storage:spans:read', purpose: 'Read GenAI traces from Grail' },
+  { scope: 'storage:buckets:read', purpose: 'List Grail buckets (prerequisite for any read)' },
+  { scope: 'storage:events:read', purpose: 'Read past evaluation bizevents — drift baseline' },
+  { scope: 'storage:events:write', purpose: 'Write evaluation results back as bizevents' },
+  { scope: 'storage:metrics:write', purpose: 'Write evaluation metrics', optional: true },
+  { scope: 'storage:logs:read', purpose: 'Connectivity probe used by `dt-evals validate`' },
+];
+
+/** Format the scopes block as a copy/paste-friendly bullet list. */
+export function formatScopes(): string {
+  const widest = Math.max(...REQUIRED_SCOPES.map(s => s.scope.length));
+  return REQUIRED_SCOPES.map(s => {
+    const pad = ' '.repeat(widest - s.scope.length);
+    const tag = s.optional ? pc.dim('  (optional)') : '';
+    return `    • ${pc.cyan(s.scope)}${pad}  — ${s.purpose}${tag}`;
+  }).join('\n');
+}
+
+/** Open a URL in the user's default browser. Best-effort; falls back to no-op. */
+export async function openBrowser(url: string): Promise<void> {
+  const platform = process.platform;
+  // Mac: `open`, Linux: `xdg-open`, Windows: `start`. Quote URL for safety.
+  const cmd =
+    platform === 'darwin' ? `open "${url}"`
+    : platform === 'win32' ? `start "" "${url}"`
+    : `xdg-open "${url}"`;
+  try {
+    await execAsync(cmd, { timeout: 5_000 });
+  } catch {
+    // Best-effort. If the platform has no opener (CI, headless), the caller
+    // will have already printed the URL — nothing to do.
+  }
+}
+
+/**
+ * Minimum heuristic for a Dynatrace API token: the `dt0c01.` family of
+ * platform tokens. We deliberately don't tighten this further — Dynatrace
+ * may issue other prefixes in future, and a too-strict regex would block
+ * legitimate tokens. Length floor catches obvious paste mistakes.
+ */
+export function looksLikePlatformToken(value: string): boolean {
+  const v = value.trim();
+  return /^dt0c0?\d\./i.test(v) && v.length >= 32;
+}

--- a/dt-eval-cli/tests/dtctl/index.test.ts
+++ b/dt-eval-cli/tests/dtctl/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { liveSubdomain } from '../../src/dtctl/index.js';
+
+describe('liveSubdomain', () => {
+  it('rewrites *.apps.dynatrace.com to *.live.dynatrace.com', () => {
+    expect(liveSubdomain('https://abc123.apps.dynatrace.com'))
+      .toBe('https://abc123.live.dynatrace.com');
+  });
+
+  it('rewrites *.apps.dynatracelabs.com to *.dynatracelabs.com', () => {
+    expect(liveSubdomain('https://abc123.apps.dynatracelabs.com'))
+      .toBe('https://abc123.dynatracelabs.com');
+  });
+
+  it('preserves a path after the host', () => {
+    expect(liveSubdomain('https://abc123.apps.dynatrace.com/api/v2/bizevents/ingest'))
+      .toBe('https://abc123.live.dynatrace.com/api/v2/bizevents/ingest');
+  });
+
+  it('is idempotent on already-rewritten .live. URLs', () => {
+    const url = 'https://abc123.live.dynatrace.com';
+    expect(liveSubdomain(url)).toBe(url);
+  });
+
+  it('passes through on-prem / cluster URLs unchanged', () => {
+    const url = 'https://my-cluster.internal.example.com';
+    expect(liveSubdomain(url)).toBe(url);
+  });
+});

--- a/dt-eval-cli/tests/dtctl/paste-token.test.ts
+++ b/dt-eval-cli/tests/dtctl/paste-token.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { looksLikePlatformToken, formatScopes, REQUIRED_SCOPES, PLATFORM_TOKENS_URL } from '../../src/dtctl/paste-token.js';
+
+describe('looksLikePlatformToken', () => {
+  it('accepts a typical platform token (dt0c01.<base32>.<base32>)', () => {
+    const token = 'dt0c01.' + 'A'.repeat(24) + '.' + 'B'.repeat(64);
+    expect(looksLikePlatformToken(token)).toBe(true);
+  });
+
+  it('rejects empty / whitespace input', () => {
+    expect(looksLikePlatformToken('')).toBe(false);
+    expect(looksLikePlatformToken('   ')).toBe(false);
+  });
+
+  it('rejects obviously wrong shapes', () => {
+    expect(looksLikePlatformToken('not-a-token')).toBe(false);
+    expect(looksLikePlatformToken('Bearer eyJhbGciOi...')).toBe(false);
+    // Right prefix but too short — almost certainly a paste error
+    expect(looksLikePlatformToken('dt0c01.ABC')).toBe(false);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    const token = '  dt0c01.' + 'A'.repeat(64) + '\n';
+    expect(looksLikePlatformToken(token)).toBe(true);
+  });
+
+  it('is case-insensitive on the prefix', () => {
+    const token = 'DT0C01.' + 'A'.repeat(64);
+    expect(looksLikePlatformToken(token)).toBe(true);
+  });
+});
+
+describe('REQUIRED_SCOPES', () => {
+  it('includes all four read/write scopes the runtime needs', () => {
+    const scopes = REQUIRED_SCOPES.map(s => s.scope);
+    expect(scopes).toContain('storage:spans:read');
+    expect(scopes).toContain('storage:buckets:read');
+    expect(scopes).toContain('storage:events:read');
+    expect(scopes).toContain('storage:events:write');
+  });
+
+  it('marks storage:metrics:write as optional', () => {
+    const metrics = REQUIRED_SCOPES.find(s => s.scope === 'storage:metrics:write');
+    expect(metrics?.optional).toBe(true);
+  });
+});
+
+describe('formatScopes', () => {
+  it('renders one line per scope with its purpose', () => {
+    const out = formatScopes();
+    const lines = out.split('\n');
+    expect(lines).toHaveLength(REQUIRED_SCOPES.length);
+    for (const s of REQUIRED_SCOPES) {
+      expect(out).toContain(s.scope);
+      expect(out).toContain(s.purpose);
+    }
+  });
+
+  it('flags optional scopes', () => {
+    expect(formatScopes()).toMatch(/optional/i);
+  });
+});
+
+describe('PLATFORM_TOKENS_URL', () => {
+  it('points at the official Dynatrace platform tokens page', () => {
+    expect(PLATFORM_TOKENS_URL).toBe('https://myaccount.dynatrace.com/platformTokens');
+  });
+});

--- a/dt-eval-cli/tests/dtctl/paste-token.test.ts
+++ b/dt-eval-cli/tests/dtctl/paste-token.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { looksLikePlatformToken, formatScopes, REQUIRED_SCOPES, PLATFORM_TOKENS_URL } from '../../src/dtctl/paste-token.js';
 
 describe('looksLikePlatformToken', () => {
-  it('accepts a typical platform token (dt0c01.<base32>.<base32>)', () => {
-    const token = 'dt0c01.' + 'A'.repeat(24) + '.' + 'B'.repeat(64);
+  it('accepts a typical platform token (dt0s16.<payload>)', () => {
+    const token = 'dt0s16.' + 'A'.repeat(24) + '.' + 'B'.repeat(64);
     expect(looksLikePlatformToken(token)).toBe(true);
   });
 
@@ -16,16 +16,16 @@ describe('looksLikePlatformToken', () => {
     expect(looksLikePlatformToken('not-a-token')).toBe(false);
     expect(looksLikePlatformToken('Bearer eyJhbGciOi...')).toBe(false);
     // Right prefix but too short — almost certainly a paste error
-    expect(looksLikePlatformToken('dt0c01.ABC')).toBe(false);
+    expect(looksLikePlatformToken('dt0s16.ABC')).toBe(false);
   });
 
   it('tolerates surrounding whitespace', () => {
-    const token = '  dt0c01.' + 'A'.repeat(64) + '\n';
+    const token = '  dt0s16.' + 'A'.repeat(64) + '\n';
     expect(looksLikePlatformToken(token)).toBe(true);
   });
 
   it('is case-insensitive on the prefix', () => {
-    const token = 'DT0C01.' + 'A'.repeat(64);
+    const token = 'DT0S16.' + 'A'.repeat(64);
     expect(looksLikePlatformToken(token)).toBe(true);
   });
 });
@@ -35,8 +35,8 @@ describe('REQUIRED_SCOPES', () => {
     const scopes = REQUIRED_SCOPES.map(s => s.scope);
     expect(scopes).toContain('storage:spans:read');
     expect(scopes).toContain('storage:buckets:read');
-    expect(scopes).toContain('storage:events:read');
-    expect(scopes).toContain('storage:events:write');
+    expect(scopes).toContain('storage:bizevents:read');
+    expect(scopes).toContain('openpipeline:bizevents:ingest');
   });
 
   it('marks storage:metrics:write as optional', () => {


### PR DESCRIPTION
Closes #89.

## Problem

dtctl 0.24+ redacts the \`Authorization\` header in its debug output (\`-vv\`), so the old \`getBearerToken()\` trick (run \`dtctl -vv auth whoami\`, grep the bearer out of the log, re-use it for permission probes and the \`apiTokens\` API call) silently fails on every fresh install:

\`\`\`
$ dtctl -vv auth whoami --plain
===> REQUEST <===
GET https://<tenant>.apps.dynatrace.com/platform/metadata/v1/user
HEADERS:
    Authorization: [REDACTED]    ← used to be "Bearer <token>"
\`\`\`

I checked every dtctl output mode (\`-vvv\`, \`--debug\`, \`-o json\`, agent mode \`-A\`, the whole command tree from \`dtctl commands -A\`). None of them expose the access token, and the on-disk dtctl config has \`token: ""\` because tokens live in the OS keychain. There's no way to patch the regex.

Users running \`dt-evals doctor\` on dtctl 0.24+ see:

> ✗ Authentication failed
> ✗ Could not extract bearer token from dtctl. The context may be unauthenticated — run: dtctl auth login --context personal

…even though their dtctl is fine and the browser OAuth flow completed successfully.

## Fix

Drop the bearer-extraction approach entirely. Replace with a paste-back flow that does the same thing the old code did, just with the user generating the token themselves at the official UI.

### Section 2 (Authentication)
- Resolve the environment URL (CLI flag → config → env → prompt)
- Print the URL \`https://myaccount.dynatrace.com/platformTokens\` and the **exact scopes** the user needs to select on that page (color-highlighted, with a one-line purpose next to each)
- Offer to open the URL in their default browser (cross-platform: \`open\` / \`xdg-open\` / \`start\`)
- \`inquirer.password()\` — **wait** for the user to paste a \`dt0c01.…\` token
- Validate the shape (length floor + prefix regex), write \`DT_API_TOKEN\` + \`DT_ENV_URL\` to \`.env\`

### Section 4 (Platform Token)
- Was the auto-mint step that called the now-broken bearer. Collapses into a one-line confirmation that the token from Section 2 is stored — keeps the 6-section structure stable so existing screenshots / docs still align.

### \`dt-evals doctor create-token\`
- Same paste-back flow, standalone. Drops \`--context\` (dtctl context selection is no longer meaningful when we're not minting tokens via dtctl).

### Permission probes still work
- Probes in \`dtctl/index.ts\` hardcoded \`Authorization: Bearer \${token}\`, which only works for OAuth bearers. A pasted \`dt0c01.…\` platform token needs the \`Api-Token\` scheme.
- New \`authScheme()\` helper picks the right scheme based on the prefix. \`Bearer\` for \`dt0s…\` / OAuth, \`Api-Token\` for \`dt0c…\` / classic + platform.
- That's the single change that lets Section 3 (Permissions) and \`dt-evals validate\` work end-to-end with a pasted token.

## UX

Before:
\`\`\`
[2/6] Dynatrace Authentication
  Found 5 contexts:
    1. personal  (https://….sprint.apps.dynatracelabs.com) [current]
    …
✔ Select a dtctl context personal
  No active session for "personal" — opening browser for OAuth...
✗ Authentication failed
  ✗ Could not extract bearer token from dtctl. The context may be unauthenticated — run: dtctl auth login --context personal
\`\`\`

After:
\`\`\`
[2/6] Dynatrace Authentication

  Generate a scoped platform token at https://myaccount.dynatrace.com/platformTokens
  Required scopes (select all of these on the token page):

    • storage:spans:read      — Read GenAI traces from Grail
    • storage:buckets:read    — List Grail buckets (prerequisite for any read)
    • storage:events:read     — Read past evaluation bizevents — drift baseline
    • storage:events:write    — Write evaluation results back as bizevents
    • storage:metrics:write   — Write evaluation metrics  (optional)
    • storage:logs:read       — Connectivity probe used by `dt-evals validate`

  ? Open the platform-tokens page in your browser now? (Y/n) y
  Opening browser…
  ? Paste your Dynatrace platform token *********************
  ✓ Token saved to /Users/.../.env
  ✓ Environment: https://….apps.dynatrace.com
\`\`\`

## Out of scope (follow-up)

- \`dtctl.getBearerToken\`, \`dtctl.authenticateWithBrowser\`, \`dtctl.createPlatformToken\` are no longer called from anywhere in this repo, but the exports stay so the diff is focused on the user-facing flow. Easy follow-up cleanup.
- \`--context\` flag on the main \`doctor\` command still exists but is now ignored. Can be deprecated separately.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 170/170 (was 160, +10 new):
  - \`looksLikePlatformToken\` accepts \`dt0c01.…\`, rejects empty / wrong-shape / too-short input
  - \`REQUIRED_SCOPES\` includes the four mandatory read/write scopes
  - \`storage:metrics:write\` is flagged optional
  - \`formatScopes()\` renders one line per scope with its purpose
  - \`PLATFORM_TOKENS_URL\` points at \`myaccount.dynatrace.com/platformTokens\`
- [ ] manual: \`dt-evals doctor\` end-to-end on dtctl 0.24+ — paste a real token, confirm \`.env\` is written, Sections 3–6 succeed
- [ ] manual: \`dt-evals doctor create-token\` — same flow standalone
- [ ] manual: \`dt-evals doctor --skip-token\` with an existing \`DT_API_TOKEN\` — confirm no paste prompt
- [ ] manual: \`dt-evals validate\` after paste — confirms the \`Api-Token\` auth scheme works against Grail