### PR TITLE
feat(dt-eval-cli): split metric into metricId/metricName in bizevent payload

### DIFF
--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -36,7 +36,8 @@ export interface JudgeInputs {
 
 export function buildBizeventPayload(
   span: GenAiSpan,
-  metric: string,
+  metricId: string,
+  metricName: string,
   result: EvalResult,
   runId: string,
   judgeProvider: string,
@@ -56,10 +57,10 @@ export function buildBizeventPayload(
     'event.provider': CLIENT_NAME,
     'trace_id': span.traceId,
     'timestamp': new Date().toISOString(),
-    'gen_ai.evaluation.name': metric,
+    'gen_ai.evaluation.name': metricName,
     'gen_ai.evaluation.type': 'ready_made',
     'gen_ai.evaluation.version': 'v1.0',
-    'gen_ai.evaluation.spec_id': `evalspec_${metric}_v1`,
+    'gen_ai.evaluation.spec_id': metricId,
     'gen_ai.evaluation.scoring_format': scoringFormat(result.score.value),
     'gen_ai.evaluation.score.value': result.score.value,
     'gen_ai.evaluation.score.label': result.score.label,
@@ -92,14 +93,15 @@ export class BizeventWriter {
 
   async writeEvalResult(
     span: GenAiSpan,
-    metric: string,
+    metricId: string,
+    metricName: string,
     result: EvalResult,
     runId: string,
     judgeProvider: string,
     judgeModel: string,
     serviceName?: string,
   ): Promise<void> {
-    const payload = buildBizeventPayload(span, metric, result, runId, judgeProvider, judgeModel, serviceName);
+    const payload = buildBizeventPayload(span, metricId, metricName, result, runId, judgeProvider, judgeModel, serviceName);
     await this.writeBatch([payload]);
   }
 

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -91,7 +91,8 @@ function buildEvalInput(span: GenAiSpan, inputs: MetricInputs | undefined): Eval
 
 interface EvalTaskResult {
   span: GenAiSpan;
-  metric: string;
+  metricId: string;
+  metricName: string;
   evalResult: EvalResult;
   /** The exact input the judge was given — may be a routed subset of span fields. */
   evalInput: EvalInput;
@@ -220,7 +221,8 @@ export async function runEvals(
       const t0 = Date.now();
       const input: EvalInput = buildEvalInput(task.span, task.inputs);
       try {
-        const evalResult = await evaluate(getPrompt(task.metric), input, libConfig);
+        const prompt = getPrompt(task.metric);
+        const evalResult = await evaluate(prompt, input, libConfig);
         evalCount++;
         const elapsed = Date.now() - t0;
         logger.debug(`eval [${evalCount}/${tasks.length}] ${task.metric} ${judgeProvider}/${judgeModel} trace=${task.span.traceId.slice(0, 8)}… ${elapsed}ms score=${evalResult.score.value}`);
@@ -232,7 +234,7 @@ export async function runEvals(
           traceId: task.span.traceId,
           durationMs: elapsed,
         });
-        return { span: task.span, metric: task.metric, evalResult, evalInput: input };
+        return { span: task.span, metricId: task.metric, metricName: prompt.name, evalResult, evalInput: input };
       } catch (err) {
         evalCount++;
         evalErrors++;
@@ -283,7 +285,7 @@ export async function runEvals(
   if (!emit) logger.step('Writing bizevents...');
   const writer = new BizeventWriter(writeClient);
   const payloads: BizeventPayload[] = successResults.map(r =>
-    buildBizeventPayload(r.span, r.metric, r.evalResult, runId, judgeProvider, judgeModel, evalConfig.scope.service, r.evalInput),
+    buildBizeventPayload(r.span, r.metricId, r.metricName, r.evalResult, runId, judgeProvider, judgeModel, evalConfig.scope.service, r.evalInput),
   );
   emit?.({ phase: 'writing', payloads: payloads.length });
 
@@ -298,7 +300,7 @@ export async function runEvals(
     // Build per-metric score arrays from this run
     const currentScores: Record<string, number[]> = {};
     for (const r of successResults) {
-      (currentScores[r.metric] ??= []).push(r.evalResult.score.value);
+      (currentScores[r.metricId] ??= []).push(r.evalResult.score.value);
     }
     // Drift compares current run against historical eval bizevents on the
     // destination tenant (where eval results live).
@@ -320,10 +322,10 @@ export async function runEvals(
   const thresholdBreaches: RunResult['thresholdBreaches'] = [];
   if (evalConfig.alerts?.thresholds) {
     for (const r of successResults) {
-      const threshold = evalConfig.alerts.thresholds[r.metric];
+      const threshold = evalConfig.alerts.thresholds[r.metricId];
       if (threshold !== undefined && r.evalResult.score.value < threshold) {
         thresholdBreaches.push({
-          metric: r.metric,
+          metric: r.metricId,
           traceId: r.span.traceId,
           score: r.evalResult.score.value,
         });

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -27,62 +27,63 @@ describe('buildBizeventPayload', () => {
   it('produces a payload with the correct schema fields', () => {
     const span = makeSpan();
     const result = makeEvalResult();
-    const payload = buildBizeventPayload(span, 'relevance', result, 'run-001', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(span, 'relevance', 'Relevance', result, 'run-001', 'openai', 'gpt-4o');
 
     expect(payload['event.type']).toBe('gen_ai.evaluation.result');
     expect(payload['event.provider']).toBe('dt-eval-cli');
     expect(payload['trace_id']).toBe('trace-abc-123');
     expect(payload['dt.eval.run_id']).toBe('run-001');
-    expect(payload['gen_ai.evaluation.name']).toBe('relevance');
+    expect(payload['gen_ai.evaluation.name']).toBe('Relevance');
+    expect(payload['gen_ai.evaluation.spec_id']).toBe('relevance');
     expect(payload['gen_ai.evaluation.score.value']).toBe(0.9);
     expect(payload['gen_ai.provider.name']).toBe('openai');
     expect(payload['gen_ai.request.model']).toBe('gpt-4o');
   });
 
   it('sets event.type to "gen_ai.evaluation.result"', () => {
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', makeEvalResult(), 'run-1', 'anthropic', 'claude');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'anthropic', 'claude');
     expect(payload['event.type']).toBe('gen_ai.evaluation.result');
   });
 
   it('sets score label to "pass" from eval result', () => {
     const result = makeEvalResult(0.9, 'pass');
-    const payload = buildBizeventPayload(makeSpan(), 'relevance', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'relevance', 'Relevance', result, 'run-1', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.score.label']).toBe('pass');
   });
 
   it('sets score label to "fail" from eval result', () => {
     const result = makeEvalResult(0.1, 'fail');
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', result, 'run-1', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.score.label']).toBe('fail');
   });
 
   it('uses the exact score.value from EvalResult', () => {
     const result = makeEvalResult(0.75, 'pass');
-    const payload = buildBizeventPayload(makeSpan(), 'user-frustration', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'user-frustration', 'User Frustration', result, 'run-1', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.score.value']).toBe(0.75);
   });
 
   it('uses explanation.summary as the explanation string', () => {
     const result = makeEvalResult(1, 'pass', 'No harmful content detected.');
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', result, 'run-1', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.explanation']).toBe('No harmful content detected.');
   });
 
   it('includes judge provider and model metadata', () => {
-    const payload = buildBizeventPayload(makeSpan(), 'faithfulness', makeEvalResult(), 'run-1', 'anthropic', 'claude-sonnet-4-6');
+    const payload = buildBizeventPayload(makeSpan(), 'faithfulness', 'Faithfulness', makeEvalResult(), 'run-1', 'anthropic', 'claude-sonnet-4-6');
     expect(payload['gen_ai.provider.name']).toBe('anthropic');
     expect(payload['gen_ai.request.model']).toBe('claude-sonnet-4-6');
   });
 
   it('omits gen_ai.system when span.system is absent', () => {
     const span = makeSpan({ system: undefined });
-    const payload = buildBizeventPayload(span, 'relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
     // gen_ai.system is not part of the dt-ai-ingest schema; only gen_ai.provider.name is used
     expect(payload['gen_ai.provider.name']).toBe('openai');
   });
 
   it('includes a valid ISO timestamp field', () => {
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
     expect(payload.timestamp).toBeDefined();
     expect(new Date(payload.timestamp!).toISOString()).toBe(payload.timestamp);
   });
@@ -97,7 +98,7 @@ describe('BizeventWriter', () => {
     };
 
     const writer = new BizeventWriter(mockClient as unknown as import('../../src/dt/client.js').DynatraceClient);
-    await writer.writeEvalResult(makeSpan(), 'toxicity', makeEvalResult(), 'run-001', 'openai', 'gpt-4o');
+    await writer.writeEvalResult(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-001', 'openai', 'gpt-4o');
 
     expect(mockClient.ingestBizevents).toHaveBeenCalledOnce();
     const callArgs = mockClient.ingestBizevents.mock.calls[0]![0] as unknown[];
@@ -118,8 +119,8 @@ describe('BizeventWriter', () => {
     const span2 = makeSpan({ traceId: 'trace-2' });
 
     const payloads = [
-      buildBizeventPayload(span1, 'toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
-      buildBizeventPayload(span2, 'relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
+      buildBizeventPayload(span1, 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
+      buildBizeventPayload(span2, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
     ];
 
     await writer.writeBatch(payloads);
@@ -150,6 +151,7 @@ describe('BizeventWriter', () => {
       const payload = buildBizeventPayload(
         span,
         'user-frustration',
+        'User Frustration',
         makeEvalResult(0, 'fail'),
         'run-1',
         'openai',
@@ -167,6 +169,7 @@ describe('BizeventWriter', () => {
       const payload = buildBizeventPayload(
         span,
         'relevance',
+        'Relevance',
         makeEvalResult(),
         'run-1',
         'openai',
@@ -182,6 +185,7 @@ describe('BizeventWriter', () => {
       const payload = buildBizeventPayload(
         span,
         'user-frustration',
+        'User Frustration',
         makeEvalResult(),
         'run-1',
         'openai',


### PR DESCRIPTION
bizevents would now have both metric id and the human readable metric name