### PR TITLE
feat(dt-eval-cli): separate evaluator context from systemInstruction

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -397,6 +397,7 @@ scope:
   spanFields:
     input: llm.user_input              # or [llm.user_input, my.custom.input]
     output: llm.response
+    context: rag.documents
     systemInstruction: llm.system
     model: llm.model
 ```
@@ -434,14 +435,16 @@ metrics:
         input: userPrompt                           # latest user-role prompt slot
     - id: hallucination
       inputs:
-        context: systemInstruction                  # use system prompt as context
+        context: systemInstruction                  # explicit override when desired
 ```
 
-Available canonical fields: `input`, `output`, `systemInstruction`, `model`,
-`userPrompt` (latest user-role prompt slot, extracted from
+Available canonical fields: `input`, `output`, `context`,
+`systemInstruction`, `model`, `userPrompt` (latest user-role prompt slot, extracted from
 `gen_ai.prompt.N.role == "user"`). When the requested field is empty on a
 given span, the slot falls back to `span.input` / `span.output` /
-`span.systemInstruction` so a single misconfiguration doesn't drop spans.
+`span.context` so a single misconfiguration doesn't drop spans. `context` has
+no built-in default span attribute; if a span does not provide it, evaluator
+context is omitted unless you explicitly route `inputs.context` elsewhere.
 
 ### Full example
 
@@ -470,12 +473,13 @@ scope:
   # Map custom span attributes to canonical fields. Defaults handle OTel
   # GenAI semconv + OpenLLMetry; override only what you need.
   spanFields:
+    context: rag.documents
     output: [gen_ai.output.message, gen_ai.output.messages]
     # input, systemInstruction, model use built-in defaults
 
 metrics:
   enabled:
-    # Plain string form — uses span.input / span.output / span.systemInstruction
+    # Plain string form — uses span.input / span.output / span.context
     - faithfulness
     - relevance
     - hallucination

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -397,7 +397,7 @@ scope:
   spanFields:
     input: llm.user_input              # or [llm.user_input, my.custom.input]
     output: llm.response
-    context: rag.documents
+    context: span.context              # can point to any span field the user wants as evaluator context, e.g. RAG context or system prompt
     systemInstruction: llm.system
     model: llm.model
 ```
@@ -435,7 +435,7 @@ metrics:
         input: userPrompt                           # latest user-role prompt slot
     - id: hallucination
       inputs:
-        context: systemInstruction                  # explicit override when desired
+        context: context                            # use the canonical context field for this metric
 ```
 
 Available canonical fields: `input`, `output`, `context`,
@@ -473,7 +473,7 @@ scope:
   # Map custom span attributes to canonical fields. Defaults handle OTel
   # GenAI semconv + OpenLLMetry; override only what you need.
   spanFields:
-    context: rag.documents
+    context: span.context              # can point to any span field the user wants as evaluator context, e.g. RAG context or system prompt
     output: [gen_ai.output.message, gen_ai.output.messages]
     # input, systemInstruction, model use built-in defaults
 

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -59,6 +59,7 @@ export interface JudgeConfig {
 export interface SpanFieldsMap {
   input?: string | string[];
   output?: string | string[];
+  context?: string | string[];
   systemInstruction?: string | string[];
   model?: string | string[];
 }
@@ -78,8 +79,8 @@ export interface ScopeConfig {
 /**
  * Which canonical span field feeds an evaluator input slot.
  *
- * - `input` / `output` / `systemInstruction` / `model` map to the like-named
- *   span field.
+ * - `input` / `output` / `context` / `systemInstruction` / `model` map to
+ *   the like-named span field.
  * - `userPrompt` is a synthetic field — the latest extracted user message.
  *   Useful for metrics like `user-frustration` that
  *   should score the user's turn in isolation, not the full conversation.
@@ -87,6 +88,7 @@ export interface ScopeConfig {
 export type CanonicalSpanField =
   | 'input'
   | 'output'
+  | 'context'
   | 'systemInstruction'
   | 'model'
   | 'userPrompt';

--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -76,12 +76,11 @@ export function buildBizeventPayload(
   }
 
   if (storeEvaluatedPrompt) {
-    // Record what the judge actually evaluated, not the raw span — they
-    // diverge when per-metric inputs routing maps a canonical field
-    // (e.g. userPrompt) onto an evaluator slot.
+    // Record the evaluated question/answer, while keeping system_prompt
+    // reserved for the actual system instruction on the traced span.
     payload['gen_ai.evaluation.input.question'] = judgeInputs?.input ?? span.input;
     payload['gen_ai.evaluation.input.answer'] = judgeInputs?.output ?? span.output;
-    const systemPrompt = judgeInputs?.context ?? span.systemInstruction;
+    const systemPrompt = span.systemInstruction;
     if (systemPrompt) {
       payload['gen_ai.evaluation.input.system_prompt'] = systemPrompt;
     }

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -22,12 +22,14 @@ const PROMPT_SLOTS = 3;
 // defaults remain as a fallback.
 const DEFAULT_INPUT_FIELDS = ['gen_ai.input.messages'];
 const DEFAULT_OUTPUT_FIELDS = ['gen_ai.output.message', 'gen_ai.output.messages', 'gen_ai.completion.0.content'];
+const DEFAULT_CONTEXT_FIELDS: string[] = [];
 const DEFAULT_SYSTEM_INSTRUCTION_FIELDS = ['gen_ai.system_instruction'];
 const DEFAULT_MODEL_FIELDS = ['gen_ai.request.model'];
 
 interface ResolvedFields {
   input: string[];
   output: string[];
+  context: string[];
   systemInstruction: string[];
   model: string[];
 }
@@ -41,6 +43,7 @@ function resolveFields(spanFields: SpanFieldsMap | undefined): ResolvedFields {
   return {
     input: [...toCandidateList(spanFields?.input), ...DEFAULT_INPUT_FIELDS],
     output: [...toCandidateList(spanFields?.output), ...DEFAULT_OUTPUT_FIELDS],
+    context: [...toCandidateList(spanFields?.context), ...DEFAULT_CONTEXT_FIELDS],
     systemInstruction: [...toCandidateList(spanFields?.systemInstruction), ...DEFAULT_SYSTEM_INSTRUCTION_FIELDS],
     model: [...toCandidateList(spanFields?.model), ...DEFAULT_MODEL_FIELDS],
   };
@@ -95,6 +98,7 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
     'gen_ai.provider.name',
     ...fields.input,
     ...fields.output,
+    ...fields.context,
     ...fields.systemInstruction,
     ...fields.model,
   ]);
@@ -129,10 +133,8 @@ function pickFirstMatch(record: Record<string, unknown>, candidates: string[]): 
  *   [{"role":"system","parts":[{"type":"text","content":"You are…"}]},
  *    {"role":"user","parts":[{"type":"text","content":"hello"}]}]
  * — the system + user + assistant turns are inlined rather than split across
- * separate prompt slots. Without parsing the JSON, the runner can't surface
- * `systemInstruction` (context) or `userPrompt`, so context-needing metrics
- * (faithfulness, hallucination, fluency, context-relevance) all error with
- * "Missing required fields: context" on these spans.
+ * separate prompt slots. Parsing this lets the runner recover the real system
+ * prompt and latest user message from structured chat payloads.
  *
  * Returns the extracted system / user / assistant content when the input is
  * a valid JSON array of role-tagged messages; otherwise `undefined` so the
@@ -204,6 +206,7 @@ export function parseSpanResults(
 
     const inputMatch = pickFirstMatch(r, fields.input);
     let input = inputMatch?.value;
+    const context = pickFirstMatch(r, fields.context)?.value;
     let systemInstruction = pickFirstMatch(r, fields.systemInstruction)?.value;
     let userPrompt: string | undefined;
 
@@ -262,6 +265,7 @@ export function parseSpanResults(
       endTime: asString(r['end_time']),
       input,
       output,
+      context,
       systemInstruction,
       userPrompt,
       // gen_ai.system (OTel) or gen_ai.provider.name (OpenLLMetry)

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -5,6 +5,7 @@ export interface GenAiSpan {
   endTime?: string;
   input: string;              // evaluator input after span-field/default parsing
   output: string;             // gen_ai.output.message
+  context?: string;           // evaluator context from scope.spanFields.context
   systemInstruction?: string; // gen_ai.system_instruction
   system?: string;            // gen_ai.provider.name (e.g. "openai")
   requestModel?: string;      // gen_ai.request.model

--- a/dt-eval-cli/src/masker/index.ts
+++ b/dt-eval-cli/src/masker/index.ts
@@ -40,6 +40,7 @@ export function maskSpan(span: GenAiSpan, config?: MaskingConfig): GenAiSpan {
     ...span,
     input: maskPii(span.input, config),
     output: maskPii(span.output, config),
+    context: span.context != null ? maskPii(span.context, config) : span.context,
     systemInstruction: span.systemInstruction != null ? maskPii(span.systemInstruction, config) : span.systemInstruction,
   };
 }

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -73,6 +73,7 @@ function resolveCanonicalField(span: GenAiSpan, field: CanonicalSpanField): stri
   switch (field) {
     case 'input': return span.input;
     case 'output': return span.output;
+    case 'context': return span.context;
     case 'systemInstruction': return span.systemInstruction;
     case 'model': return span.requestModel;
     case 'userPrompt': return span.userPrompt;
@@ -82,12 +83,12 @@ function resolveCanonicalField(span: GenAiSpan, field: CanonicalSpanField): stri
 /** Build the EvalInput passed to dt-eval-lib, applying any per-metric routing. */
 function buildEvalInput(span: GenAiSpan, inputs: MetricInputs | undefined): EvalInput {
   if (!inputs) {
-    return { input: span.input, output: span.output, context: span.systemInstruction };
+    return { input: span.input, output: span.output, context: span.context };
   }
   return {
     input: (inputs.input && resolveCanonicalField(span, inputs.input)) ?? span.input,
     output: (inputs.output && resolveCanonicalField(span, inputs.output)) ?? span.output,
-    context: (inputs.context && resolveCanonicalField(span, inputs.context)) ?? span.systemInstruction,
+    context: (inputs.context && resolveCanonicalField(span, inputs.context)) ?? span.context,
   };
 }
 

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -190,6 +190,23 @@ describe('BizeventWriter', () => {
       expect(payload['gen_ai.evaluation.input.system_prompt']).toBe('be nice');
     });
 
+    it('does not store generic evaluator context as system_prompt', () => {
+      const span = makeSpan({ context: 'retrieved facts', systemInstruction: undefined });
+      const payload = buildBizeventPayload(
+        span,
+        'faithfulness',
+        'Faithfulness',
+        makeEvalResult(),
+        'run-1',
+        'openai',
+        'gpt-4o',
+        undefined,
+        { context: 'retrieved facts' },
+        true,
+      );
+      expect(payload['gen_ai.evaluation.input.system_prompt']).toBeUndefined();
+    });
+
     it('falls back to span fields when judgeInputs is not supplied', () => {
       const span = makeSpan({ systemInstruction: 'be helpful' });
       const payload = buildBizeventPayload(

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -292,6 +292,14 @@ describe('spanFields configuration', () => {
     expect(query).toContain('gen_ai.output.message');
   });
 
+  it('buildGenAiSpanQuery includes user-supplied context candidate in fields clause', () => {
+    const query = buildGenAiSpanQuery({
+      since: '1h',
+      spanFields: { context: 'rag.context' },
+    });
+    expect(query).toContain('rag.context');
+  });
+
   it('parseSpanResults prefers user-supplied input over default candidates', () => {
     const records = [
       {
@@ -340,6 +348,19 @@ describe('spanFields configuration', () => {
     ];
     const spans = parseSpanResults(records, { spanFields: { model: 'llm.model' } });
     expect(spans[0]!.requestModel).toBe('claude-sonnet');
+  });
+
+  it('parseSpanResults respects user-supplied context candidate', () => {
+    const records = [
+      {
+        'trace.id': 'custom-context',
+        'gen_ai.input.messages': 'q',
+        'gen_ai.output.message': 'a',
+        'rag.context': 'retrieved facts',
+      },
+    ];
+    const spans = parseSpanResults(records, { spanFields: { context: 'rag.context' } });
+    expect(spans[0]!.context).toBe('retrieved facts');
   });
 });
 

--- a/dt-eval-cli/tests/masker/pii.test.ts
+++ b/dt-eval-cli/tests/masker/pii.test.ts
@@ -113,6 +113,13 @@ describe('maskSpan', () => {
     expect(masked.systemInstruction).toContain('[REDACTED]');
   });
 
+  it('masks context field when present', () => {
+    const span = makeSpan({ context: 'Context from admin@corp.com' });
+    const masked = maskSpan(span);
+    expect(masked.context).not.toContain('admin@corp.com');
+    expect(masked.context).toContain('[REDACTED]');
+  });
+
   it('leaves traceId unchanged', () => {
     const span = makeSpan({ traceId: 'trace-abc-123', input: 'user@test.com' });
     const masked = maskSpan(span);
@@ -149,5 +156,11 @@ describe('maskSpan', () => {
     const span = makeSpan({ systemInstruction: undefined });
     const masked = maskSpan(span);
     expect(masked.systemInstruction).toBeUndefined();
+  });
+
+  it('handles span with undefined context gracefully', () => {
+    const span = makeSpan({ context: undefined });
+    const masked = maskSpan(span);
+    expect(masked.context).toBeUndefined();
   });
 });

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -72,6 +72,7 @@ function makeDtClient(spans: GenAiSpan[]) {
     'gen_ai.output.message': s.output,
     'gen_ai.system': s.system,
     'gen_ai.request.model': s.requestModel,
+    'rag.context': s.context,
     'gen_ai.system_instruction': s.systemInstruction,
     // Include a user-role prompt slot so the parser surfaces userPrompt
     // for tests that rely on per-metric inputs routing.
@@ -171,6 +172,33 @@ describe('runEvals', () => {
     expect(dtClient.ingestBizevents).toHaveBeenCalledOnce();
     const [payloads] = dtClient.ingestBizevents.mock.calls[0] as [unknown[]];
     expect(payloads).toHaveLength(6);
+  });
+
+  it('uses canonical context by default instead of systemInstruction', async () => {
+    const dtClient = makeDtClient([
+      makeSpan({
+        context: 'retrieved facts',
+        systemInstruction: 'be concise',
+      }),
+    ]);
+    const config = makeConfig({
+      scope: {
+        since: '1h',
+        sampling: { strategy: 'random', percent: 100 },
+        spanFields: { context: 'rag.context' },
+      },
+      metrics: { enabled: ['faithfulness'] },
+    });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    const callArgs = evaluate.mock.calls[0] as unknown[];
+    const evalInput = callArgs[1] as { context?: string };
+    expect(evalInput.context).toBe('retrieved facts');
   });
 
   it('dry-run returns correct counts without writing bizevents', async () => {
@@ -358,6 +386,64 @@ describe('runEvals', () => {
     const callArgs = evaluate.mock.calls[0] as unknown[];
     const evalInput = callArgs[1] as { input: string };
     expect(evalInput.input).toBe(span.input);
+  });
+
+  it('routes context from systemInstruction when explicitly requested', async () => {
+    const dtClient = makeDtClient([
+      makeSpan({
+        context: 'retrieved facts',
+        systemInstruction: 'be concise',
+      }),
+    ]);
+    const config = makeConfig({
+      scope: {
+        since: '1h',
+        sampling: { strategy: 'random', percent: 100 },
+        spanFields: { context: 'rag.context' },
+      },
+      metrics: {
+        enabled: [{ id: 'faithfulness', inputs: { context: 'systemInstruction' } }],
+      },
+    });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    const callArgs = evaluate.mock.calls[0] as unknown[];
+    const evalInput = callArgs[1] as { context?: string };
+    expect(evalInput.context).toBe('be concise');
+  });
+
+  it('falls back to canonical context when routed context field is unset', async () => {
+    const dtClient = makeDtClient([
+      makeSpan({
+        context: 'retrieved facts',
+        systemInstruction: undefined,
+      }),
+    ]);
+    const config = makeConfig({
+      scope: {
+        since: '1h',
+        sampling: { strategy: 'random', percent: 100 },
+        spanFields: { context: 'rag.context' },
+      },
+      metrics: {
+        enabled: [{ id: 'faithfulness', inputs: { context: 'systemInstruction' } }],
+      },
+    });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    const callArgs = evaluate.mock.calls[0] as unknown[];
+    const evalInput = callArgs[1] as { context?: string };
+    expect(evalInput.context).toBe('retrieved facts');
   });
 
   it('emits onProgress events for each phase in order', async () => {


### PR DESCRIPTION
Summary
- add first-class scope.spanFields.context
- add canonical context for per-metric routing
- default evaluator context to canonical context instead of systemInstruction
- keep systemInstruction reserved for actual system prompts

Behavior
Defaults
- input still defaults from gen_ai.input.messages
- output keeps the existing output parsing behavior
- context has no built-in default span attribute, so evaluator context is omitted unless configured
- systemInstruction still resolves from system-prompt sources, but it is no longer used as evaluator context by default

Custom mapping
- scope.spanFields.context maps a span attribute into canonical context
- scope.spanFields.systemInstruction maps a span attribute into canonical systemInstruction
- plain/default metric execution now uses span.context for evaluator context
- metrics can still explicitly route inputs.context: systemInstruction when they really want the system prompt

Fallbacks
- when a metric routes inputs.context to another canonical field and that field is empty, the runner falls back to canonical context
- if canonical context is also empty, evaluator context is omitted

Testing
- npm test