### PR TITLE
fix(dt-ai-ingest): route label-only eval scores through the shared schema builder

### DIFF
--- a/dt-ai-ingest/src/dt_ai_ingest/deepeval/evaluation.py
+++ b/dt-ai-ingest/src/dt_ai_ingest/deepeval/evaluation.py
@@ -149,27 +149,16 @@ def _build_events(
             if score_label is not None:
                 build_kwargs["score_label"] = score_label
 
-            if score is not None:
-                events.append(
-                    build_eval_result_event(
-                        eval_name=metric_name,
-                        score_value=score,
-                        extra=event_extra,
-                        **build_kwargs,
-                    )
+            # A metric that errored has score=None; the event is still emitted
+            # (with its pass/fail label) — build_eval_result_event omits the
+            # numeric score key when score_value is None.
+            events.append(
+                build_eval_result_event(
+                    eval_name=metric_name,
+                    score_value=score,
+                    extra=event_extra,
+                    **build_kwargs,
                 )
-            else:
-                # Metric errored — emit event without score_value.
-                # build_eval_result_event requires score_value, so we build
-                # the event dict manually for the error case.
-                event: dict[str, Any] = {
-                    "event.type": "gen_ai.evaluation.result",
-                    "event.provider": "deepeval",
-                }
-                event["gen_ai.evaluation.name"] = metric_name
-                if score_label is not None:
-                    event["gen_ai.evaluation.score.label"] = score_label
-                event.update(event_extra)
-                events.append(event)
+            )
 
     return events

--- a/dt-ai-ingest/src/dt_ai_ingest/langfuse/evaluation.py
+++ b/dt-ai-ingest/src/dt_ai_ingest/langfuse/evaluation.py
@@ -227,37 +227,31 @@ def _build_events(
                 string_value if string_value is not None else ("True" if value == 1.0 else "False")
             )
             build_kwargs["score_label"] = score_label
-            if value is not None:
-                events.append(
-                    build_eval_result_event(
-                        eval_name=name,
-                        score_value=value,
-                        extra=score_extra,
-                        **build_kwargs,
-                    )
+            # value may be None (no numeric score); the builder omits the
+            # numeric score key in that case and still emits the label.
+            events.append(
+                build_eval_result_event(
+                    eval_name=name,
+                    score_value=value,
+                    extra=score_extra,
+                    **build_kwargs,
                 )
-            else:
-                # No numeric value — build manually
-                event = _build_manual_event(name, score_extra, build_kwargs)
-                events.append(event)
+            )
 
         elif data_type == "CATEGORICAL":
             # Categorical: string_value is the category, value may be numeric mapping (default 0)
             if string_value is not None:
                 build_kwargs["score_label"] = string_value
-            if value is not None:
-                events.append(
-                    build_eval_result_event(
-                        eval_name=name,
-                        score_value=value,
-                        extra=score_extra,
-                        **build_kwargs,
-                    )
+            # value may be None (no numeric mapping); the builder omits the
+            # numeric score key in that case and still emits the label.
+            events.append(
+                build_eval_result_event(
+                    eval_name=name,
+                    score_value=value,
+                    extra=score_extra,
+                    **build_kwargs,
                 )
-            else:
-                # No numeric value — build manually
-                event = _build_manual_event(name, score_extra, build_kwargs)
-                events.append(event)
+            )
 
         else:
             # NUMERIC (default) — straightforward
@@ -274,28 +268,3 @@ def _build_events(
                 logger.debug("Skipping score %r with no numeric value.", name)
 
     return events
-
-
-def _build_manual_event(
-    name: str,
-    score_extra: dict[str, Any],
-    build_kwargs: dict[str, Any],
-) -> dict[str, Any]:
-    """Build a BizEvent dict manually (for scores without a numeric value).
-
-    Used for CATEGORICAL scores without numeric mapping or BOOLEAN scores
-    missing a value, where ``build_eval_result_event()`` can't be used
-    because it requires ``score_value``.
-    """
-    from dt_ai_ingest.schema import _EVAL_RESULT_FIELD_MAP
-
-    event: dict[str, Any] = {"event.type": "gen_ai.evaluation.result"}
-    event["gen_ai.evaluation.name"] = name
-
-    # Map known kwargs to BizEvent fields.
-    for k, v in build_kwargs.items():
-        if k in _EVAL_RESULT_FIELD_MAP and v is not None:
-            event[_EVAL_RESULT_FIELD_MAP[k]] = v
-
-    event.update(score_extra)
-    return event

--- a/dt-ai-ingest/src/dt_ai_ingest/schema.py
+++ b/dt-ai-ingest/src/dt_ai_ingest/schema.py
@@ -123,7 +123,7 @@ class EvalEvent(BaseModel):
 def build_eval_result_event(
     *,
     eval_name: str,
-    score_value: float,
+    score_value: float | None = None,
     extra: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> dict[str, Any]:
@@ -132,6 +132,11 @@ def build_eval_result_event(
     One event per metric per evaluated item.  Valid keyword arguments are
     the keys of ``_EVAL_RESULT_FIELD_MAP``.  Unknown keys are ignored.
     Pass ``extra`` for arbitrary framework-specific metadata.
+
+    ``score_value`` is optional: metrics that produce a label but no numeric
+    score (e.g. an errored DeepEval metric or a Langfuse categorical score
+    without a numeric mapping) still emit a schema-conformant event — the
+    ``gen_ai.evaluation.score.value`` key is simply omitted.
     """
     all_fields = {"eval_name": eval_name, "score_value": score_value, **kwargs}
     event: dict[str, Any] = {"event.type": "gen_ai.evaluation.result"}


### PR DESCRIPTION
Schema Builder - Logic split in multiple places

Make score_value optional in build_eval_result_event so metrics that produce a label but no numeric score go through the one central builder instead of hand-built event dicts. The builder already drops None-valued fields, so the gen_ai.evaluation.score.value key is simply omitted.

Affected paths:
- errored DeepEval metrics (score=None)
- Langfuse BOOLEAN/CATEGORICAL scores without a numeric mapping

Removes the two duplicated manual event builders in the DeepEval and Langfuse adapters, so gen_ai.evaluation.result events are produced in exactly one place. Behaviour is unchanged and covered by existing tests.