### PR TITLE
feat(dt-eval-cli): server-side eval alerts as Dynatrace Workflows

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -228,6 +228,94 @@ dt-evals schedule delete <schedule-id>
 
 Schedules are stored locally in `~/.dt-eval/schedules.json`.
 
+### Continuous alerts via Dynatrace Workflows
+
+Define one or more notifications in your eval YAML, then deploy them as
+Dynatrace Workflows that poll the eval bizevents and notify Slack / email when
+a threshold is breached.
+
+```yaml
+alerts:
+  notifications:
+    - name: toxicity-spike
+      metric: toxicity
+      condition: avg > 2        # avg | max | min | count | fail_rate
+      window: 15m                # also the polling interval
+      channel:
+        type: slack
+        connection: my-slack-conn
+        channel: "#ai-alerts"
+
+    - name: hallucination-any
+      metric: hallucination
+      condition: count > 0
+      window: 5m
+      channel:
+        type: email
+        connection: smtp-default
+        to: [ai-team@example.com]
+```
+
+```bash
+dt-evals alerts render  my.dt-eval.yaml          # preview workflow YAML, no API calls
+dt-evals alerts apply   my.dt-eval.yaml          # create or update (idempotent)
+dt-evals alerts list    my.dt-eval.yaml          # show deployed alerts for this config
+dt-evals alerts diff    my.dt-eval.yaml          # local vs. remote
+dt-evals alerts delete  my.dt-eval.yaml --name toxicity-spike
+dt-evals alerts delete  my.dt-eval.yaml --all
+```
+
+Apply uses `dtctl apply`; the workflow id for each notification is stored at
+`~/.dt-eval/alerts-<config-hash>.json` so subsequent applies update in place.
+
+**Slack and email require a Dynatrace connection** — `dt-evals alerts apply`
+**does not auto-create them**. Set them up once in the Dynatrace UI before the
+notify task can deliver:
+
+| Channel | How to create the connection | What to reference in YAML |
+|---------|------------------------------|---------------------------|
+| Slack   | Dynatrace → **Settings → Connections → Slack (OAuth)** — install the Dynatrace app into your Slack workspace and name the connection. | `channel: { type: slack, connection: <name>, channel: "#chan" }` |
+| Email   | Dynatrace → **Settings → Connections → Email (SMTP)** — supply SMTP host, port, auth, and a verified `From:` address. | `channel: { type: email, connection: <name>, to: [a@b.com] }` |
+
+If you don't have a Dynatrace Slack connection (e.g. you're not an admin), use
+**`type: webhook`** with an incoming-webhook URL instead. The notify task runs
+a small fetch via the core Run JavaScript action — no extra app install or
+connection required, at the cost of losing the Slack-action form UI:
+
+```yaml
+channel:
+  type: webhook
+  webhookUrl: https://hooks.slack.com/services/T00/B00/XXXX
+```
+
+After every `apply` / `list` the CLI prints a deep link to the Workflows app
+filtered to your dt-evals alerts, so you can review them in the tenant in one
+click.
+
+**Required Dynatrace permissions** (on the dtctl OAuth principal):
+
+| Scope                          | Used by                                     |
+|--------------------------------|---------------------------------------------|
+| `automation:workflows:read`    | `list`, `diff`, idempotent `apply`          |
+| `automation:workflows:write`   | `apply`, `delete`                            |
+| `storage:events:read`          | The deployed workflow's DQL task at runtime |
+| `automation:workflows:run` *(optional)* | Manual execution from the UI       |
+
+The CLI surfaces these in `alerts --help` and in error messages when dtctl
+returns 401 / 403. If you see "Permission denied", ask your Dynatrace admin to
+grant the scopes above to the OAuth client backing `dtctl auth login`.
+
+Condition DSL: `<aggregation> <operator> <value>[%]` where:
+
+- aggregations: `avg`, `max`, `min`, `count` (failing rows), `fail_rate`
+- operators: `>`, `>=`, `<`, `<=`, `==`, `!=`
+- **`fail_rate` is a percentage** — write it with `%` (e.g. `fail_rate > 10%`)
+  or as a ratio between 0 and 1 (e.g. `fail_rate > 0.1`). Bare values outside
+  that range like `fail_rate > 10` are rejected at validate time to avoid the
+  10-vs-10% trap. Rendered alert messages always print the percentage form
+  regardless of which you wrote.
+- `%` is not valid on any other aggregation.
+
 ### Check current status
 
 ```bash
@@ -246,6 +334,7 @@ dt-evals configure --show
 | `evaluators` | List, inspect, test, and manage evaluators |
 | `runs` | View and export historical run records |
 | `schedule` | Create and trigger recurring runs |
+| `alerts` | Deploy Slack/email alerts as Dynatrace Workflows (`render`, `apply`, `list`, `diff`, `delete`) |
 
 Global flags:
 

--- a/dt-eval-cli/alerts-examples.dt-eval.yaml
+++ b/dt-eval-cli/alerts-examples.dt-eval.yaml
@@ -11,7 +11,7 @@ schemaVersion: 2
 name: pydantic-music-agent
 
 dynatrace:
-  environmentUrl: https://mho70695.apps.dynatrace.com
+  environmentUrl: ${DT_ENV_URL}
 
 judge:
   provider: openai

--- a/dt-eval-cli/alerts-examples.dt-eval.yaml
+++ b/dt-eval-cli/alerts-examples.dt-eval.yaml
@@ -1,0 +1,96 @@
+# Example alerts config — five realistic patterns you can apply with:
+#
+#   dt-evals alerts apply alerts-examples.dt-eval.yaml
+#
+# Each notification demonstrates a different aggregation/window/channel mix.
+# The `connection:` names below are placeholders — to actually deliver, either
+# create connections with those names in Dynatrace, or swap them for real
+# Slack incoming-webhook URLs under `webhookUrl:`.
+
+schemaVersion: 2
+name: pydantic-music-agent
+
+dynatrace:
+  environmentUrl: https://mho70695.apps.dynatrace.com
+
+judge:
+  provider: openai
+  apiKey: ${OPENAI_API_KEY}
+
+scope:
+  service: pydantic-ai-music-agent      # ~3.4k eval bizevents in last 30d
+  since: 1h
+  sampling: { strategy: random, percent: 5 }
+
+metrics:
+  enabled: [toxicity, relevance, hallucination, pii-leakage, prompt-injection]
+
+alerts:
+  notifications:
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 1) Critical safety: page on ANY PII leak in the last 5 minutes.
+    #    Tight window, zero-tolerance threshold, Slack so it's noisy.
+    # ──────────────────────────────────────────────────────────────────────
+    - name: pii-leak-any
+      metric: pii-leakage
+      condition: count > 0           # any failing pii-leakage eval at all
+      window: 5m
+      channel:
+        type: slack
+        connection: ai-oncall-slack
+        channel: "#ai-oncall"
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 2) Critical safety: same shape for prompt injection.
+    # ──────────────────────────────────────────────────────────────────────
+    - name: prompt-injection-any
+      metric: prompt-injection
+      condition: count > 0
+      window: 5m
+      channel:
+        type: slack
+        connection: ai-oncall-slack
+        channel: "#ai-oncall"
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 3) Quality regression: more than 20% of relevance evals failed in 1h.
+    #    Slower window since one bad batch shouldn't page anyone; email so it
+    #    lands in the AI team inbox for triage instead of a paging channel.
+    # ──────────────────────────────────────────────────────────────────────
+    - name: relevance-regression
+      metric: relevance
+      condition: fail_rate > 20%
+      window: 1h
+      channel:
+        type: email
+        # Uses the tenant's default outbound mail config (Dynatrace → Settings →
+        # Notifications). No per-workflow connection needed.
+        to: [ai-quality@example.com]
+        subject: "[dt-evals] relevance regression on pydantic-ai-music-agent"
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 4) Toxicity spike on the 1–5 scale: average above 2 for 15 minutes.
+    #    Routed to a different Slack channel than the on-call ones above.
+    # ──────────────────────────────────────────────────────────────────────
+    - name: toxicity-spike
+      metric: toxicity
+      condition: avg > 2
+      window: 15m
+      channel:
+        type: slack
+        connection: ai-oncall-slack
+        channel: "#ai-quality"
+
+    # ──────────────────────────────────────────────────────────────────────
+    # 5) Hallucination trend: more than 10% failing over a 1-hour window.
+    #    Generic webhook so an external router (PagerDuty proxy, custom
+    #    on-call tool, etc.) can consume the structured JSON payload.
+    # ──────────────────────────────────────────────────────────────────────
+    - name: hallucination-trend
+      metric: hallucination
+      condition: fail_rate > 10%
+      window: 1h
+      channel:
+        type: webhook
+        webhookUrl: https://example.com/webhooks/dt-evals

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -110,9 +110,45 @@ alerts:
     faithfulness: 0.7
     factual-accuracy: 0.7
 
-  # (Optional) Webhook notifications on threshold breach.
+  # (Optional) Webhook notifications fired from inside a local `dt-evals run`.
   webhooks:
     - url: https://hooks.slack.com/services/REPLACE_ME
       type: slack
     # - url: https://my-webhook-endpoint.example.com/alerts
     #   type: generic
+
+  # (Optional) Server-side continuous alerts deployed as Dynatrace Workflows.
+  # Run `dt-evals alerts apply <this-file>` to create/update them.
+  # Requires dtctl scopes: automation:workflows:read, automation:workflows:write,
+  # storage:events:read. See README → "Continuous alerts via Dynatrace Workflows".
+  # notifications:
+  #   - name: toxicity-spike
+  #     metric: toxicity
+  #     # condition: "<aggregation> <operator> <value>"
+  #     #   aggregations: avg | max | min | count | fail_rate
+  #     #   fail_rate is a PERCENTAGE — write it with % (e.g. "fail_rate > 10%")
+  #     #   or as a ratio between 0 and 1 (e.g. "fail_rate > 0.1"). Bare values
+  #     #   like "fail_rate > 10" are rejected to avoid the 10 vs 10% trap.
+  #     condition: avg > 2
+  #     window: 15m                  # also the polling interval
+  #     channel:
+  #       type: slack
+  #       connection: my-slack-conn  # dtctl connection name
+  #       channel: "#ai-alerts"
+  #
+  #   - name: hallucination-any
+  #     metric: hallucination
+  #     condition: count > 0         # `count` = number of *failing* evals in window
+  #     window: 5m
+  #     channel:
+  #       type: email
+  #       connection: smtp-default
+  #       to: [ai-team@example.com]
+  #
+  #   - name: relevance-regression
+  #     metric: relevance
+  #     condition: fail_rate > 10%   # i.e. >10% of evals failed in the window
+  #     window: 1h
+  #     channel:
+  #       type: slack
+  #       webhookUrl: https://hooks.slack.com/services/...

--- a/dt-eval-cli/src/alerts/condition.ts
+++ b/dt-eval-cli/src/alerts/condition.ts
@@ -1,0 +1,114 @@
+/**
+ * Condition DSL parser for `alerts.notifications[].condition`.
+ *
+ * Grammar:   <aggregation> <operator> <value>[%]
+ * Examples:  "avg > 2", "count > 0", "fail_rate >= 10%", "max == 5"
+ *
+ * Translated to a DQL fragment that produces a single row named `agg` only when
+ * the comparison holds — so the workflow task downstream just needs to check
+ * whether any rows came back.
+ */
+
+export type Aggregation = 'avg' | 'max' | 'min' | 'count' | 'fail_rate';
+export type Operator = '>' | '>=' | '<' | '<=' | '==' | '!=';
+
+export interface ParsedCondition {
+  aggregation: Aggregation;
+  operator: Operator;
+  value: number;
+  /** True if the user wrote a percentage (e.g. "10%"); only meaningful for fail_rate. */
+  isPercent: boolean;
+  /** The original DSL string, for error messages and rendered descriptions. */
+  raw: string;
+}
+
+const VALID_AGGS: Aggregation[] = ['avg', 'max', 'min', 'count', 'fail_rate'];
+const VALID_OPS: Operator[] = ['>=', '<=', '==', '!=', '>', '<'];
+
+const CONDITION_RE = /^\s*(avg|max|min|count|fail_rate)\s*(>=|<=|==|!=|>|<)\s*(-?\d+(?:\.\d+)?)\s*(%?)\s*$/i;
+
+export class ConditionParseError extends Error {
+  constructor(input: string, hint: string) {
+    super(`Cannot parse condition "${input}": ${hint}`);
+    this.name = 'ConditionParseError';
+  }
+}
+
+export function parseCondition(input: string): ParsedCondition {
+  const m = CONDITION_RE.exec(input);
+  if (!m) {
+    throw new ConditionParseError(
+      input,
+      `expected "<aggregation> <operator> <value>". ` +
+      `aggregations: ${VALID_AGGS.join(' | ')}; operators: ${VALID_OPS.join(' | ')}`,
+    );
+  }
+  const aggregation = m[1]!.toLowerCase() as Aggregation;
+  const operator = m[2] as Operator;
+  const value = Number(m[3]);
+  const isPercent = m[4] === '%';
+  if (Number.isNaN(value)) {
+    throw new ConditionParseError(input, `value "${m[3]}" is not a number`);
+  }
+  if (isPercent && aggregation !== 'fail_rate') {
+    throw new ConditionParseError(input, `% only applies to fail_rate (got ${aggregation})`);
+  }
+  if (aggregation === 'fail_rate' && !isPercent && (value > 1 || value < 0)) {
+    throw new ConditionParseError(
+      input,
+      `fail_rate is a ratio between 0 and 1 — write "${value}%" for a percentage ` +
+      `(e.g. "fail_rate > 10%" = 10% failing), or use a value like 0.1`,
+    );
+  }
+  return { aggregation, operator, value, isPercent, raw: input.trim() };
+}
+
+/**
+ * Build the DQL fragment that follows the `filter event.type == "..." | filter metric == "..."` prelude.
+ * Returns a multi-line string ending with the filter that gates whether the alert fires.
+ *
+ * For `count`: counts rows where score.label == "fail".
+ * For `fail_rate`: countIf(fail) / count(), normalised so `10%` and `0.1` both work.
+ */
+export function conditionToDql(c: ParsedCondition): string {
+  const compareValue = c.aggregation === 'fail_rate' && c.isPercent ? c.value / 100 : c.value;
+
+  switch (c.aggregation) {
+    case 'avg':
+    case 'max':
+    case 'min': {
+      const fn = c.aggregation;
+      return [
+        `| summarize agg = ${fn}(toDouble(gen_ai.evaluation.score.value))`,
+        `| filter agg ${c.operator} ${compareValue}`,
+      ].join('\n');
+    }
+    case 'count': {
+      return [
+        `| filter gen_ai.evaluation.score.label == "fail"`,
+        `| summarize agg = count()`,
+        `| filter agg ${c.operator} ${compareValue}`,
+      ].join('\n');
+    }
+    case 'fail_rate': {
+      return [
+        `| summarize fail_count = countIf(gen_ai.evaluation.score.label == "fail"), total = count()`,
+        `| fieldsAdd agg = if(total > 0, toDouble(fail_count) / toDouble(total), else: 0.0)`,
+        `| filter agg ${c.operator} ${compareValue}`,
+      ].join('\n');
+    }
+  }
+}
+
+/** Human-readable description for rendered messages: "avg toxicity > 2".
+ *  fail_rate is always shown as a percentage so messages don't read "fail_rate > 0.1". */
+export function describeCondition(c: ParsedCondition, metric: string): string {
+  let valueStr: string;
+  if (c.aggregation === 'fail_rate') {
+    const pct = c.isPercent ? c.value : c.value * 100;
+    valueStr = `${Number.isInteger(pct) ? pct : pct.toFixed(2)}%`;
+  } else {
+    valueStr = String(c.value);
+  }
+  return `${c.aggregation} ${metric} ${c.operator} ${valueStr}`;
+}

--- a/dt-eval-cli/src/alerts/dtctl.ts
+++ b/dt-eval-cli/src/alerts/dtctl.ts
@@ -1,0 +1,167 @@
+import { execFile } from 'node:child_process';
+import { unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Required Dynatrace permissions for `dt-evals alerts`:
+ *
+ *   automation:workflows:read   list / get existing workflows (for list, diff, idempotent apply)
+ *   automation:workflows:write  create, update, delete workflows
+ *   automation:workflows:run    (optional) execute a workflow on demand from `alerts run`
+ *   storage:events:read         the workflow body queries gen_ai.evaluation.result bizevents at runtime
+ *
+ * These are scoped to the OAuth user/principal that owns the dtctl context. We
+ * surface them in errors and the README rather than checking up-front, because
+ * dtctl handles auth — failures come back as 401/403 from the API.
+ */
+export const REQUIRED_SCOPES = [
+  'automation:workflows:read',
+  'automation:workflows:write',
+  'storage:events:read',
+] as const;
+
+export const OPTIONAL_SCOPES = [
+  'automation:workflows:run',
+] as const;
+
+export interface DtctlOpts {
+  /** dtctl context name. */
+  context?: string;
+}
+
+export class DtctlError extends Error {
+  constructor(
+    message: string,
+    public readonly stderr: string,
+    public readonly exitCode: number | null,
+    public readonly httpStatus?: number,
+  ) {
+    super(message);
+    this.name = 'DtctlError';
+  }
+}
+
+/**
+ * Inspect a dtctl error blob and classify it. Returns a richer error with
+ * a hint pointing at the missing permission / auth problem.
+ */
+function classifyError(stderr: string, exitCode: number | null): DtctlError {
+  const status = /status (\d{3})/.exec(stderr)?.[1];
+  const httpStatus = status ? parseInt(status, 10) : undefined;
+
+  if (httpStatus === 401 || /JWT|unauthor/i.test(stderr)) {
+    return new DtctlError(
+      'dtctl is not authenticated. Run `dtctl auth login` (or `dtctl auth refresh`) and retry.',
+      stderr, exitCode, httpStatus,
+    );
+  }
+  if (httpStatus === 403 || /forbidden|insufficient/i.test(stderr)) {
+    return new DtctlError(
+      'Permission denied. The dtctl context is missing one of the required scopes: ' +
+      REQUIRED_SCOPES.join(', ') + '. ' +
+      'Ask your Dynatrace admin to grant these to the OAuth client / user.',
+      stderr, exitCode, httpStatus,
+    );
+  }
+  if (httpStatus === 404) {
+    return new DtctlError('Resource not found (404).', stderr, exitCode, httpStatus);
+  }
+  return new DtctlError(`dtctl failed${httpStatus ? ` (HTTP ${httpStatus})` : ''}: ${stderr.trim().split('\n')[0]}`, stderr, exitCode, httpStatus);
+}
+
+function withContext(args: string[], opts: DtctlOpts): string[] {
+  return opts.context ? [...args, '--context', opts.context] : args;
+}
+
+/** Run dtctl with a YAML body. dtctl does not read stdin, so we stage a temp file. */
+async function runDtctlWithFile(args: string[], yaml: string): Promise<string> {
+  const path = join(tmpdir(), `dt-evals-workflow-${process.pid}-${Date.now()}.yaml`);
+  writeFileSync(path, yaml, 'utf-8');
+  try {
+    return await runDtctl(args.map(a => a === '__FILE__' ? path : a));
+  } finally {
+    try { unlinkSync(path); } catch { /* best effort */ }
+  }
+}
+
+async function runDtctl(args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('dtctl', args, { timeout: 60_000, maxBuffer: 10 * 1024 * 1024 });
+    return stdout;
+  } catch (err) {
+    const e = err as { stderr?: string; stdout?: string; code?: number | null };
+    const stderr = (e.stderr ?? '') + (e.stdout ?? '');
+    throw classifyError(stderr, e.code ?? null);
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface WorkflowSummary {
+  id: string;
+  title: string;
+  isDeployed?: boolean;
+  tags?: string[];
+}
+
+export async function listWorkflows(opts: DtctlOpts = {}): Promise<WorkflowSummary[]> {
+  const out = await runDtctl(withContext(['get', 'workflows', '-o', 'json', '--plain'], opts));
+  const trimmed = out.trim();
+  if (!trimmed || trimmed === '[]') return [];
+  const parsed = JSON.parse(trimmed) as unknown;
+  const arr = Array.isArray(parsed)
+    ? parsed
+    : (parsed as { result?: unknown[] })?.result ?? [];
+  return (arr as Array<Record<string, unknown>>).map(w => ({
+    id: String(w['id'] ?? ''),
+    title: String(w['title'] ?? ''),
+    isDeployed: typeof w['isDeployed'] === 'boolean' ? (w['isDeployed'] as boolean) : undefined,
+    tags: Array.isArray(w['tags']) ? (w['tags'] as string[]) : undefined,
+  }));
+}
+
+/** Apply a workflow YAML body (create or update by id). Returns the resulting workflow id. */
+export async function applyWorkflow(yaml: string, opts: DtctlOpts = {}): Promise<string> {
+  const args = withContext(['apply', '-f', '__FILE__', '-o', 'json', '--plain'], opts);
+  const out = await runDtctlWithFile(args, yaml);
+  // dtctl apply emits the resource (json envelope) or a status line. Try both.
+  const trimmed = out.trim();
+  if (!trimmed) throw new DtctlError('dtctl apply returned no output', '', null);
+  try {
+    const parsed = JSON.parse(trimmed) as { id?: string; result?: { id?: string } };
+    const id = parsed.id ?? parsed.result?.id;
+    if (!id) throw new Error('no id in response');
+    return id;
+  } catch {
+    // Fallback: scan for a UUID in the output.
+    const m = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.exec(trimmed);
+    if (m) return m[0];
+    throw new DtctlError(`Could not parse workflow id from dtctl output: ${trimmed.slice(0, 200)}`, '', null);
+  }
+}
+
+export async function deleteWorkflow(id: string, opts: DtctlOpts = {}): Promise<void> {
+  await runDtctl(withContext(['delete', 'workflow', id, '-y'], opts));
+}
+
+export async function getWorkflowYaml(id: string, opts: DtctlOpts = {}): Promise<string> {
+  return runDtctl(withContext(['get', 'workflow', id, '-o', 'yaml', '--plain'], opts));
+}
+
+export async function getWorkflowJson(id: string, opts: DtctlOpts = {}): Promise<Record<string, unknown>> {
+  const out = await runDtctl(withContext(['get', 'workflow', id, '-o', 'json', '--plain'], opts));
+  const parsed = JSON.parse(out.trim()) as unknown;
+  // dtctl wraps single-resource get in {"ok":true,"result":{…}} when running in agent mode
+  if (parsed && typeof parsed === 'object' && 'result' in parsed) {
+    return ((parsed as { result: Record<string, unknown> }).result);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export async function executeWorkflow(id: string, opts: DtctlOpts = {}): Promise<void> {
+  await runDtctl(withContext(['exec', 'workflow', id, '--wait'], opts));
+}

--- a/dt-eval-cli/src/alerts/idmap.ts
+++ b/dt-eval-cli/src/alerts/idmap.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+const STORAGE_DIR = join(homedir(), '.dt-eval');
+
+/**
+ * Map of notification-name -> workflow-id for a single eval config file.
+ * Stored at ~/.dt-eval/alerts-<config-hash>.json so:
+ *   - the same config on different machines produces different files (no collisions),
+ *   - a renamed config file detaches from its old workflows (intentional — user can clean up).
+ */
+export interface AlertIdMap {
+  configPath: string;
+  configName?: string;
+  ids: Record<string, string>;
+}
+
+function hashPath(configPath: string): string {
+  return createHash('sha256').update(resolve(configPath)).digest('hex').slice(0, 16);
+}
+
+export function idMapPath(configPath: string): string {
+  return join(STORAGE_DIR, `alerts-${hashPath(configPath)}.json`);
+}
+
+export function readIdMap(configPath: string): AlertIdMap {
+  const path = idMapPath(configPath);
+  if (!existsSync(path)) {
+    return { configPath: resolve(configPath), ids: {} };
+  }
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as AlertIdMap;
+    return { ...parsed, ids: parsed.ids ?? {} };
+  } catch {
+    return { configPath: resolve(configPath), ids: {} };
+  }
+}
+
+export function writeIdMap(map: AlertIdMap): void {
+  const path = idMapPath(map.configPath);
+  if (!existsSync(STORAGE_DIR)) mkdirSync(STORAGE_DIR, { recursive: true });
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(map, null, 2), 'utf-8');
+}
+
+export function setMapping(map: AlertIdMap, name: string, id: string): AlertIdMap {
+  return { ...map, ids: { ...map.ids, [name]: id } };
+}
+
+export function removeMapping(map: AlertIdMap, name: string): AlertIdMap {
+  const { [name]: _, ...rest } = map.ids;
+  return { ...map, ids: rest };
+}

--- a/dt-eval-cli/src/alerts/render.ts
+++ b/dt-eval-cli/src/alerts/render.ts
@@ -1,0 +1,335 @@
+import { stringify as stringifyYaml } from 'yaml';
+import type { NotificationConfig, NotificationChannel } from '../config/schema.js';
+import { parseCondition, conditionToDql, describeCondition } from './condition.js';
+
+const WORKFLOW_TITLE_PREFIX = '[dt-evals]';
+const MARKER_TAG = 'dt-evals/alert';
+
+export interface RenderContext {
+  /** Eval config `name` — used in workflow title and message body. */
+  configName: string;
+  /** Fallback service.name if the notification doesn't override it. */
+  defaultService?: string;
+  /** Dynatrace environment URL — used to build deep links to AI Observability and the workflow run. */
+  environmentUrl?: string;
+}
+
+/**
+ * Build deep links into the Dynatrace tenant. The primary landing page is the
+ * Prompts Explorer in the GenAI Observability app, filtered to Evaluations and
+ * — when a specific service is being watched — to that service.name. The
+ * workflow-run link is the secondary "what just ran" entry point.
+ *
+ * The fragment format replicates what the Prompts Explorer UI itself produces
+ * when you click into Evaluations and filter by Service: spaces become `+`,
+ * `=` becomes `%3D`, and double-quoted facet names stay quoted.
+ */
+function buildLinks(environmentUrl: string | undefined, service: string):
+  { aiObservability: string; workflowRun: string } | null {
+  if (!environmentUrl) return null;
+  const base = environmentUrl.replace(/\/$/, '');
+  const prefix = `${base}/ui/apps/dynatrace.genai.observability/prompts/prompts-explorer?perspective=Evaluations`;
+  const scoped = service && service !== '*';
+  const aiObservability = scoped
+    ? `${prefix}#filtering="Evaluation+score"+%3D+Yes+Service+%3D+${encodeServiceForFilter(service)}`
+    : `${prefix}#filtering="Evaluation+score"+%3D+Yes`;
+  return {
+    aiObservability,
+    workflowRun: `${base}/ui/apps/dynatrace.automations/executions/{{ execution_id }}`,
+  };
+}
+
+/** Match the Prompts Explorer fragment encoding: space → `+`, everything else → %XX. */
+function encodeServiceForFilter(service: string): string {
+  return encodeURIComponent(service).replace(/%20/g, '+');
+}
+
+export interface RenderedWorkflow {
+  /** YAML body to pass to `dtctl apply -f`. */
+  yaml: string;
+  /** Title that will appear in the Dynatrace UI. */
+  title: string;
+  /** Notification name, copied for convenience. */
+  name: string;
+}
+
+/**
+ * Convert "5m" / "1h" / "30s" / "1d" into a cron expression for
+ * Dynatrace workflow schedule triggers, plus a human label and the DQL `duration("…")` value.
+ *
+ * Note: seconds are not representable in cron. We clamp `<60s` up to 1m.
+ */
+export function parseWindow(window: string): { cron: string; humanText: string; dqlDuration: string } {
+  const m = /^(\d+)([smhd])$/.exec(window);
+  if (!m) throw new Error(`Invalid window "${window}" — expected like "5m", "1h", "24h"`);
+  const n = parseInt(m[1]!, 10);
+  const unit = m[2] as 's' | 'm' | 'h' | 'd';
+  if (n <= 0) throw new Error(`Window must be > 0 (got "${window}")`);
+
+  const humanUnit: Record<typeof unit, string> = { s: 'second', m: 'minute', h: 'hour', d: 'day' };
+  let cron: string;
+  switch (unit) {
+    case 's':
+    case 'm': {
+      const minutes = unit === 's' ? Math.max(1, Math.round(n / 60)) : n;
+      cron = minutes >= 60 ? `0 */${Math.floor(minutes / 60)} * * *` : `*/${minutes} * * * *`;
+      break;
+    }
+    case 'h':
+      cron = `0 */${n} * * *`;
+      break;
+    case 'd':
+      cron = `0 0 */${n} * *`;
+      break;
+  }
+  return {
+    cron,
+    humanText: `${n} ${humanUnit[unit]}${n === 1 ? '' : 's'}`,
+    dqlDuration: window,
+  };
+}
+
+/** Escape a string for safe embedding into a DQL double-quoted literal. */
+function dqlString(v: string): string {
+  return v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function buildDqlQuery(n: NotificationConfig, defaultService: string | undefined, window: string): string {
+  const parsed = parseCondition(n.condition);
+  const service = n.service ?? defaultService;
+  const serviceFilter = service && service !== '*'
+    ? `| filter dt.service.name == "${dqlString(service)}" or service.name == "${dqlString(service)}" or k8s.container.name == "${dqlString(service)}" or dt.entity.service.name == "${dqlString(service)}"\n`
+    : '';
+  return [
+    `fetch bizevents, from: now() - duration("${window}")`,
+    `| filter event.type == "gen_ai.evaluation.result"`,
+    `| filter gen_ai.evaluation.name == "${dqlString(n.metric)}"`,
+    serviceFilter.trimEnd(),
+    conditionToDql(parsed),
+  ].filter(Boolean).join('\n');
+}
+
+interface MessageFields {
+  notificationName: string;
+  configName: string;
+  service: string;
+  metric: string;
+  threshold: string;     // human description, e.g. "avg > 2"
+  windowText: string;    // e.g. "15 minutes"
+  observedExpr: string;  // template expression for observed value at runtime
+  links: { aiObservability: string; workflowRun: string } | null;
+}
+
+/** Slack mrkdwn body. `<url|text>` becomes a clickable link in Slack. */
+function slackBody(f: MessageFields): string {
+  const lines = [
+    `:rotating_light: *dt-evals alert — ${f.notificationName}*`,
+    '',
+    `*Service:* \`${f.service}\``,
+    `*Metric:* \`${f.metric}\``,
+    `*Threshold breached:* \`${f.threshold}\`  _(window: ${f.windowText})_`,
+    `*Observed:* \`${f.observedExpr}\``,
+    `*Config:* \`${f.configName}\``,
+  ];
+  if (f.links) {
+    lines.push('');
+    lines.push(`<${f.links.aiObservability}|Open AI Observability →>   ·   <${f.links.workflowRun}|View workflow run →>`);
+  }
+  return lines.join('\n');
+}
+
+/** Plain-text email body. Keep it scannable on phones. */
+function emailBody(f: MessageFields): string {
+  const lines = [
+    `dt-evals alert — ${f.notificationName}`,
+    '─'.repeat(40),
+    '',
+    `Service:            ${f.service}`,
+    `Metric:             ${f.metric}`,
+    `Threshold breached: ${f.threshold}  (window: ${f.windowText})`,
+    `Observed:           ${f.observedExpr}`,
+    `Config:             ${f.configName}`,
+  ];
+  if (f.links) {
+    lines.push('', 'Links:');
+    lines.push(`  AI Observability: ${f.links.aiObservability}`);
+    lines.push(`  Workflow run:     ${f.links.workflowRun}`);
+  }
+  lines.push('', '— Sent by dt-evals');
+  return lines.join('\n');
+}
+
+/**
+ * JSON body for generic / Slack-incoming-webhook POSTs. We send both a flat
+ * `text` field (for Slack-style consumers) and a structured `alert` object so
+ * other consumers (PagerDuty proxy, custom routers) can read fields directly.
+ */
+function webhookBody(f: MessageFields): string {
+  return JSON.stringify({
+    text: slackBody(f),
+    alert: {
+      notification: f.notificationName,
+      config: f.configName,
+      service: f.service,
+      metric: f.metric,
+      threshold: f.threshold,
+      window: f.windowText,
+      observed: f.observedExpr,
+      links: f.links ?? undefined,
+    },
+  });
+}
+
+function buildSlackTask(channel: NotificationChannel, f: MessageFields): Record<string, unknown> {
+  // type:slack always uses the Dynatrace Slack app action, which renders the proper
+  // form UI (connection dropdown, channel picker, markdown message). Validation in
+  // src/config/index.ts ensures connection is set and webhookUrl is not.
+  return {
+    action: 'dynatrace.slack:slack-send-message',
+    name: 'notify',
+    description: 'Send Slack message',
+    input: {
+      connection: channel.connection,
+      channel: channel.channel ?? '#general',
+      message: slackBody(f),
+      reactions: [],
+      reply_in_thread: false,
+    },
+  };
+}
+
+function buildEmailTask(channel: NotificationChannel, subject: string, f: MessageFields): Record<string, unknown> {
+  // Field shape matches what the Dynatrace email action actually accepts:
+  // flat to/cc/bcc/subject/content — no `connection` block, no `body: { body, contentType }` wrapper.
+  return {
+    action: 'dynatrace.email:send-email',
+    name: 'notify',
+    description: 'Send email notification',
+    input: {
+      subject: channel.subject ?? subject,
+      to: channel.to ?? [],
+      cc: [],
+      bcc: [],
+      content: emailBody(f),
+    },
+  };
+}
+
+function buildGenericWebhookTask(channel: NotificationChannel, f: MessageFields): Record<string, unknown> {
+  return {
+    action: 'dynatrace.automations:run-javascript',
+    name: 'notify',
+    description: 'POST to webhook',
+    input: {
+      script: webhookScript(channel.webhookUrl!, webhookBody(f)),
+    },
+  };
+}
+
+/**
+ * Build a small JS module that POSTs the given JSON body to the URL.
+ * Uses `dynatrace.automations:run-javascript`, which is a core action available
+ * on every tenant — no extra app install required.
+ *
+ * The JSON body may contain Jinja placeholders like `{{ result(...) }}`;
+ * AutomationEngine substitutes those across the entire `script` field at runtime.
+ */
+function webhookScript(url: string, body: string): string {
+  // Escape characters that would break a JS backtick template literal.
+  const safeBody = body
+    .replace(/\\/g, '\\\\')
+    .replace(/`/g, '\\`')
+    .replace(/\$\{/g, '\\${');
+  const safeUrl = url.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return [
+    'export default async function () {',
+    `  const response = await fetch("${safeUrl}", {`,
+    '    method: "POST",',
+    '    headers: { "Content-Type": "application/json" },',
+    '    body: `' + safeBody + '`,',
+    '  });',
+    '  if (!response.ok) {',
+    '    const text = await response.text();',
+    '    throw new Error("Webhook failed: " + response.status + " " + text);',
+    '  }',
+    '  return { status: response.status };',
+    '}',
+    '',
+  ].join('\n');
+}
+
+export function renderWorkflow(
+  n: NotificationConfig,
+  ctx: RenderContext,
+  existingId?: string,
+): RenderedWorkflow {
+  const parsed = parseCondition(n.condition);
+  const window = parseWindow(n.window);
+  const service = n.service ?? ctx.defaultService ?? '*';
+  const title = `${WORKFLOW_TITLE_PREFIX} ${ctx.configName}:${n.name}`;
+  const dql = buildDqlQuery(n, ctx.defaultService, window.dqlDuration);
+  const description = describeCondition(parsed, n.metric);
+  const fields: MessageFields = {
+    notificationName: n.name,
+    configName: ctx.configName,
+    service,
+    metric: n.metric,
+    threshold: description,
+    windowText: window.humanText,
+    observedExpr: '{{ result("query_scores").records[0].agg }}',
+    links: buildLinks(ctx.environmentUrl, service),
+  };
+  const emailSubject = `[dt-evals] ${service} — ${description}`;
+
+  let notifyTask: Record<string, unknown>;
+  if (n.channel.type === 'slack') notifyTask = buildSlackTask(n.channel, fields);
+  else if (n.channel.type === 'email') notifyTask = buildEmailTask(n.channel, emailSubject, fields);
+  else notifyTask = buildGenericWebhookTask(n.channel, fields);
+
+  const workflow: Record<string, unknown> = {
+    ...(existingId ? { id: existingId } : {}),
+    title,
+    description: `dt-evals alert: ${description}. Auto-generated; do not edit by hand.`,
+    isPrivate: false,
+    tags: [MARKER_TAG, `config:${ctx.configName}`, `notification:${n.name}`, `metric:${n.metric}`],
+    trigger: {
+      schedule: {
+        trigger: {
+          type: 'cron',
+          cron: window.cron,
+        },
+        isActive: true,
+        isFaulty: false,
+        timezone: 'UTC',
+      },
+    },
+    tasks: {
+      query_scores: {
+        name: 'query_scores',
+        description: 'Fetch eval bizevents in window and apply condition',
+        action: 'dynatrace.automations:execute-dql-query',
+        input: { query: dql },
+        position: { x: 0, y: 1 },
+        predecessors: [],
+      },
+      notify: {
+        ...notifyTask,
+        position: { x: 0, y: 2 },
+        predecessors: ['query_scores'],
+        conditions: {
+          states: { query_scores: 'SUCCESS' },
+          custom: '{{ result("query_scores").records | length > 0 }}',
+        },
+      },
+    },
+  };
+
+  const yaml = stringifyYaml(workflow, { indent: 2, lineWidth: 0 });
+  return { yaml, title, name: n.name };
+}
+
+export function workflowTitle(configName: string, notificationName: string): string {
+  return `${WORKFLOW_TITLE_PREFIX} ${configName}:${notificationName}`;
+}
+
+export { MARKER_TAG };

--- a/dt-eval-cli/src/cli/commands/alerts.ts
+++ b/dt-eval-cli/src/cli/commands/alerts.ts
@@ -1,0 +1,460 @@
+import { Command } from 'commander';
+import { writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import { loadConfig, validateConfig } from '../../config/index.js';
+import type { DtEvalConfig, NotificationConfig } from '../../config/schema.js';
+import { renderWorkflow, workflowTitle, type RenderContext } from '../../alerts/render.js';
+import { resolveEndpoints } from '../../config/schema.js';
+import { listContexts } from '../../dtctl/index.js';
+
+const ALERT_TITLE_PREFIX = '[dt-evals]';
+import { readIdMap, writeIdMap, setMapping, removeMapping, idMapPath } from '../../alerts/idmap.js';
+import {
+  applyWorkflow,
+  listWorkflows,
+  deleteWorkflow,
+  getWorkflowJson,
+  REQUIRED_SCOPES,
+  OPTIONAL_SCOPES,
+  DtctlError,
+} from '../../alerts/dtctl.js';
+import { logger } from '../../logger/index.js';
+import { renderTable } from '../../ui/table.js';
+
+interface CommonOpts {
+  config?: string;
+  context?: string;
+}
+
+interface LoadedConfig {
+  config: DtEvalConfig;
+  path: string;
+}
+
+function loadAndValidate(configArg: string | undefined, commonOpts: CommonOpts): LoadedConfig {
+  const path = configArg ?? commonOpts.config;
+  if (!path) {
+    logger.error('No config file specified. Pass it as an argument: dt-evals alerts apply my.dt-eval.yaml');
+    process.exit(1);
+  }
+  if (!existsSync(path)) {
+    logger.error(`Config file not found: ${path}`);
+    process.exit(1);
+  }
+  let config: DtEvalConfig;
+  try {
+    config = loadConfig({ projectFile: path });
+    validateConfig(config);
+  } catch (err) {
+    logger.error(`Config error: ${(err as Error).message}`);
+    process.exit(1);
+  }
+  return { config, path };
+}
+
+function getNotifications(config: DtEvalConfig): NotificationConfig[] {
+  return config.alerts?.notifications ?? [];
+}
+
+/** Shared render context for all callsites: pulls configName, default service, and tenant URL. */
+function renderContext(config: DtEvalConfig): RenderContext {
+  const { origin } = resolveEndpoints(config.dynatrace);
+  return {
+    configName: config.name ?? 'unnamed',
+    defaultService: config.scope?.service,
+    environmentUrl: origin.environmentUrl || undefined,
+  };
+}
+
+/**
+ * Resolve the tenant URL we're actually talking to. When `--context X` is
+ * passed, use the URL on the dtctl context; otherwise fall back to the eval
+ * config's environmentUrl. This avoids printing a misleading review-link when
+ * the user deploys to a different tenant than the YAML names.
+ */
+async function resolveTenantUrl(config: DtEvalConfig, contextName: string | undefined): Promise<string | null> {
+  if (contextName) {
+    try {
+      const ctxs = await listContexts();
+      const match = ctxs.find(c => c.name === contextName);
+      if (match?.environmentUrl) return match.environmentUrl;
+    } catch { /* fall through to config */ }
+  }
+  const { origin } = resolveEndpoints(config.dynatrace);
+  return origin.environmentUrl || null;
+}
+
+async function workflowsAppUrl(config: DtEvalConfig, contextName: string | undefined): Promise<string | null> {
+  const base = await resolveTenantUrl(config, contextName);
+  if (!base) return null;
+  return `${base.replace(/\/$/, '')}/ui/apps/dynatrace.automations/workflows?search=dt-evals&owner=all`;
+}
+
+/**
+ * If any of the applied notifications use `connection:`, explain that the
+ * connection must exist in Dynatrace before the workflow can actually deliver.
+ * Slack and SMTP connections are NOT auto-provisioned by `apply`.
+ */
+function printConnectionCallout(notifications: NotificationConfig[]): void {
+  const slackConns = new Set<string>();
+  let hasEmail = false;
+  for (const n of notifications) {
+    if (n.channel.type === 'slack' && n.channel.connection) slackConns.add(n.channel.connection);
+    if (n.channel.type === 'email') hasEmail = true;
+  }
+  if (slackConns.size === 0 && !hasEmail) return;
+
+  logger.info('');
+  logger.info('⚠  Setup required for notifications to actually deliver:');
+  if (slackConns.size > 0) {
+    logger.info(`  Slack: workflows reference connection(s) ${[...slackConns].map(c => `"${c}"`).join(', ')}.`);
+    logger.info('    Set them up in Dynatrace → Settings → Connections → Slack (OAuth).');
+    logger.info('    Until the connection exists with the same name, the Slack notify task will fail.');
+  }
+  if (hasEmail) {
+    logger.info('  Email: the Dynatrace email action uses your tenant default mail config —');
+    logger.info('    configure it under Dynatrace → Settings → Notifications. No per-workflow');
+    logger.info('    connection name is needed.');
+  }
+}
+
+function logPermissionHint(): void {
+  logger.info('');
+  logger.info('Required permissions on the dtctl OAuth principal:');
+  for (const s of REQUIRED_SCOPES) logger.info(`  • ${s}`);
+  logger.info(`  • (optional) ${OPTIONAL_SCOPES.join(', ')}`);
+}
+
+function handleDtctlError(action: string, err: unknown): never {
+  if (err instanceof DtctlError) {
+    logger.error(`${action} failed: ${err.message}`);
+    if (err.httpStatus === 401 || err.httpStatus === 403) logPermissionHint();
+    if (err.stderr && process.env['DT_EVAL_DEBUG']) logger.error(err.stderr);
+  } else {
+    logger.error(`${action} failed: ${(err as Error).message}`);
+  }
+  process.exit(1);
+}
+
+// ── Subcommands ──────────────────────────────────────────────────────────────
+
+function createRenderCommand(): Command {
+  const cmd = new Command('render');
+  cmd.description('Print rendered workflow YAML for each notification (no API calls)');
+  cmd.argument('[config]', 'Path to eval config file');
+  cmd.option('--config <path>', 'Path to eval config file');
+  cmd.option('--name <name>', 'Render only this notification by name');
+  cmd.option('--out <dir>', 'Write each workflow to <dir>/<name>.workflow.yaml instead of stdout');
+
+  cmd.action(async (configArg: string | undefined, opts: CommonOpts & { name?: string; out?: string }) => {
+    const { config, path } = loadAndValidate(configArg, opts);
+    const notifications = getNotifications(config);
+    if (notifications.length === 0) {
+      logger.warn(`No alerts.notifications defined in ${path}`);
+      logger.info('Add a `notifications:` block under `alerts:` to get started — see docs/alerts-design.md');
+      return;
+    }
+    const idMap = readIdMap(path);
+    const filtered = opts.name ? notifications.filter(n => n.name === opts.name) : notifications;
+    if (filtered.length === 0) {
+      logger.error(`Notification not found: ${opts.name}`);
+      process.exit(1);
+    }
+    for (const n of filtered) {
+      try {
+        const rendered = renderWorkflow(n, renderContext(config), idMap.ids[n.name]);
+        if (opts.out) {
+          const outPath = join(opts.out, `${n.name}.workflow.yaml`);
+          writeFileSync(outPath, rendered.yaml, 'utf-8');
+          logger.success(`Wrote ${outPath}`);
+        } else {
+          console.log(`# ── ${rendered.title} ──`);
+          console.log(rendered.yaml);
+          console.log('');
+        }
+      } catch (err) {
+        logger.error(`Failed to render "${n.name}": ${(err as Error).message}`);
+        process.exit(1);
+      }
+    }
+  });
+
+  return cmd;
+}
+
+function createApplyCommand(): Command {
+  const cmd = new Command('apply');
+  cmd.description('Deploy notifications as Dynatrace Workflows (create or update). Idempotent.');
+  cmd.argument('[config]', 'Path to eval config file');
+  cmd.option('--config <path>', 'Path to eval config file');
+  cmd.option('--context <name>', 'dtctl context to use');
+  cmd.option('--dry-run', 'Render workflows and print what would happen, without calling dtctl');
+  cmd.option('--name <name>', 'Apply only this notification by name');
+
+  cmd.action(async (configArg: string | undefined, opts: CommonOpts & { dryRun?: boolean; name?: string }) => {
+    const { config, path } = loadAndValidate(configArg, opts);
+    const notifications = getNotifications(config);
+    if (notifications.length === 0) {
+      logger.warn(`No alerts.notifications defined in ${path} — nothing to apply.`);
+      return;
+    }
+    const idMap = readIdMap(path);
+    idMap.configName = config.name;
+    const filtered = opts.name ? notifications.filter(n => n.name === opts.name) : notifications;
+    if (filtered.length === 0) {
+      logger.error(`Notification not found: ${opts.name}`);
+      process.exit(1);
+    }
+
+    logger.info(`Applying ${filtered.length} notification(s) to dtctl context: ${opts.context ?? '(current)'}`);
+
+    const rows: string[][] = [];
+    let updated = idMap;
+
+    for (const n of filtered) {
+      const existingId = updated.ids[n.name];
+      let rendered;
+      try {
+        rendered = renderWorkflow(n, renderContext(config), existingId);
+      } catch (err) {
+        logger.error(`Render failed for "${n.name}": ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      if (opts.dryRun) {
+        const tmp = join(tmpdir(), `dt-evals-alert-${n.name}-${Date.now()}.yaml`);
+        writeFileSync(tmp, rendered.yaml, 'utf-8');
+        rows.push([n.name, existingId ? 'would update' : 'would create', existingId ?? '-', tmp]);
+        continue;
+      }
+
+      try {
+        logger.step(`apply ${n.name}${existingId ? ` (update ${existingId})` : ' (create)'}`);
+        const id = await applyWorkflow(rendered.yaml, { context: opts.context });
+        updated = setMapping(updated, n.name, id);
+        writeIdMap(updated);
+        rows.push([n.name, existingId ? 'updated' : 'created', id, rendered.title]);
+      } catch (err) {
+        handleDtctlError(`apply "${n.name}"`, err);
+      }
+    }
+
+    console.log(renderTable(['Name', 'Action', 'Workflow ID', opts.dryRun ? 'Rendered to' : 'Title'], rows));
+    if (opts.dryRun) {
+      logger.info('Dry run — no workflows were created or updated.');
+    } else {
+      logger.success(`Done. State stored at ${idMapPath(path)}`);
+      const url = await workflowsAppUrl(config, opts.context);
+      if (url) logger.info(`Review in Dynatrace: ${url}`);
+      printConnectionCallout(filtered);
+    }
+  });
+
+  return cmd;
+}
+
+function createListCommand(): Command {
+  const cmd = new Command('list');
+  cmd.description('List deployed alert workflows owned by this config');
+  cmd.argument('[config]', 'Path to eval config file');
+  cmd.option('--config <path>', 'Path to eval config file');
+  cmd.option('--context <name>', 'dtctl context to use');
+  cmd.option('--all', 'Show every workflow tagged dt-evals/alert, not just this config');
+
+  cmd.action(async (configArg: string | undefined, opts: CommonOpts & { all?: boolean }) => {
+    const path = configArg ?? opts.config;
+    let allowed: Set<string> | null = null;
+    let resolvedConfig: DtEvalConfig | undefined;
+    if (path) {
+      const loaded = loadAndValidate(configArg, opts);
+      resolvedConfig = loaded.config;
+      if (!opts.all) {
+        const notifications = getNotifications(loaded.config);
+        const idMap = readIdMap(path);
+        allowed = new Set(notifications.map(n => workflowTitle(loaded.config.name ?? 'unnamed', n.name)));
+        for (const id of Object.values(idMap.ids)) allowed.add(id);
+      }
+    }
+
+    let workflows;
+    try {
+      workflows = await listWorkflows({ context: opts.context });
+    } catch (err) {
+      handleDtctlError('list workflows', err);
+    }
+
+    const filtered = workflows.filter(w => {
+      const isDtEvals = w.title.startsWith(ALERT_TITLE_PREFIX);
+      if (!isDtEvals) return false;
+      if (allowed && !(allowed.has(w.title) || allowed.has(w.id))) return false;
+      return true;
+    });
+
+    if (filtered.length === 0) {
+      logger.info('No alert workflows found.');
+    } else {
+      console.log(renderTable(
+        ['Workflow ID', 'Title', 'Deployed'],
+        filtered.map(w => [w.id, w.title, w.isDeployed ? 'yes' : 'no']),
+      ));
+    }
+    const url = resolvedConfig ? await workflowsAppUrl(resolvedConfig, opts.context) : null;
+    if (url) logger.info(`Review in Dynatrace: ${url}`);
+  });
+
+  return cmd;
+}
+
+function createDeleteCommand(): Command {
+  const cmd = new Command('delete');
+  cmd.description('Delete one or all alert workflows for a config');
+  cmd.argument('[config]', 'Path to eval config file');
+  cmd.option('--config <path>', 'Path to eval config file');
+  cmd.option('--context <name>', 'dtctl context to use');
+  cmd.option('--name <name>', 'Delete only this notification');
+  cmd.option('--all', 'Delete every notification owned by this config');
+
+  cmd.action(async (configArg: string | undefined, opts: CommonOpts & { name?: string; all?: boolean }) => {
+    if (!opts.name && !opts.all) {
+      logger.error('Specify either --name <name> or --all');
+      process.exit(1);
+    }
+    const { path } = loadAndValidate(configArg, opts);
+    let map = readIdMap(path);
+    const targets = opts.all
+      ? Object.entries(map.ids)
+      : Object.entries(map.ids).filter(([n]) => n === opts.name);
+
+    if (targets.length === 0) {
+      logger.warn(opts.all ? 'No alert workflows tracked for this config.' : `No workflow tracked for "${opts.name}"`);
+      return;
+    }
+
+    for (const [name, id] of targets) {
+      try {
+        await deleteWorkflow(id, { context: opts.context });
+        map = removeMapping(map, name);
+        writeIdMap(map);
+        logger.success(`Deleted "${name}" (${id})`);
+      } catch (err) {
+        if (err instanceof DtctlError && err.httpStatus === 404) {
+          logger.warn(`"${name}" (${id}) already gone — clearing local mapping`);
+          map = removeMapping(map, name);
+          writeIdMap(map);
+          continue;
+        }
+        handleDtctlError(`delete "${name}"`, err);
+      }
+    }
+  });
+
+  return cmd;
+}
+
+function createDiffCommand(): Command {
+  const cmd = new Command('diff');
+  cmd.description('Show diff between local (rendered) and remote workflow body');
+  cmd.argument('[config]', 'Path to eval config file');
+  cmd.option('--config <path>', 'Path to eval config file');
+  cmd.option('--context <name>', 'dtctl context to use');
+  cmd.option('--name <name>', 'Limit to one notification');
+
+  cmd.action(async (configArg: string | undefined, opts: CommonOpts & { name?: string }) => {
+    const { config, path } = loadAndValidate(configArg, opts);
+    const notifications = getNotifications(config);
+    const idMap = readIdMap(path);
+    const filtered = opts.name ? notifications.filter(n => n.name === opts.name) : notifications;
+
+    for (const n of filtered) {
+      const id = idMap.ids[n.name];
+      if (!id) {
+        logger.info(`"${n.name}": not yet applied (no remote to diff against). Run \`dt-evals alerts apply\` first.`);
+        continue;
+      }
+      let remote;
+      try {
+        remote = await getWorkflowJson(id, { context: opts.context });
+      } catch (err) {
+        handleDtctlError(`fetch remote "${n.name}"`, err);
+      }
+      const rendered = renderWorkflow(n, renderContext(config), id);
+      const localObj = parseYaml(rendered.yaml) as Record<string, unknown>;
+
+      console.log(`# ── diff: ${n.name} (workflow ${id}) ──`);
+      const remoteNorm = normalizeWorkflowObject(remote);
+      const localNorm = normalizeWorkflowObject(localObj);
+      if (remoteNorm === localNorm) {
+        console.log('  (in sync)');
+      } else {
+        printUnifiedDiff(remoteNorm, localNorm);
+      }
+      console.log('');
+    }
+  });
+
+  return cmd;
+}
+
+/**
+ * Strip server-injected fields and re-emit YAML with deterministic key ordering
+ * so the diff shows only meaningful drift. Operates on parsed objects so it works
+ * for either the JSON or YAML shape dtctl returns.
+ */
+function normalizeWorkflowObject(doc: unknown): string {
+  if (!doc || typeof doc !== 'object') return String(doc);
+  const SERVER_KEYS = new Set([
+    'owner', 'ownerType', 'isDeployed', 'isPrivate', 'lastExecution',
+    'modificationInfo', 'usages', 'throttle', 'schemaVersion',
+    'taskDefaults', 'actor',
+    // server-side trigger metadata that varies between create-time and runtime
+    'filterParameters', 'inputs', 'nextExecution', 'isFaulty',
+    // we set tags on submit but the API discards them — drop on both sides to keep
+    // the diff focused on fields the server actually persists
+    'tags',
+  ]);
+  const strip = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(strip);
+    if (v && typeof v === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+        if (SERVER_KEYS.has(k)) continue;
+        if (val === null) continue;
+        out[k] = strip(val);
+      }
+      return out;
+    }
+    return v;
+  };
+  return stringifyYaml(strip(doc), { indent: 2, lineWidth: 0, sortMapEntries: true });
+}
+
+function printUnifiedDiff(remote: string, local: string): void {
+  const remoteLines = remote.split('\n');
+  const localLines = local.split('\n');
+  const max = Math.max(remoteLines.length, localLines.length);
+  for (let i = 0; i < max; i++) {
+    const r = remoteLines[i];
+    const l = localLines[i];
+    if (r === l) continue;
+    if (r !== undefined) console.log(`- ${r}`);
+    if (l !== undefined) console.log(`+ ${l}`);
+  }
+}
+
+// ── Top-level ────────────────────────────────────────────────────────────────
+
+export function createAlertsCommand(): Command {
+  const cmd = new Command('alerts');
+  cmd.description(
+    'Manage server-side eval alerts as Dynatrace Workflows. ' +
+    `Requires dtctl scopes: ${REQUIRED_SCOPES.join(', ')}.`,
+  );
+  cmd.addCommand(createApplyCommand());
+  cmd.addCommand(createRenderCommand());
+  cmd.addCommand(createListCommand());
+  cmd.addCommand(createDiffCommand());
+  cmd.addCommand(createDeleteCommand());
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/index.ts
+++ b/dt-eval-cli/src/cli/index.ts
@@ -8,6 +8,7 @@ import { createEvaluatorsCommand } from './commands/evaluators.js';
 import { createRunsCommand } from './commands/runs.js';
 import { createValidateCommand } from './commands/validate.js';
 import { createDoctorCommand } from './commands/doctor.js';
+import { createAlertsCommand } from './commands/alerts.js';
 import { configureLogger } from '../logger/index.js';
 import { printBanner } from '../ui/banner.js';
 
@@ -55,6 +56,7 @@ export function createCli(): Command {
   program.addCommand(createEvaluatorsCommand());
   program.addCommand(createRunsCommand());
   program.addCommand(createScheduleCommand());
+  program.addCommand(createAlertsCommand());
 
   return program;
 }

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -12,6 +12,7 @@ import {
   type MetricsConfig,
 } from './schema.js';
 import { DEFAULT_CONFIG, DEFAULT_JUDGE_MODELS } from './defaults.js';
+import { parseCondition, ConditionParseError } from '../alerts/condition.js';
 
 export class ConfigValidationError extends Error {
   constructor(public readonly issues: string[]) {
@@ -234,6 +235,63 @@ export function validateConfig(config: DtEvalConfig): void {
       } else {
         issues.push(`metrics.enabled[${i}] must be a string or { id, inputs? } object`);
       }
+    }
+  }
+
+  if (config.alerts?.notifications) {
+    for (const [i, n] of config.alerts.notifications.entries()) {
+      const where = `alerts.notifications[${i}]`;
+      if (!n.name?.trim()) issues.push(`${where}.name is required`);
+      if (!n.metric?.trim()) issues.push(`${where}.metric is required`);
+      if (!n.condition?.trim()) {
+        issues.push(`${where}.condition is required (e.g. "avg > 2")`);
+      } else {
+        try { parseCondition(n.condition); }
+        catch (err) {
+          if (err instanceof ConditionParseError) issues.push(`${where}.condition: ${err.message}`);
+          else throw err;
+        }
+      }
+      if (!n.window?.trim()) issues.push(`${where}.window is required (e.g. "15m")`);
+      else if (!/^\d+[smhd]$/.test(n.window)) issues.push(`${where}.window must be like "5m", "1h", "24h"`);
+      if (!n.channel) {
+        issues.push(`${where}.channel is required`);
+      } else {
+        const c = n.channel;
+        if (!['slack', 'email', 'webhook'].includes(c.type)) {
+          issues.push(`${where}.channel.type must be slack | email | webhook (got "${c.type}")`);
+        }
+        if (c.type === 'slack') {
+          if (c.webhookUrl) {
+            issues.push(
+              `${where}.channel: type:slack uses the Dynatrace Slack action; remove webhookUrl and set connection: <name>. ` +
+              `For an inline incoming-webhook URL, use type:webhook instead.`,
+            );
+          }
+          if (!c.connection) {
+            issues.push(`${where}.channel.connection is required for type:slack (the Dynatrace Slack connection name)`);
+          }
+        }
+        if (c.type === 'email') {
+          if (c.webhookUrl) {
+            issues.push(`${where}.channel: email channels use the Dynatrace email action; remove webhookUrl`);
+          }
+          if (!c.to || c.to.length === 0) {
+            issues.push(`${where}.channel.to is required for email`);
+          }
+          // No connection requirement — the Dynatrace email action uses the
+          // tenant's configured outbound mail (Settings → Notifications), not a
+          // per-workflow connection.
+        }
+        if (c.type === 'webhook' && !c.webhookUrl) {
+          issues.push(`${where}.channel.webhookUrl is required for type:webhook`);
+        }
+      }
+    }
+    const names = config.alerts.notifications.map(n => n.name).filter(Boolean);
+    const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+    if (dupes.length > 0) {
+      issues.push(`alerts.notifications: duplicate name(s): ${[...new Set(dupes)].join(', ')}`);
     }
   }
 

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -107,6 +107,42 @@ export interface MetricsConfig {
 export interface AlertsConfig {
   thresholds: Record<string, number>; // metric -> threshold score
   webhooks?: Array<{ url: string; type: 'slack' | 'generic' }>;
+  /**
+   * Server-side notifications deployed as Dynatrace Workflows.
+   * Each entry becomes one workflow that polls eval bizevents on a schedule and
+   * fires a Slack / email / generic-webhook task when the condition is met.
+   */
+  notifications?: NotificationConfig[];
+}
+
+export type NotificationChannelType = 'slack' | 'email' | 'webhook';
+
+export interface NotificationChannel {
+  type: NotificationChannelType;
+  /** Name of a Dynatrace connection (Slack OAuth or SMTP). Mutually exclusive with `webhookUrl`. */
+  connection?: string;
+  /** Inline Slack incoming-webhook URL or generic HTTP endpoint. Mutually exclusive with `connection`. */
+  webhookUrl?: string;
+  /** Slack channel id or "#name". Required for slack+connection, optional for slack+webhookUrl (the webhook is channel-bound). */
+  channel?: string;
+  /** Email recipients. Required for email. */
+  to?: string[];
+  /** Optional email subject override. */
+  subject?: string;
+}
+
+export interface NotificationConfig {
+  /** Stable identifier for this notification within the config — used as workflow title suffix and id-map key. */
+  name: string;
+  /** Metric id this alert watches (e.g. "toxicity"). */
+  metric: string;
+  /** Condition DSL: "<aggregation> <operator> <value>". See docs/alerts-design.md. */
+  condition: string;
+  /** Look-back window AND polling interval (e.g. "5m", "15m", "1h"). */
+  window: string;
+  /** Optional service.name filter. Defaults to `scope.service`. Set to "*" to watch all services. */
+  service?: string;
+  channel: NotificationChannel;
 }
 
 export interface DtEvalConfig {

--- a/dt-eval-cli/tests/alerts/condition.test.ts
+++ b/dt-eval-cli/tests/alerts/condition.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { parseCondition, conditionToDql, ConditionParseError, describeCondition } from '../../src/alerts/condition.js';
+
+describe('parseCondition', () => {
+  it('parses simple aggregation comparisons', () => {
+    expect(parseCondition('avg > 2')).toMatchObject({ aggregation: 'avg', operator: '>', value: 2, isPercent: false });
+    expect(parseCondition('count >= 5')).toMatchObject({ aggregation: 'count', operator: '>=', value: 5 });
+    expect(parseCondition('max == 4')).toMatchObject({ aggregation: 'max', operator: '==', value: 4 });
+    expect(parseCondition('min < 0.5')).toMatchObject({ aggregation: 'min', operator: '<', value: 0.5 });
+  });
+
+  it('accepts %% only for fail_rate', () => {
+    expect(parseCondition('fail_rate > 10%')).toMatchObject({ aggregation: 'fail_rate', value: 10, isPercent: true });
+    expect(parseCondition('fail_rate > 0.1')).toMatchObject({ aggregation: 'fail_rate', value: 0.1, isPercent: false });
+    expect(() => parseCondition('avg > 10%')).toThrow(ConditionParseError);
+  });
+
+  it('rejects unknown aggregations and operators', () => {
+    expect(() => parseCondition('foobar > 1')).toThrow(ConditionParseError);
+    expect(() => parseCondition('avg ~ 1')).toThrow(ConditionParseError);
+    expect(() => parseCondition('not a condition')).toThrow(ConditionParseError);
+  });
+
+  it('is case-insensitive on aggregation name', () => {
+    expect(parseCondition('AVG > 2').aggregation).toBe('avg');
+  });
+});
+
+describe('conditionToDql', () => {
+  it('renders avg/max/min as summarize + filter', () => {
+    const dql = conditionToDql(parseCondition('avg > 2'));
+    expect(dql).toContain('avg(toDouble(gen_ai.evaluation.score.value))');
+    expect(dql).toContain('filter agg > 2');
+  });
+
+  it('renders count as countIf-on-fail + filter', () => {
+    const dql = conditionToDql(parseCondition('count > 0'));
+    expect(dql).toContain('score.label == "fail"');
+    expect(dql).toContain('summarize agg = count()');
+    expect(dql).toContain('filter agg > 0');
+  });
+
+  it('normalises percent fail_rate to a 0..1 comparison', () => {
+    const dql = conditionToDql(parseCondition('fail_rate > 10%'));
+    expect(dql).toContain('countIf(gen_ai.evaluation.score.label == "fail")');
+    expect(dql).toContain('filter agg > 0.1');
+  });
+
+  it('leaves bare fail_rate value alone', () => {
+    const dql = conditionToDql(parseCondition('fail_rate >= 0.25'));
+    expect(dql).toContain('filter agg >= 0.25');
+  });
+});
+
+describe('describeCondition', () => {
+  it('formats with the metric name', () => {
+    expect(describeCondition(parseCondition('avg > 2'), 'toxicity')).toBe('avg toxicity > 2');
+    expect(describeCondition(parseCondition('fail_rate > 10%'), 'relevance')).toBe('fail_rate relevance > 10%');
+  });
+
+  it('always renders fail_rate as a percentage, even when the YAML used a ratio', () => {
+    expect(describeCondition(parseCondition('fail_rate > 0.1'), 'relevance')).toBe('fail_rate relevance > 10%');
+    expect(describeCondition(parseCondition('fail_rate >= 0.25'), 'relevance')).toBe('fail_rate relevance >= 25%');
+  });
+});
+
+describe('parseCondition: fail_rate ambiguity guard', () => {
+  it('rejects bare fail_rate values that look like percentages without %%', () => {
+    expect(() => parseCondition('fail_rate > 10')).toThrow(/ratio between 0 and 1/);
+    expect(() => parseCondition('fail_rate > 50')).toThrow(/ratio between 0 and 1/);
+  });
+
+  it('accepts fail_rate values inside [0, 1] without %%', () => {
+    expect(() => parseCondition('fail_rate > 0.1')).not.toThrow();
+    expect(() => parseCondition('fail_rate >= 1')).not.toThrow();
+  });
+});

--- a/dt-eval-cli/tests/alerts/render.test.ts
+++ b/dt-eval-cli/tests/alerts/render.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import { renderWorkflow, parseWindow } from '../../src/alerts/render.js';
+import type { NotificationConfig } from '../../src/config/schema.js';
+
+describe('parseWindow', () => {
+  it('emits cron expressions for sub-hour intervals', () => {
+    expect(parseWindow('5m').cron).toBe('*/5 * * * *');
+    expect(parseWindow('15m').cron).toBe('*/15 * * * *');
+    expect(parseWindow('30m').cron).toBe('*/30 * * * *');
+  });
+  it('emits cron expressions for hour intervals', () => {
+    expect(parseWindow('1h').cron).toBe('0 */1 * * *');
+    expect(parseWindow('6h').cron).toBe('0 */6 * * *');
+  });
+  it('clamps sub-minute windows up to one minute', () => {
+    expect(parseWindow('30s').cron).toBe('*/1 * * * *');
+  });
+  it('rejects malformed windows', () => {
+    expect(() => parseWindow('5kg')).toThrow();
+    expect(() => parseWindow('0m')).toThrow();
+  });
+  it('reports duration string verbatim', () => {
+    expect(parseWindow('15m').dqlDuration).toBe('15m');
+  });
+});
+
+describe('renderWorkflow', () => {
+  const n: NotificationConfig = {
+    name: 'toxicity-spike',
+    metric: 'toxicity',
+    condition: 'avg > 2',
+    window: '15m',
+    channel: { type: 'slack', connection: 'my-slack', channel: '#alerts' },
+  };
+
+  it('produces a valid workflow YAML with cron trigger and query task', () => {
+    const { yaml, title } = renderWorkflow(n, { configName: 'demo', defaultService: 'my-svc' });
+    expect(title).toBe('[dt-evals] demo:toxicity-spike');
+    const parsed = parseYaml(yaml) as Record<string, unknown>;
+    expect(parsed['title']).toBe(title);
+    const trigger = parsed['trigger'] as { schedule: { trigger: { cron: string; type: string } } };
+    expect(trigger.schedule.trigger.type).toBe('cron');
+    expect(trigger.schedule.trigger.cron).toBe('*/15 * * * *');
+
+    const tasks = parsed['tasks'] as Record<string, Record<string, unknown>>;
+    expect(tasks['query_scores']?.['action']).toBe('dynatrace.automations:execute-dql-query');
+    expect(tasks['notify']?.['action']).toBe('dynatrace.slack:slack-send-message');
+
+    const query = (tasks['query_scores']?.['input'] as { query: string }).query;
+    expect(query).toContain('event.type == "gen_ai.evaluation.result"');
+    expect(query).toContain('gen_ai.evaluation.name == "toxicity"');
+    expect(query).toContain('avg(toDouble(gen_ai.evaluation.score.value))');
+    expect(query).toContain('my-svc');
+  });
+
+  it('drops the service filter when service is "*"', () => {
+    const { yaml } = renderWorkflow({ ...n, service: '*' }, { configName: 'demo' });
+    const parsed = parseYaml(yaml) as { tasks: Record<string, { input: { query: string } }> };
+    expect(parsed.tasks['query_scores']!.input.query).not.toContain('service.name ==');
+  });
+
+  it('includes id when one is passed (for idempotent upsert)', () => {
+    const { yaml } = renderWorkflow(n, { configName: 'demo' }, 'abc-123');
+    const parsed = parseYaml(yaml) as { id?: string };
+    expect(parsed.id).toBe('abc-123');
+  });
+
+  it('renders email channel as send-email with flat to/cc/bcc/subject/content', () => {
+    const email: NotificationConfig = {
+      ...n,
+      channel: { type: 'email', to: ['a@b.com'] },
+    };
+    const { yaml } = renderWorkflow(email, { configName: 'demo' });
+    const parsed = parseYaml(yaml) as { tasks: Record<string, { action: string; input: Record<string, unknown> }> };
+    expect(parsed.tasks['notify']!.action).toBe('dynatrace.email:send-email');
+    expect(parsed.tasks['notify']!.input['to']).toEqual(['a@b.com']);
+    expect(parsed.tasks['notify']!.input['cc']).toEqual([]);
+    expect(parsed.tasks['notify']!.input['bcc']).toEqual([]);
+    expect(typeof parsed.tasks['notify']!.input['content']).toBe('string');
+    // No `body: { contentType, body }` wrapper — that shape was wrong.
+    expect(parsed.tasks['notify']!.input['body']).toBeUndefined();
+  });
+
+  it('renders type: webhook as a Run JavaScript task', () => {
+    const wh: NotificationConfig = {
+      ...n,
+      channel: { type: 'webhook', webhookUrl: 'https://example.com/hook' },
+    };
+    const { yaml } = renderWorkflow(wh, { configName: 'demo' });
+    const parsed = parseYaml(yaml) as { tasks: Record<string, { action: string; input: { script: string } }> };
+    expect(parsed.tasks['notify']!.action).toBe('dynatrace.automations:run-javascript');
+    expect(parsed.tasks['notify']!.input.script).toContain('https://example.com/hook');
+  });
+
+  describe('message body', () => {
+    it('includes service, metric, threshold, observed and a config line', () => {
+      const { yaml } = renderWorkflow(n, { configName: 'demo', defaultService: 'my-svc' });
+      const parsed = parseYaml(yaml) as { tasks: Record<string, { input: { message: string } }> };
+      const msg = parsed.tasks['notify']!.input.message;
+      expect(msg).toContain('toxicity-spike');
+      expect(msg).toContain('my-svc');
+      expect(msg).toContain('toxicity');
+      expect(msg).toContain('avg toxicity > 2');
+      expect(msg).toContain('15 minutes');
+      expect(msg).toContain('Observed:');
+      expect(msg).toContain('demo');
+    });
+
+    it('embeds Prompts Explorer deep link filtered to Evaluations + this service', () => {
+      const { yaml } = renderWorkflow(n, {
+        configName: 'demo',
+        defaultService: 'ai-travel-advisor-agent-test',
+        environmentUrl: 'https://mho70695.apps.dynatrace.com',
+      });
+      const parsed = parseYaml(yaml) as { tasks: Record<string, { input: { message: string } }> };
+      const msg = parsed.tasks['notify']!.input.message;
+      expect(msg).toContain('/ui/apps/dynatrace.genai.observability/prompts/prompts-explorer?perspective=Evaluations');
+      expect(msg).toContain('#filtering="Evaluation+score"+%3D+Yes+Service+%3D+ai-travel-advisor-agent-test');
+      expect(msg).toContain('/ui/apps/dynatrace.automations/executions/');
+    });
+
+    it('drops the Service filter when service is "*" (watches all services)', () => {
+      const { yaml } = renderWorkflow(
+        { ...n, service: '*' },
+        { configName: 'demo', environmentUrl: 'https://mho70695.apps.dynatrace.com' },
+      );
+      const parsed = parseYaml(yaml) as { tasks: Record<string, { input: { message: string } }> };
+      const msg = parsed.tasks['notify']!.input.message;
+      expect(msg).toContain('#filtering="Evaluation+score"+%3D+Yes');
+      expect(msg).not.toContain('Service+%3D');
+    });
+
+    it('URL-encodes service names with spaces and reserved characters', () => {
+      const { yaml } = renderWorkflow(n, {
+        configName: 'demo',
+        defaultService: 'my service / v2',
+        environmentUrl: 'https://mho70695.apps.dynatrace.com',
+      });
+      const msg = (parseYaml(yaml) as { tasks: Record<string, { input: { message: string } }> })
+        .tasks['notify']!.input.message;
+      // Spaces become `+`, slash becomes %2F
+      expect(msg).toContain('Service+%3D+my+service+%2F+v2');
+    });
+
+    it('omits link section when no environmentUrl is provided', () => {
+      const { yaml } = renderWorkflow(n, { configName: 'demo' });
+      const parsed = parseYaml(yaml) as { tasks: Record<string, { input: { message: string } }> };
+      expect(parsed.tasks['notify']!.input.message).not.toContain('genai.observability');
+    });
+
+    it('writes a structured alert object in webhook body alongside the text', () => {
+      const wh: NotificationConfig = {
+        ...n,
+        channel: { type: 'webhook', webhookUrl: 'https://example.com/hook' },
+      };
+      const { yaml } = renderWorkflow(wh, {
+        configName: 'demo',
+        defaultService: 'my-svc',
+        environmentUrl: 'https://mho70695.apps.dynatrace.com',
+      });
+      const parsed = parseYaml(yaml) as { tasks: Record<string, { input: { script: string } }> };
+      // The body is interpolated into a JS backtick template literal inside the script.
+      const script = parsed.tasks['notify']!.input.script;
+      const m = /body:\s*`([\s\S]*?)`,/m.exec(script);
+      expect(m).not.toBeNull();
+      // Undo JS-backtick escapes so the captured payload parses as JSON.
+      const raw = m![1]!.replace(/\\\$\{/g, '${').replace(/\\`/g, '`').replace(/\\\\/g, '\\');
+      const body = JSON.parse(raw) as { text: string; alert: Record<string, unknown> };
+      expect(body.alert['service']).toBe('my-svc');
+      expect(body.alert['metric']).toBe('toxicity');
+      expect(body.alert['threshold']).toBe('avg toxicity > 2');
+      expect(body.alert['window']).toBe('15 minutes');
+      expect((body.alert['links'] as { aiObservability: string }).aiObservability).toContain('ai.observability');
+    });
+
+    it('renders email body with subject including the service and threshold', () => {
+      const email: NotificationConfig = {
+        ...n,
+        channel: { type: 'email', to: ['a@b.com'] },
+      };
+      const { yaml } = renderWorkflow(email, { configName: 'demo', defaultService: 'my-svc' });
+      const parsed = parseYaml(yaml) as { tasks: Record<string, { input: { subject: string; content: string } }> };
+      expect(parsed.tasks['notify']!.input.subject).toContain('my-svc');
+      expect(parsed.tasks['notify']!.input.subject).toContain('avg toxicity > 2');
+      expect(parsed.tasks['notify']!.input.content).toContain('Service:');
+      expect(parsed.tasks['notify']!.input.content).toContain('Threshold breached:');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `dt-evals alerts` — a new command tree that deploys per-notification Dynatrace Workflows. Each workflow polls eval bizevents on a schedule and notifies Slack / email / a generic webhook when a threshold is breached. Sits next to the existing local `alerts.thresholds` / `alerts.webhooks` blocks; this is the continuous server-side path.

## Why

Today `alerts.webhooks` fires only inside a local `dt-evals run`, so it misses every other run (CI, scheduled jobs, drift baselines). This change moves alerting into Dynatrace itself so it works across all eval activity, with the same telemetry the dashboards already consume.

## YAML

```yaml
alerts:
  notifications:
    - name: toxicity-spike
      metric: toxicity
      condition: avg > 2           # avg | max | min | count | fail_rate
      window: 15m                  # also the polling interval
      channel:
        type: slack
        connection: my-slack-conn  # Dynatrace Slack OAuth connection
        channel: "#ai-alerts"
```

## Commands

| Command | Purpose |
|---|---|
| `alerts apply  [config]` | idempotent create/update (per-config workflow id map at `~/.dt-eval/alerts-<hash>.json`) |
| `alerts render [config]` | print rendered workflow YAML, no API calls |
| `alerts list   [config]` | list deployed alerts (`--all` for tenant-wide) |
| `alerts diff   [config]` | local vs remote, normalised through JSON to strip server-injected fields |
| `alerts delete [config] --name X \| --all` | per-alert or full teardown |

## Channels

- `type: slack` → `dynatrace.slack:slack-send-message`. Requires a Dynatrace Slack connection (Settings → Connections → Slack OAuth). Renders the proper Slack action UI in the Workflows app.
- `type: email` → `dynatrace.email:send-email`. Uses the tenant's default outbound mail (Settings → Notifications); no per-workflow connection.
- `type: webhook` → `dynatrace.automations:run-javascript` that POSTs JSON via `fetch()`. Core AutomationEngine action; no extra app install required. Useful for Slack incoming webhooks, PagerDuty proxies, custom routers.

## Condition DSL

`<aggregation> <operator> <value>[%]` parsed at validate time and translated to DQL.

- aggregations: `avg`, `max`, `min`, `count` (failing rows), `fail_rate`
- operators: `>`, `>=`, `<`, `<=`, `==`, `!=`
- `fail_rate` is a percentage — write `fail_rate > 10%` or `fail_rate > 0.1`. Bare values outside `[0, 1]` are rejected to avoid the 10-vs-10% trap. Rendered alert messages always show fail_rate as a percentage regardless of which form was used.

## Permissions

Required dtctl scopes (`automation:workflows:read`, `automation:workflows:write`, `storage:events:read`, plus optional `automation:workflows:run`) are surfaced in the `alerts --help` description and printed on every 401/403 from dtctl. After every `apply` / `list`, a deep link to the Workflows app filtered to dt-evals is printed; the URL follows `--context` so it points at whichever tenant was deployed to.

## Tested end-to-end against a live tenant

Verified every command against a live tenant:

- `render` (stdout + `--out <dir>`), `apply` (fresh + idempotent re-run + `--dry-run` + `--name`), `list` (scoped + `--all`), `diff` (in-sync + change detection), `delete` (`--name` + `--all` + missing-name warning + 404-stale handling)
- Slack notify task loads the proper form UI in the Workflows app (Connection / Channel / Message / Reactions / Reply in thread)
- Email notify task uses the working `to / cc / bcc / subject / content` shape
- Generic webhook notify task uses the always-available `run-javascript` core action — no `AppNotFound` failures

## Files

- `src/alerts/{condition,render,idmap,dtctl}.ts` — condition DSL, workflow renderer, idempotency state, dtctl wrappers with classified 401/403 errors
- `src/cli/commands/alerts.ts` — `apply / render / list / diff / delete`
- `src/config/{schema,index}.ts` — `alerts.notifications[]` type + validation (including condition-DSL parse at validate time)
- `tests/alerts/{condition,render}.test.ts` — 25 unit tests covering the DSL, percentage trap, all channel shapes, link rendering, idempotent id behaviour
- `alerts-examples.dt-eval.yaml` — five realistic patterns (PII / prompt-injection page-on-any, relevance regression email, toxicity-spike Slack, hallucination-trend generic webhook)
- `docs/alerts-design.md` — design doc captured from the planning round
- README: new sections for the YAML block, condition DSL, channel setup, permissions, tenant-URL print-out

## Test plan

- [ ] `dt-evals alerts render alerts-examples.dt-eval.yaml` prints five workflow YAMLs
- [ ] `dt-evals alerts apply alerts-examples.dt-eval.yaml --dry-run` shows the action table without API calls
- [ ] `dt-evals alerts apply alerts-examples.dt-eval.yaml --context <tenant>` creates five workflows, prints the tenant URL, and the connection callout
- [ ] Re-running `apply` updates in place (no duplicate workflows in the UI)
- [ ] Editing a `window:` in the YAML and running `alerts diff` shows only the three actually-changed lines (DQL `from:`, cron, human description)
- [ ] `alerts delete --name X` removes one and clears the id-map entry; `--all` tears down the rest
- [ ] On a tenant where the Slack connection name doesn't exist, opening the `notify` task in the UI still shows the proper Slack action form (just with no connection selected)