### PR TITLE
fix(dt-eval-cli): avoid leaking api keys across providers

### DIFF
--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -94,35 +94,33 @@ const PROVIDER_KEY_ENV: Partial<Record<DtEvalConfig['judge']['provider'], string
 };
 
 /**
- * Collect the secrets the user entered this session into `.env` variable names.
- * Only non-empty, explicitly-entered values are included so we never clobber an
- * existing `.env`/env value with a blank. Secrets are written to `.env` instead
- * of the YAML config (see saveConfig → stripSecrets).
+ * Collect the effective secrets from the resolved config into `.env` variable
+ * names. This preserves existing working credentials when a user re-runs
+ * `configure` without re-entering every secret, so stripping YAML secrets does
+ * not silently break the config.
  */
-function collectSecretEnv(
-  provider: DtEvalConfig['judge']['provider'],
-  entered: { apiToken?: string; apiKey?: string; bedrockSecretKey?: string },
-): Record<string, string> {
+function collectSecretEnv(config: DtEvalConfig): Record<string, string> {
   const env: Record<string, string> = {};
-  if (entered.apiToken) env['DT_API_TOKEN'] = entered.apiToken;
-  const keyEnv = PROVIDER_KEY_ENV[provider];
-  if (keyEnv && entered.apiKey) env[keyEnv] = entered.apiKey;
-  if (provider === 'bedrock' && entered.bedrockSecretKey) {
-    env['AWS_SECRET_ACCESS_KEY'] = entered.bedrockSecretKey;
+
+  if (config.dynatrace.apiToken) env['DT_API_TOKEN'] = config.dynatrace.apiToken;
+  if (config.dynatrace.origin?.apiToken) env['DT_ORIGIN_API_TOKEN'] = config.dynatrace.origin.apiToken;
+  if (config.dynatrace.destination?.apiToken) env['DT_DESTINATION_API_TOKEN'] = config.dynatrace.destination.apiToken;
+
+  const keyEnv = PROVIDER_KEY_ENV[config.judge.provider];
+  if (keyEnv && config.judge.apiKey) env[keyEnv] = config.judge.apiKey;
+  if (config.judge.provider === 'bedrock' && config.judge.secretKey) {
+    env['AWS_SECRET_ACCESS_KEY'] = config.judge.secretKey;
   }
+
   return env;
 }
 
 /**
- * Persist entered secrets to cwd `.env` (gitignored) and tell the user which
- * names to wire up as CI/CD pipeline secrets. No-op when nothing was entered.
+ * Persist secrets to cwd `.env` (gitignored) and tell the user which names to
+ * wire up as CI/CD pipeline secrets. No-op when nothing is configured.
  */
-function persistSecretsToEnv(
-  provider: DtEvalConfig['judge']['provider'],
-  entered: { apiToken?: string; apiKey?: string; bedrockSecretKey?: string },
-  log: (msg: string) => void,
-): void {
-  const secretEnv = collectSecretEnv(provider, entered);
+function persistSecretsToEnv(config: DtEvalConfig, log: (msg: string) => void): void {
+  const secretEnv = collectSecretEnv(config);
   if (Object.keys(secretEnv).length === 0) return;
   const envPath = join(process.cwd(), '.env');
   updateEnvFile(envPath, secretEnv);
@@ -459,11 +457,7 @@ export function createConfigureCommand(): Command {
       try {
         saveConfig(updated, outputPath);
         logger.success(`Config saved to ${outputPath}`);
-        persistSecretsToEnv(
-          provider,
-          { apiToken, apiKey, bedrockSecretKey },
-          (msg) => logger.info(msg),
-        );
+        persistSecretsToEnv(updated, (msg) => logger.info(msg));
       } catch (err) {
         logger.error(`Failed to save config: ${(err as Error).message}`);
         process.exit(1);
@@ -494,14 +488,14 @@ export function createConfigureCommand(): Command {
 
     // ── Flag-only mode ────────────────────────────────────
     const provider = (options.provider as DtEvalConfig['judge']['provider']) ?? existing.judge?.provider ?? 'openai';
-    const preservesExistingVertexKey = !(
+    const preserveExistingVertexKey = !(
       options.provider === 'vertex' ||
       options.project !== undefined ||
       options.location !== undefined ||
       options.apiKey !== undefined
     );
     const resolvedApiKey = resolveConfiguredApiKey(existing.judge, provider, options.apiKey, {
-      preserveExistingVertexKey: preservesExistingVertexKey,
+      preserveExistingVertexKey,
     });
 
     const updated: DtEvalConfig = {
@@ -542,11 +536,7 @@ export function createConfigureCommand(): Command {
     try {
       saveConfig(updated, outputPath);
       console.log(`Config saved to ${outputPath}`);
-      persistSecretsToEnv(
-        provider,
-        { apiToken: options.apiToken, apiKey: options.apiKey },
-        (msg) => console.log(msg),
-      );
+      persistSecretsToEnv(updated, (msg) => console.log(msg));
       console.log(`\n  Copy this to run the newly created config:`);
       console.log(`  dt-evals run ${basename(outputPath)}\n`);
     } catch (err) {

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -310,6 +310,7 @@ export function createConfigureCommand(): Command {
         vertex: 'Vertex AI API key (optional — leave blank to use ADC / Workload Identity)',
         bedrock: 'AWS Access Key ID — leave blank to rely on AWS_ACCESS_KEY_ID env var / IAM role',
       };
+      const existingProviderApiKey = resolveConfiguredApiKey(existing.judge, provider, undefined);
 
       let apiKey: string;
       let bedrockSecretKey = '';
@@ -322,7 +323,7 @@ export function createConfigureCommand(): Command {
       if (provider === 'bedrock') {
         apiKey = await input({
           message: providerApiKeyLabel[provider],
-          default: existing.judge?.apiKey ?? '',
+          default: existingProviderApiKey ?? '',
         });
         bedrockSecretKey = await password({
           message: 'AWS Secret Access Key — leave blank to rely on AWS_SECRET_ACCESS_KEY env var',

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -79,6 +79,27 @@ function printCostEstimate(
   console.log('  Always monitor your actual inference costs in your provider dashboard.\n');
 }
 
+export function resolveConfiguredApiKey(
+  existing: Partial<DtEvalConfig['judge']> | undefined,
+  provider: DtEvalConfig['judge']['provider'],
+  enteredApiKey: string | undefined,
+  opts?: { preserveExistingVertexKey?: boolean },
+): string | undefined {
+  if (enteredApiKey) {
+    return enteredApiKey;
+  }
+
+  if (provider !== existing?.provider) {
+    return undefined;
+  }
+
+  if (provider === 'vertex' && !opts?.preserveExistingVertexKey) {
+    return undefined;
+  }
+
+  return existing.apiKey;
+}
+
 async function testServiceSpans(
   environmentUrl: string,
   apiToken: string,
@@ -310,6 +331,8 @@ export function createConfigureCommand(): Command {
         default: existing.judge?.model ?? '',
       });
 
+      const resolvedApiKey = resolveConfiguredApiKey(existing.judge, provider, apiKey);
+
       // ── Evaluators ───────────────────────────────────────
       const enabledMetricIds = (existing.metrics?.enabled ?? allMetricIds).map(metricId);
       const selectedMetrics = await checkbox({
@@ -344,7 +367,7 @@ export function createConfigureCommand(): Command {
         },
         judge: {
           provider,
-          apiKey: apiKey || existing.judge?.apiKey,
+          ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
           ...(provider === 'bedrock' && {
             secretKey: bedrockSecretKey || existing.judge?.secretKey,
             region: bedrockRegion || existing.judge?.region,
@@ -414,6 +437,17 @@ export function createConfigureCommand(): Command {
     }
 
     // ── Flag-only mode ────────────────────────────────────
+    const provider = (options.provider as DtEvalConfig['judge']['provider']) ?? existing.judge?.provider ?? 'openai';
+    const preservesExistingVertexKey = !(
+      options.provider === 'vertex' ||
+      options.project !== undefined ||
+      options.location !== undefined ||
+      options.apiKey !== undefined
+    );
+    const resolvedApiKey = resolveConfiguredApiKey(existing.judge, provider, options.apiKey, {
+      preserveExistingVertexKey: preservesExistingVertexKey,
+    });
+
     const updated: DtEvalConfig = {
       schemaVersion: existing.schemaVersion ?? 1,
       name: existing.name,
@@ -422,8 +456,8 @@ export function createConfigureCommand(): Command {
         apiToken: options.apiToken ?? existing.dynatrace?.apiToken,
       },
       judge: {
-        provider: (options.provider as DtEvalConfig['judge']['provider']) ?? existing.judge?.provider ?? 'openai',
-        apiKey: options.apiKey ?? existing.judge?.apiKey,
+        provider,
+        ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
         model: options.model ?? existing.judge?.model,
         project: options.project ?? existing.judge?.project,
         location: options.location ?? existing.judge?.location,

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { spawnSync } from 'node:child_process';
 import { join, basename } from 'node:path';
 import { loadConfig, saveConfig, validateConfig } from '../../config/index.js';
+import { updateEnvFile } from '../../config/env-file.js';
 import type { DtEvalConfig } from '../../config/schema.js';
 import { metricId } from '../../config/schema.js';
 import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
@@ -77,6 +78,56 @@ function printCostEstimate(
   console.log(`  Total per run:       ~$${totalUsd.toFixed(4)}`);
   console.log('\n  ⚠  Ballpark only — token counts vary by span length and metric.');
   console.log('  Always monitor your actual inference costs in your provider dashboard.\n');
+}
+
+/**
+ * Env var name that holds the API key for each provider, matching the fallbacks
+ * in applyEnvVars(). Vertex is intentionally absent — it uses ADC / Workload
+ * Identity and needs no key.
+ */
+const PROVIDER_KEY_ENV: Partial<Record<DtEvalConfig['judge']['provider'], string>> = {
+  openai: 'OPENAI_API_KEY',
+  anthropic: 'ANTHROPIC_API_KEY',
+  'azure-openai': 'AZURE_OPENAI_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  bedrock: 'AWS_ACCESS_KEY_ID',
+};
+
+/**
+ * Collect the secrets the user entered this session into `.env` variable names.
+ * Only non-empty, explicitly-entered values are included so we never clobber an
+ * existing `.env`/env value with a blank. Secrets are written to `.env` instead
+ * of the YAML config (see saveConfig → stripSecrets).
+ */
+function collectSecretEnv(
+  provider: DtEvalConfig['judge']['provider'],
+  entered: { apiToken?: string; apiKey?: string; bedrockSecretKey?: string },
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (entered.apiToken) env['DT_API_TOKEN'] = entered.apiToken;
+  const keyEnv = PROVIDER_KEY_ENV[provider];
+  if (keyEnv && entered.apiKey) env[keyEnv] = entered.apiKey;
+  if (provider === 'bedrock' && entered.bedrockSecretKey) {
+    env['AWS_SECRET_ACCESS_KEY'] = entered.bedrockSecretKey;
+  }
+  return env;
+}
+
+/**
+ * Persist entered secrets to cwd `.env` (gitignored) and tell the user which
+ * names to wire up as CI/CD pipeline secrets. No-op when nothing was entered.
+ */
+function persistSecretsToEnv(
+  provider: DtEvalConfig['judge']['provider'],
+  entered: { apiToken?: string; apiKey?: string; bedrockSecretKey?: string },
+  log: (msg: string) => void,
+): void {
+  const secretEnv = collectSecretEnv(provider, entered);
+  if (Object.keys(secretEnv).length === 0) return;
+  const envPath = join(process.cwd(), '.env');
+  updateEnvFile(envPath, secretEnv);
+  log(`Secrets written to ${envPath} (gitignored) — kept out of the config file`);
+  log(`For CI/CD, set these as pipeline secrets instead: ${Object.keys(secretEnv).join(', ')}`);
 }
 
 export function resolveConfiguredApiKey(
@@ -408,6 +459,11 @@ export function createConfigureCommand(): Command {
       try {
         saveConfig(updated, outputPath);
         logger.success(`Config saved to ${outputPath}`);
+        persistSecretsToEnv(
+          provider,
+          { apiToken, apiKey, bedrockSecretKey },
+          (msg) => logger.info(msg),
+        );
       } catch (err) {
         logger.error(`Failed to save config: ${(err as Error).message}`);
         process.exit(1);
@@ -486,6 +542,11 @@ export function createConfigureCommand(): Command {
     try {
       saveConfig(updated, outputPath);
       console.log(`Config saved to ${outputPath}`);
+      persistSecretsToEnv(
+        provider,
+        { apiToken: options.apiToken, apiKey: options.apiKey },
+        (msg) => console.log(msg),
+      );
       console.log(`\n  Copy this to run the newly created config:`);
       console.log(`  dt-evals run ${basename(outputPath)}\n`);
     } catch (err) {

--- a/dt-eval-cli/src/cli/commands/doctor.ts
+++ b/dt-eval-cli/src/cli/commands/doctor.ts
@@ -1,12 +1,13 @@
 import { Command } from 'commander';
 import { execFile } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { promisify } from 'node:util';
 import pc from 'picocolors';
 import { Spinner } from '../../ui/spinner.js';
 import { loadConfig, validateConfig } from '../../config/index.js';
+import { updateEnvFile } from '../../config/env-file.js';
 import { probeProvider } from '../../probe/provider.js';
 import * as dtctl from '../../dtctl/index.js';
 import * as pasteToken from '../../dtctl/paste-token.js';
@@ -40,26 +41,6 @@ const warn = (msg: string) => console.log(`  ${pc.yellow('⚠')} ${msg}`);
 const info = (msg: string) => console.log(`  ${pc.dim('→')} ${msg}`);
 const sectionHeader = (n: number, total: number, title: string) =>
   console.log(`\n${pc.bold(`[${n}/${total}]`)} ${pc.bold(title)}`);
-
-function updateEnvFile(filePath: string, updates: Record<string, string>): void {
-  let lines: string[] = existsSync(filePath)
-    ? readFileSync(filePath, 'utf-8').split('\n')
-    : [];
-
-  for (const [key, value] of Object.entries(updates)) {
-    const idx = lines.findIndex(l => l.startsWith(`${key}=`) || l.startsWith(`${key} =`));
-    const newLine = `${key}=${value}`;
-    if (idx !== -1) {
-      lines[idx] = newLine;
-    } else {
-      lines.push(newLine);
-    }
-  }
-
-  // Remove trailing empty lines then add one
-  while (lines.length > 0 && lines[lines.length - 1]?.trim() === '') lines.pop();
-  writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8');
-}
 
 function getNodeMajor(): number {
   return parseInt(process.version.replace('v', '').split('.')[0] ?? '0', 10);

--- a/dt-eval-cli/src/config/env-file.ts
+++ b/dt-eval-cli/src/config/env-file.ts
@@ -1,0 +1,29 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Upsert `key=value` pairs into a dotenv-style file, preserving existing lines
+ * and comments. Existing keys are updated in place; new keys are appended.
+ *
+ * Secrets live here (gitignored) rather than in the YAML config, and are loaded
+ * into `process.env` at startup (see src/index.ts). Real environment variables
+ * always take precedence over `.env`, so CI/CD pipeline secrets win.
+ */
+export function updateEnvFile(filePath: string, updates: Record<string, string>): void {
+  const lines: string[] = existsSync(filePath)
+    ? readFileSync(filePath, 'utf-8').split('\n')
+    : [];
+
+  for (const [key, value] of Object.entries(updates)) {
+    const idx = lines.findIndex((l) => l.startsWith(`${key}=`) || l.startsWith(`${key} =`));
+    const newLine = `${key}=${value}`;
+    if (idx !== -1) {
+      lines[idx] = newLine;
+    } else {
+      lines.push(newLine);
+    }
+  }
+
+  // Remove trailing empty lines then add exactly one
+  while (lines.length > 0 && lines[lines.length - 1]?.trim() === '') lines.pop();
+  writeFileSync(filePath, lines.join('\n') + '\n', 'utf-8');
+}

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -177,12 +177,32 @@ export function loadConfig(opts?: LoadConfigOptions): DtEvalConfig {
   return applyEnvVars(merged);
 }
 
+/**
+ * Return a copy of `config` with all credentials removed. Secrets are never
+ * written to the YAML config — they are resolved from env vars / `.env` at load
+ * time (see {@link applyEnvVars} and src/index.ts). This keeps tokens out of
+ * files that are easy to commit or share.
+ */
+function stripSecrets(config: DtEvalConfig): DtEvalConfig {
+  const clone = JSON.parse(JSON.stringify(config)) as DtEvalConfig;
+  if (clone.judge) {
+    delete clone.judge.apiKey;
+    delete clone.judge.secretKey;
+  }
+  if (clone.dynatrace) {
+    delete clone.dynatrace.apiToken;
+    if (clone.dynatrace.origin) delete clone.dynatrace.origin.apiToken;
+    if (clone.dynatrace.destination) delete clone.dynatrace.destination.apiToken;
+  }
+  return clone;
+}
+
 export function saveConfig(config: DtEvalConfig, filePath: string): void {
   const dir = dirname(filePath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  const yamlContent = stringifyYaml(config, { indent: 2 });
+  const yamlContent = stringifyYaml(stripSecrets(config), { indent: 2 });
   writeFileSync(filePath, yamlContent, 'utf-8');
 }
 

--- a/dt-eval-cli/tests/cli/commands/configure.test.ts
+++ b/dt-eval-cli/tests/cli/commands/configure.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { resolveConfiguredApiKey } from '../../../src/cli/commands/configure.js';
+
+describe('resolveConfiguredApiKey', () => {
+  it('keeps an existing key only for the same non-vertex provider', () => {
+    expect(
+      resolveConfiguredApiKey({ provider: 'openai', apiKey: 'old-openai-key' }, 'openai', undefined),
+    ).toBe('old-openai-key');
+
+    expect(
+      resolveConfiguredApiKey({ provider: 'openai', apiKey: 'old-openai-key' }, 'anthropic', undefined),
+    ).toBeUndefined();
+  });
+
+  it('omits stale or blank API keys for vertex by default', () => {
+    expect(
+      resolveConfiguredApiKey({ provider: 'openai', apiKey: 'old-openai-key' }, 'vertex', undefined),
+    ).toBeUndefined();
+
+    expect(
+      resolveConfiguredApiKey({ provider: 'vertex', apiKey: 'old-vertex-key' }, 'vertex', undefined),
+    ).toBeUndefined();
+  });
+
+  it('preserves an existing vertex key only when explicitly requested', () => {
+    expect(
+      resolveConfiguredApiKey(
+        { provider: 'vertex', apiKey: 'old-vertex-key' },
+        'vertex',
+        undefined,
+        { preserveExistingVertexKey: true },
+      ),
+    ).toBe('old-vertex-key');
+  });
+
+  it('always prefers an explicitly entered key', () => {
+    expect(
+      resolveConfiguredApiKey({ provider: 'openai', apiKey: 'old-openai-key' }, 'vertex', 'new-vertex-key'),
+    ).toBe('new-vertex-key');
+  });
+});

--- a/dt-eval-cli/tests/cli/commands/configure.test.ts
+++ b/dt-eval-cli/tests/cli/commands/configure.test.ts
@@ -10,6 +10,14 @@ describe('resolveConfiguredApiKey', () => {
     expect(
       resolveConfiguredApiKey({ provider: 'openai', apiKey: 'old-openai-key' }, 'anthropic', undefined),
     ).toBeUndefined();
+
+    expect(
+      resolveConfiguredApiKey({ provider: 'bedrock', apiKey: 'old-bedrock-key' }, 'bedrock', undefined),
+    ).toBe('old-bedrock-key');
+
+    expect(
+      resolveConfiguredApiKey({ provider: 'openai', apiKey: 'old-openai-key' }, 'bedrock', undefined),
+    ).toBeUndefined();
   });
 
   it('omits stale or blank API keys for vertex by default', () => {

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -353,10 +353,26 @@ describe('config', () => {
   });
 
   describe('saveConfig', () => {
-    it('writes valid YAML to disk', async () => {
+    it('writes valid YAML to disk without secrets', async () => {
       const { readFileSync } = await import('node:fs');
       const { parse } = await import('yaml');
-      const config = makeValidConfig();
+      const config = makeValidConfig({
+        dynatrace: {
+          environmentUrl: 'https://test.live.dynatrace.com',
+          apiToken: 'top-level-token',
+          origin: { environmentUrl: 'https://read.live.dynatrace.com', apiToken: 'origin-token' },
+          destination: { environmentUrl: 'https://write.live.dynatrace.com', apiToken: 'destination-token' },
+        },
+        judge: {
+          provider: 'bedrock',
+          apiKey: 'access-key-id',
+          secretKey: 'secret-access-key',
+          region: 'us-east-1',
+          model: 'anthropic.claude-sonnet-4-5-20251001-v1:0',
+          timeout: 30000,
+          maxRetries: 2,
+        },
+      });
       const outPath = join(TEST_DIR, 'output.yaml');
 
       saveConfig(config, outPath);
@@ -364,18 +380,27 @@ describe('config', () => {
       const content = readFileSync(outPath, 'utf-8');
       const parsed = parse(content);
       expect(parsed.dynatrace.environmentUrl).toBe(config.dynatrace.environmentUrl);
+      expect(parsed.dynatrace.apiToken).toBeUndefined();
+      expect(parsed.dynatrace.origin.apiToken).toBeUndefined();
+      expect(parsed.dynatrace.destination.apiToken).toBeUndefined();
       expect(parsed.judge.provider).toBe(config.judge.provider);
+      expect(parsed.judge.apiKey).toBeUndefined();
+      expect(parsed.judge.secretKey).toBeUndefined();
     });
 
-    it('roundtrip: save then load returns the same config', () => {
+    it('roundtrip: save then load restores the same effective config when env vars provide secrets', () => {
       const config = makeValidConfig();
       const outPath = join(TEST_DIR, 'roundtrip.yaml');
 
       saveConfig(config, outPath);
 
+      process.env['DT_API_TOKEN'] = config.dynatrace.apiToken;
+      process.env['OPENAI_API_KEY'] = config.judge.apiKey;
       const loaded = loadConfig({ globalFile: join(TEST_DIR, 'nonexistent.yaml'), projectFile: outPath });
       expect(loaded.dynatrace.environmentUrl).toBe(config.dynatrace.environmentUrl);
+      expect(loaded.dynatrace.apiToken).toBe(config.dynatrace.apiToken);
       expect(loaded.judge.provider).toBe(config.judge.provider);
+      expect(loaded.judge.apiKey).toBe(config.judge.apiKey);
       expect(loaded.metrics.enabled).toEqual(config.metrics.enabled);
       expect(loaded.scope.since).toBe(config.scope.since);
     });

--- a/dt-eval-lib/src/engine/providers/base.ts
+++ b/dt-eval-lib/src/engine/providers/base.ts
@@ -1,7 +1,7 @@
 import type { LLMJudgeResponse, LLMProvider, ProviderConfig } from "./types";
 
 export abstract class BaseProvider implements LLMProvider {
-  protected readonly apiKey: string;
+  protected readonly apiKey: string | undefined;
   protected readonly model: string;
   protected readonly timeout: number;
   protected readonly baseUrl?: string;

--- a/dt-eval-lib/src/engine/providers/base.ts
+++ b/dt-eval-lib/src/engine/providers/base.ts
@@ -1,7 +1,7 @@
 import type { LLMJudgeResponse, LLMProvider, ProviderConfig } from "./types";
 
 export abstract class BaseProvider implements LLMProvider {
-  protected readonly apiKey: string | undefined;
+  protected readonly apiKey: string;
   protected readonly model: string;
   protected readonly timeout: number;
   protected readonly baseUrl?: string;


### PR DESCRIPTION
## Problem
`dt-evals configure` writes credentials into the generated config and can also carry a stale API key across provider switches.

## Solution
Write only non-secret settings to YAML, persist local secrets via the existing `.env` flow, and stop reusing a previous provider key when the provider changes.