### PR TITLE
fix(dt-eval-cli): default structured input to last user message

### DIFF
--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -80,8 +80,8 @@ export interface ScopeConfig {
  *
  * - `input` / `output` / `systemInstruction` / `model` map to the like-named
  *   span field.
- * - `userPrompt` is a synthetic field — the content of the latest prompt slot
- *   whose role is `user`. Useful for metrics like `user-frustration` that
+ * - `userPrompt` is a synthetic field — the latest extracted user message.
+ *   Useful for metrics like `user-frustration` that
  *   should score the user's turn in isolation, not the full conversation.
  */
 export type CanonicalSpanField =

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -32,6 +32,11 @@ interface ResolvedFields {
   model: string[];
 }
 
+interface FieldMatch {
+  key: string;
+  value: string;
+}
+
 function resolveFields(spanFields: SpanFieldsMap | undefined): ResolvedFields {
   return {
     input: [...toCandidateList(spanFields?.input), ...DEFAULT_INPUT_FIELDS],
@@ -107,12 +112,13 @@ export interface ParseSpanOptions {
 
 /**
  * Walk a candidate attribute list and return the first non-empty stringified
- * value. Handles strings, numbers, booleans, and JSON-encodable objects.
+ * value together with its source key. Handles strings, numbers, booleans,
+ * and JSON-encodable objects.
  */
-function pickFirst(record: Record<string, unknown>, candidates: string[]): string | undefined {
+function pickFirstMatch(record: Record<string, unknown>, candidates: string[]): FieldMatch | undefined {
   for (const key of candidates) {
     const value = asString(record[key]);
-    if (value) return value;
+    if (value) return { key, value };
   }
   return undefined;
 }
@@ -196,8 +202,9 @@ export function parseSpanResults(
     const traceId = asString(r['trace.id']);
     if (!traceId) continue;
 
-    let input = pickFirst(r, fields.input);
-    let systemInstruction = pickFirst(r, fields.systemInstruction);
+    const inputMatch = pickFirstMatch(r, fields.input);
+    let input = inputMatch?.value;
+    let systemInstruction = pickFirstMatch(r, fields.systemInstruction)?.value;
     let userPrompt: string | undefined;
 
     // Walk OpenLLMetry prompt slots: collect user-role content into userPrompt,
@@ -230,9 +237,12 @@ export function parseSpanResults(
     if (inputRoles) {
       systemInstruction ??= inputRoles.system;
       userPrompt ??= inputRoles.user;
+      if (inputMatch?.key === DEFAULT_INPUT_FIELDS[0] && inputRoles.user) {
+        input = inputRoles.user;
+      }
     }
 
-    let output = pickFirst(r, fields.output);
+    let output = pickFirstMatch(r, fields.output)?.value;
     // Same shape on the output side: `gen_ai.output.messages` may be a JSON
     // array of one or more {role: "assistant", …} messages. Flatten to text.
     const outputRoles = extractRolesFromJsonMessages(output);
@@ -256,7 +266,7 @@ export function parseSpanResults(
       userPrompt,
       // gen_ai.system (OTel) or gen_ai.provider.name (OpenLLMetry)
       system: asString(r['gen_ai.system']) ?? asString(r['gen_ai.provider.name']),
-      requestModel: pickFirst(r, fields.model),
+      requestModel: pickFirstMatch(r, fields.model)?.value,
       isError: statusCode === 'ERROR' || undefined,
     });
   }

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -3,13 +3,13 @@ export interface GenAiSpan {
   spanId?: string;
   startTime?: string;
   endTime?: string;
-  input: string;              // gen_ai.input.messages (stringified)
+  input: string;              // evaluator input after span-field/default parsing
   output: string;             // gen_ai.output.message
   systemInstruction?: string; // gen_ai.system_instruction
   system?: string;            // gen_ai.provider.name (e.g. "openai")
   requestModel?: string;      // gen_ai.request.model
-  /** Latest user-role prompt content. Useful for metrics that should score
-   * the user's turn alone (e.g. user-frustration). */
+  /** Latest user-role content extracted from prompt slots or structured messages.
+   * Useful for metrics that should score the user's turn alone. */
   userPrompt?: string;
   isError?: boolean;
 }

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -103,7 +103,7 @@ describe('parseSpanResults', () => {
     expect(span.traceId).toBe('abc123');
     expect(span.spanId).toBe('span001');
     expect(span.startTime).toBe('2026-03-01T10:00:00Z');
-    expect(span.input).toBe('[{"role":"user","content":"Hello"}]');
+    expect(span.input).toBe('Hello');
     expect(span.output).toBe('Hi there!');
     expect(span.systemInstruction).toBe('Be helpful.');
     expect(span.system).toBe('openai');
@@ -201,7 +201,7 @@ describe('parseSpanResults', () => {
     expect(parseSpanResults([])).toEqual([]);
   });
 
-  it('handles object-typed input messages by stringifying', () => {
+  it('uses the last user message when input messages are structured objects', () => {
     const records = [
       {
         'trace.id': 'obj-input',
@@ -211,7 +211,7 @@ describe('parseSpanResults', () => {
     ];
 
     const spans = parseSpanResults(records);
-    expect(spans[0]!.input).toBe('[{"role":"user","content":"Hello"}]');
+    expect(spans[0]!.input).toBe('Hello');
   });
 
   it('falls back to gen_ai.provider.name when gen_ai.system is absent', () => {
@@ -363,9 +363,34 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
     const spans = parseSpanResults(records, { spanFields: { output: 'gen_ai.output.messages' } });
     expect(spans).toHaveLength(1);
     const s = spans[0]!;
+    expect(s.input).toBe('What about Bach?');
     expect(s.systemInstruction).toBe('You are a music historian.');
     expect(s.userPrompt).toBe('What about Bach?');
     expect(s.output).toBe('Bach was prolific…');
+  });
+
+  it('uses the last user message and concatenates text parts for default input', () => {
+    const records = [
+      {
+        'trace.id': 'json-multipart-user',
+        'gen_ai.input.messages': JSON.stringify([
+          { role: 'system', parts: [{ type: 'text', content: 'You are helpful.' }] },
+          { role: 'user', parts: [{ type: 'text', content: 'First question' }] },
+          { role: 'assistant', parts: [{ type: 'text', content: 'First answer' }] },
+          {
+            role: 'user',
+            parts: [
+              { type: 'text', content: 'Second question' },
+              { type: 'text', content: 'More detail' },
+            ],
+          },
+        ]),
+        'gen_ai.output.message': 'Second answer',
+      },
+    ];
+    const spans = parseSpanResults(records);
+    expect(spans[0]!.input).toBe('Second question\nMore detail');
+    expect(spans[0]!.userPrompt).toBe('Second question\nMore detail');
   });
 
   it('handles `content` strings (no parts array)', () => {
@@ -409,5 +434,18 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
     ];
     const spans = parseSpanResults(records);
     expect(spans[0]!.systemInstruction).toBe('explicit system');
+  });
+
+  it('keeps explicit spanFields.input unchanged when it is configured', () => {
+    const records = [
+      {
+        'trace.id': 'custom-structured-input',
+        'custom.input': 'use this exact input',
+        'gen_ai.input.messages': inputJson,
+        'gen_ai.output.message': 'answer',
+      },
+    ];
+    const spans = parseSpanResults(records, { spanFields: { input: 'custom.input' } });
+    expect(spans[0]!.input).toBe('use this exact input');
   });
 });


### PR DESCRIPTION
## Summary
- default structured `gen_ai.input.messages` to the last extracted user message
- preserve explicit `scope.spanFields.input` overrides and plain-string input behavior
- cover multipart user messages and updated parser expectations in tests

## Testing
- npm test