### PR TITLE
fix(dt-eval-cli): correct token scopes in README and parse gen_ai.output.messages

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -342,7 +342,7 @@ dynatrace:
     apiToken: dt0s16.xxxxx          # needs storage:spans:read, storage:buckets:read
   destination:
     environmentUrl: https://eval-results.dev.apps.dynatracelabs.com
-    apiToken: dt0s16.yyyyy          # needs storage:bizevents:write, storage:metric:write
+    apiToken: dt0s16.yyyyy          # needs storage:events:write, storage:metrics:write
 ```
 
 Top-level `environmentUrl` / `apiToken` (if present) act as fallbacks — if
@@ -353,10 +353,29 @@ The `validate` command probes each side separately, including a real
 `fetch spans | limit 1` against the origin to catch missing
 `storage:spans:read` scope before a run is attempted.
 
+### Required token scopes
+
+| Scope | Required for |
+|---|---|
+| `storage:spans:read` | Reading GenAI spans (origin) |
+| `storage:buckets:read` | Grail prerequisite — without this, DQL returns empty results silently |
+| `storage:events:read` | Drift detection baseline (reads past eval bizevents) |
+| `storage:events:write` | Writing evaluation results as bizevents (destination) |
+| `storage:metrics:write` | Writing evaluation metrics *(optional)* |
+| `storage:logs:read` | `dt-evals validate` connectivity probe |
+
+For `dt-evals alerts apply` (Dynatrace Workflows), grant these additionally on the dtctl OAuth client:
+
+| Scope | Required for |
+|---|---|
+| `automation:workflows:read` | `list`, `diff`, idempotent `apply` |
+| `automation:workflows:write` | `apply`, `delete` |
+| `automation:workflows:run` | Manual execution from the UI *(optional)* |
+
 ### Custom span field mapping
 
 By default, the CLI reads OTel GenAI semconv (`gen_ai.input.messages`,
-`gen_ai.output.message`, …) and OpenLLMetry conventions (`gen_ai.prompt.N.*`,
+`gen_ai.output.messages`, `gen_ai.output.message`, …) and OpenLLMetry conventions (`gen_ai.prompt.N.*`,
 `gen_ai.completion.0.content`). If your spans expose the LLM I/O under
 different attribute names, point the CLI at them via `scope.spanFields`.
 Each entry accepts a single attribute or a list of candidates; the first

--- a/dt-eval-cli/src/cli/commands/validate.ts
+++ b/dt-eval-cli/src/cli/commands/validate.ts
@@ -134,6 +134,7 @@ export function createValidateCommand(): Command {
         } else {
           logger.error(`origin cannot read spans bucket: ${probe.reason}`);
           logger.error(`  → token needs storage:spans:read (and storage:buckets:read)`);
+          logger.error(`  → full required scope list: storage:spans:read, storage:buckets:read, storage:events:read, storage:events:write, storage:metrics:write, storage:logs:read`);
           failures++;
         }
       }

--- a/dt-eval-cli/src/dt/client.ts
+++ b/dt-eval-cli/src/dt/client.ts
@@ -123,7 +123,10 @@ export class DynatraceClient {
 
     if (!response.ok) {
       const text = await response.text();
-      throw new Error(`DQL execute failed (${response.status}): ${text}`);
+      const hint = response.status === 401 || response.status === 403
+        ? ' — token needs storage:spans:read, storage:buckets:read, storage:events:read'
+        : '';
+      throw new Error(`DQL execute failed (${response.status})${hint}: ${text}`);
     }
 
     const data = (await response.json()) as DqlExecuteResponse;
@@ -183,7 +186,10 @@ export class DynatraceClient {
 
     if (!response.ok) {
       const text = await response.text();
-      throw new Error(`Bizevent ingest failed (${response.status}): ${text}`);
+      const hint = response.status === 401 || response.status === 403
+        ? ' — token needs storage:events:write'
+        : '';
+      throw new Error(`Bizevent ingest failed (${response.status})${hint}: ${text}`);
     }
   }
 
@@ -198,7 +204,10 @@ export class DynatraceClient {
 
     if (!response.ok) {
       const text = await response.text();
-      throw new Error(`Metrics ingest failed (${response.status}): ${text}`);
+      const hint = response.status === 401 || response.status === 403
+        ? ' — token needs storage:metrics:write'
+        : '';
+      throw new Error(`Metrics ingest failed (${response.status})${hint}: ${text}`);
     }
   }
 

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -21,7 +21,7 @@ const PROMPT_SLOTS = 3;
 // candidates are prepended to these so the user's choice wins, but the
 // defaults remain as a fallback.
 const DEFAULT_INPUT_FIELDS = ['gen_ai.input.messages'];
-const DEFAULT_OUTPUT_FIELDS = ['gen_ai.output.message', 'gen_ai.completion.0.content'];
+const DEFAULT_OUTPUT_FIELDS = ['gen_ai.output.message', 'gen_ai.output.messages', 'gen_ai.completion.0.content'];
 const DEFAULT_SYSTEM_INSTRUCTION_FIELDS = ['gen_ai.system_instruction'];
 const DEFAULT_MODEL_FIELDS = ['gen_ai.request.model'];
 

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -252,6 +252,23 @@ describe('parseSpanResults', () => {
     ];
     expect(parseSpanResults(records)[0]!.userPrompt).toBeUndefined();
   });
+
+  it('parses gen_ai.output.messages (plural) when gen_ai.output.message is absent', () => {
+    const outputMessages = JSON.stringify([
+      { role: 'assistant', parts: [{ type: 'text', content: 'Here is your answer.' }] },
+    ]);
+    const records = [
+      {
+        'trace.id': 'plural-output',
+        'gen_ai.input.messages': '[{"role":"user","content":"What is 2+2?"}]',
+        'gen_ai.output.message': null,
+        'gen_ai.output.messages': outputMessages,
+      },
+    ];
+    const spans = parseSpanResults(records);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.output).toBe('Here is your answer.');
+  });
 });
 
 describe('spanFields configuration', () => {


### PR DESCRIPTION
## What

Two independent fixes found while running `dt-evals` end-to-end against a real customer instance (`mho70695.apps.dynatrace.com`).

### 1. README scope names are wrong and incomplete

The cross-tenant config example had two typos and two missing scopes compared to what the code actually uses (`dtctl/index.ts`, `doctor.ts`):

| README said | Code actually uses |
|---|---|
| `storage:bizevents:write` | `storage:events:write` |
| `storage:metric:write` | `storage:metrics:write` |
| *(missing)* | `storage:buckets:read` |
| *(missing)* | `storage:logs:read` |

`storage:buckets:read` is particularly dangerous to leave undocumented — without it Grail returns `SUCCEEDED` with empty records and no error, so spans silently disappear and `dt-evals run` reports 0 results with no indication of what went wrong.

Adds a dedicated **Required token scopes** table so all scopes (including the alerts/workflows ones) are in one place rather than scattered across examples.

### 2. `gen_ai.output.messages` (plural) not in default output candidates

When testing against the instance, `dt-evals run` fetched 0 spans despite 103 GenAI spans existing in Dynatrace. Running with `--debug --verbose` showed the DQL query was correct and returning records. The spans were being silently dropped in `parseSpanResults` at the `if (!input || !output) continue` guard (`dql.ts:243`).

Root cause: the instance uses the OTel GenAI evolved convention where the full conversation — including the assistant response — is stored as a JSON array under `gen_ai.output.messages` (plural). The default output candidate list only contained `gen_ai.output.message` (singular) and `gen_ai.completion.0.content`. The parser already handles the JSON array role extraction via `extractRolesFromJsonMessages`, the field just wasn't being fetched.

Fix: add `gen_ai.output.messages` to `DEFAULT_OUTPUT_FIELDS` so it is included in the DQL `fields` clause and checked before falling back to the singular form.

Test added to `dql.test.ts` covering a span with `gen_ai.output.message: null` and `gen_ai.output.messages` containing a role-tagged assistant message.

## Test plan
- [x] `npm test` — 161/161
- [x] Live run against `mho70695.apps.dynatrace.com` without `spanFields` workaround: 103 spans fetched, 10 eval results written