### PR TITLE
fix(dt-eval-cli): stop sending evaluated prompt/response back to Dynatrace by default

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -57,6 +57,7 @@ Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many j
 - **Statistical drift detection** against a 7 day baseline of prior evaluation scores
 - **Flexible sampling** with random percentage, latest `N`, or `errors-only`
 - **PII masking before judge calls** for emails, phone numbers, credit cards, and SSNs
+- **Evaluated prompt/response excluded from bizevents by default** — opt in with `storeEvaluatedPrompt` (see [Configuration](#configuration))
 - **OpenAI and Anthropic support** with optional custom base URLs for gateways and proxies
 - **CI friendly runs** with JSON output and non-zero exit codes on threshold breaches
 - **Local run history** with list, inspect, and export flows
@@ -266,6 +267,7 @@ Global flags:
 --dry-run              Do not call the judge or write results
 --ci                   JSON result output and exit 1 on threshold breach
 --concurrency <n>      Parallel judge calls (overrides judge.concurrency in the config; default 5)
+--store-evaluated-prompt   Include the evaluated prompt/response in bizevents (overrides storeEvaluatedPrompt in the config; default: false)
 --debug                Per-step timing logs
 ```
 
@@ -318,6 +320,11 @@ alerts:
     faithfulness: 0.7
     relevance: 0.7
     answer-completeness: 0.8
+
+# Off by default — the evaluated prompt/response are not written back to Dynatrace.
+# Set to true to include gen_ai.evaluation.input.question/.answer/.system_prompt
+# in the result bizevents. Overridable per-invocation with --store-evaluated-prompt.
+storeEvaluatedPrompt: false
 ```
 
 Sampling strategies:

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -116,3 +116,12 @@ alerts:
       type: slack
     # - url: https://my-webhook-endpoint.example.com/alerts
     #   type: generic
+
+# ---------------------------------------------------------------------------
+# Privacy — what gets written back to Dynatrace
+# ---------------------------------------------------------------------------
+# (Optional) Off by default: the evaluated prompt/response are not included in
+# result bizevents. Set to true to also write gen_ai.evaluation.input.question,
+# .answer, and .system_prompt. Overridable per-invocation with
+# --store-evaluated-prompt.
+# storeEvaluatedPrompt: false

--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -81,6 +81,7 @@ export function createRunCommand(): Command {
   cmd.option('--dry-run', 'Fetch and transform traces, print payloads, do not send');
   cmd.option('--ci', 'Non-interactive mode: JSON stdout, exit 1 on threshold breach');
   cmd.option('--concurrency <n>', 'Number of parallel evaluation workers (overrides judge.concurrency in the config; default 5)', (v) => parseInt(v, 10));
+  cmd.option('--store-evaluated-prompt', 'Include the evaluated prompt/response in bizevents written to Dynatrace (overrides storeEvaluatedPrompt in the config; default: false)');
   cmd.option('--debug', 'Enable debug logging with per-step timing');
 
   cmd.action(async (configArg: string | undefined, options: {
@@ -91,6 +92,7 @@ export function createRunCommand(): Command {
     dryRun?: boolean;
     ci?: boolean;
     concurrency?: number;
+    storeEvaluatedPrompt?: boolean;
     debug?: boolean;
   }) => {
     if (options.debug) {
@@ -146,6 +148,7 @@ export function createRunCommand(): Command {
         dryRun: options.dryRun,
         ci: options.ci,
         concurrency: options.concurrency ?? config.judge.concurrency,
+        storeEvaluatedPrompt: options.storeEvaluatedPrompt,
         onProgress,
       });
 

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -118,6 +118,12 @@ export interface DtEvalConfig {
   scope: ScopeConfig;
   metrics: MetricsConfig;
   alerts?: AlertsConfig;
+  /**
+   * Include the evaluated prompt and response — `gen_ai.evaluation.input.question`,
+   * `.answer`, and `.system_prompt` — in the bizevents written back to Dynatrace.
+   * Default: false. Overridable per-invocation with `--store-evaluated-prompt`.
+   */
+  storeEvaluatedPrompt?: boolean;
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -44,14 +44,8 @@ export function buildBizeventPayload(
   judgeModel: string,
   serviceName?: string,
   judgeInputs?: JudgeInputs,
+  storeEvaluatedPrompt = false,
 ): BizeventPayload {
-  // Record what the judge actually evaluated, not the raw span — they
-  // diverge when per-metric inputs routing maps a canonical field
-  // (e.g. userPrompt) onto an evaluator slot.
-  const question = judgeInputs?.input ?? span.input;
-  const answer = judgeInputs?.output ?? span.output;
-  const systemPrompt = judgeInputs?.context ?? span.systemInstruction;
-
   const payload: BizeventPayload = {
     'event.type': 'gen_ai.evaluation.result',
     'event.provider': CLIENT_NAME,
@@ -66,8 +60,6 @@ export function buildBizeventPayload(
     'gen_ai.evaluation.score.label': result.score.label,
     'gen_ai.evaluation.explanation': result.explanation.summary,
     'gen_ai.evaluation.method': 'llm_as_judge',
-    'gen_ai.evaluation.input.question': question,
-    'gen_ai.evaluation.input.answer': answer,
     'gen_ai.request.model': judgeModel,
     'gen_ai.provider.name': judgeProvider,
     ...(serviceName ? { 'dt.service.name': serviceName } : {}),
@@ -81,8 +73,16 @@ export function buildBizeventPayload(
     payload['gen_ai.response.id'] = span.spanId;
   }
 
-  if (systemPrompt) {
-    payload['gen_ai.evaluation.input.system_prompt'] = systemPrompt;
+  if (storeEvaluatedPrompt) {
+    // Record what the judge actually evaluated, not the raw span — they
+    // diverge when per-metric inputs routing maps a canonical field
+    // (e.g. userPrompt) onto an evaluator slot.
+    payload['gen_ai.evaluation.input.question'] = judgeInputs?.input ?? span.input;
+    payload['gen_ai.evaluation.input.answer'] = judgeInputs?.output ?? span.output;
+    const systemPrompt = judgeInputs?.context ?? span.systemInstruction;
+    if (systemPrompt) {
+      payload['gen_ai.evaluation.input.system_prompt'] = systemPrompt;
+    }
   }
 
   return payload;

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -29,8 +29,11 @@ export interface BizeventPayload {
   'gen_ai.evaluation.score.label': 'pass' | 'fail';
   'gen_ai.evaluation.explanation': string;
   'gen_ai.evaluation.method': 'llm_as_judge';
-  'gen_ai.evaluation.input.question': string;
-  'gen_ai.evaluation.input.answer': string;
+  /** Only present when `storeEvaluatedPrompt` is enabled. */
+  'gen_ai.evaluation.input.question'?: string;
+  /** Only present when `storeEvaluatedPrompt` is enabled. */
+  'gen_ai.evaluation.input.answer'?: string;
+  /** Only present when `storeEvaluatedPrompt` is enabled. */
   'gen_ai.evaluation.input.system_prompt'?: string;
   'gen_ai.request.model'?: string;
   'gen_ai.provider.name'?: string;

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -38,6 +38,8 @@ export interface RunOptions {
   dryRun?: boolean;
   ci?: boolean;
   concurrency?: number;
+  /** Include the evaluated prompt/response in bizevents. Falls back to `storeEvaluatedPrompt` in the config when omitted. Default: false. */
+  storeEvaluatedPrompt?: boolean;
   /**
    * Receives phase-transition events as the run progresses. Used by the CLI
    * to drive an accurate spinner. When omitted, the runner falls back to the
@@ -283,9 +285,10 @@ export async function runEvals(
 
   // 8. Write bizevents
   if (!emit) logger.step('Writing bizevents...');
+  const storeEvaluatedPrompt = opts.storeEvaluatedPrompt ?? evalConfig.storeEvaluatedPrompt ?? false;
   const writer = new BizeventWriter(writeClient);
   const payloads: BizeventPayload[] = successResults.map(r =>
-    buildBizeventPayload(r.span, r.metricId, r.metricName, r.evalResult, runId, judgeProvider, judgeModel, evalConfig.scope.service, r.evalInput),
+    buildBizeventPayload(r.span, r.metricId, r.metricName, r.evalResult, runId, judgeProvider, judgeModel, evalConfig.scope.service, r.evalInput, storeEvaluatedPrompt),
   );
   emit?.({ phase: 'writing', payloads: payloads.length });
 

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -87,6 +87,31 @@ describe('buildBizeventPayload', () => {
     expect(payload.timestamp).toBeDefined();
     expect(new Date(payload.timestamp!).toISOString()).toBe(payload.timestamp);
   });
+
+  describe('storeEvaluatedPrompt', () => {
+    it('omits the evaluated question/answer/system_prompt by default', () => {
+      const span = makeSpan({ systemInstruction: 'be helpful' });
+      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+      expect(payload['gen_ai.evaluation.input.question']).toBeUndefined();
+      expect(payload['gen_ai.evaluation.input.answer']).toBeUndefined();
+      expect(payload['gen_ai.evaluation.input.system_prompt']).toBeUndefined();
+    });
+
+    it('omits them when explicitly disabled', () => {
+      const span = makeSpan({ systemInstruction: 'be helpful' });
+      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o', undefined, undefined, false);
+      expect(payload['gen_ai.evaluation.input.question']).toBeUndefined();
+      expect(payload['gen_ai.evaluation.input.answer']).toBeUndefined();
+    });
+
+    it('includes them when enabled', () => {
+      const span = makeSpan({ systemInstruction: 'be helpful' });
+      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o', undefined, undefined, true);
+      expect(payload['gen_ai.evaluation.input.question']).toBe(span.input);
+      expect(payload['gen_ai.evaluation.input.answer']).toBe(span.output);
+      expect(payload['gen_ai.evaluation.input.system_prompt']).toBe('be helpful');
+    });
+  });
 });
 
 describe('BizeventWriter', () => {
@@ -158,6 +183,7 @@ describe('BizeventWriter', () => {
         'gpt-4o',
         'my-service',
         { input: 'i am angry', output: 'I understand', context: 'be nice' },
+        true,
       );
       expect(payload['gen_ai.evaluation.input.question']).toBe('i am angry');
       expect(payload['gen_ai.evaluation.input.answer']).toBe('I understand');
@@ -174,6 +200,9 @@ describe('BizeventWriter', () => {
         'run-1',
         'openai',
         'gpt-4o',
+        undefined,
+        undefined,
+        true,
       );
       expect(payload['gen_ai.evaluation.input.question']).toBe(span.input);
       expect(payload['gen_ai.evaluation.input.answer']).toBe(span.output);
@@ -192,6 +221,7 @@ describe('BizeventWriter', () => {
         'gpt-4o',
         undefined,
         { input: 'just the user turn' }, // output / context not routed
+        true,
       );
       expect(payload['gen_ai.evaluation.input.question']).toBe('just the user turn');
       expect(payload['gen_ai.evaluation.input.answer']).toBe(span.output);


### PR DESCRIPTION
## Summary
- Bizevents written back to Dynatrace no longer include the evaluated prompt/response (`gen_ai.evaluation.input.question`, `.answer`, `.system_prompt`) unless explicitly opted in
- New `storeEvaluatedPrompt` YAML config field (default: `false`) and matching `--store-evaluated-prompt` CLI flag for customers who want that data stored in the result

## Test plan
- [x] `npx vitest run` — all 191 tests pass, including new coverage for the default-off / explicit-off / explicit-on cases
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — builds cleanly