### PR TITLE
fix(dt-eval-cli): suggest correct default model per provider in wizard

### DIFF
--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -5,7 +5,7 @@ import { loadConfig, saveConfig, validateConfig } from '../../config/index.js';
 import { updateEnvFile } from '../../config/env-file.js';
 import type { DtEvalConfig } from '../../config/schema.js';
 import { metricId } from '../../config/schema.js';
-import { DEFAULT_JUDGE_MODELS } from '../../config/defaults.js';
+import { DEFAULT_JUDGE_MODELS, suggestModelForProvider } from '../../config/defaults.js';
 import { stringify as stringifyYaml } from 'yaml';
 import { redactSecrets } from '../../ui/format.js';
 import { logger } from '../../logger/index.js';
@@ -378,7 +378,7 @@ export function createConfigureCommand(): Command {
 
       const model = await input({
         message: `Evaluator model  (${modelPlaceholder})`,
-        default: existing.judge?.model ?? '',
+        default: suggestModelForProvider(provider, existing.judge?.provider, existing.judge?.model),
       });
 
       const resolvedApiKey = resolveConfiguredApiKey(existing.judge, provider, apiKey);
@@ -430,7 +430,10 @@ export function createConfigureCommand(): Command {
             project: vertexProject || existing.judge?.project,
             location: vertexLocation || existing.judge?.location,
           }),
-          model: model || existing.judge?.model,
+          // Never carry over another provider's model (e.g. the OpenAI default
+          // that resolveEffectiveConfig injects). Fall back to this provider's
+          // default, or undefined when it has none (azure-openai deployments).
+          model: model || suggestModelForProvider(provider, existing.judge?.provider, existing.judge?.model) || undefined,
           timeout: existing.judge?.timeout ?? 30000,
           maxRetries: existing.judge?.maxRetries ?? 2,
         },
@@ -509,7 +512,9 @@ export function createConfigureCommand(): Command {
       judge: {
         provider,
         ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
-        model: options.model ?? existing.judge?.model,
+        // Don't inherit another provider's model (e.g. the OpenAI default that
+        // resolveEffectiveConfig injects) when switching providers via --provider.
+        model: options.model ?? (suggestModelForProvider(provider, existing.judge?.provider, existing.judge?.model) || undefined),
         project: options.project ?? existing.judge?.project,
         location: options.location ?? existing.judge?.location,
         timeout: existing.judge?.timeout ?? 30000,

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -55,3 +55,23 @@ export const DEFAULT_JUDGE_MODELS: Record<string, string> = {
   // azure-openai: no default — deployment names are user-defined in Azure portal
   bedrock: 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
 };
+
+/**
+ * Suggests the model to pre-fill in the configure wizard's model prompt.
+ *
+ * Only reuses a previously configured model when the user stays on the same
+ * provider — otherwise the provider-specific default is suggested. This
+ * prevents carrying over one provider's model (e.g. an OpenAI default filled
+ * in by resolveEffectiveConfig) when the user switches to another provider.
+ * Returns '' when no default exists (e.g. azure-openai deployment names).
+ */
+export function suggestModelForProvider(
+  provider: DtEvalConfig['judge']['provider'],
+  existingProvider?: DtEvalConfig['judge']['provider'],
+  existingModel?: string,
+): string {
+  if (existingProvider === provider && existingModel) {
+    return existingModel;
+  }
+  return DEFAULT_JUDGE_MODELS[provider] ?? '';
+}

--- a/dt-eval-cli/tests/config-defaults.test.ts
+++ b/dt-eval-cli/tests/config-defaults.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { suggestModelForProvider, DEFAULT_JUDGE_MODELS } from '../src/config/defaults.js';
+import type { DtEvalConfig } from '../src/config/schema.js';
+
+type Provider = DtEvalConfig['judge']['provider'];
+
+// Derive everything from the single source of truth so updating a model name in
+// defaults.ts never breaks these tests — they assert the routing logic, not the
+// literal model strings.
+const providersWithDefault = Object.keys(DEFAULT_JUDGE_MODELS) as Provider[];
+
+describe('suggestModelForProvider', () => {
+  it('suggests each provider default from DEFAULT_JUDGE_MODELS when no existing config', () => {
+    expect(providersWithDefault.length).toBeGreaterThan(0);
+    for (const provider of providersWithDefault) {
+      expect(suggestModelForProvider(provider)).toBe(DEFAULT_JUDGE_MODELS[provider]);
+    }
+  });
+
+  // Regression for AI-315: switching provider must not carry over the previous
+  // provider's model (e.g. an OpenAI default filled in by resolveEffectiveConfig).
+  it('ignores the existing model when the provider changed', () => {
+    const stale = DEFAULT_JUDGE_MODELS['openai'];
+    for (const provider of providersWithDefault) {
+      if (provider === 'openai') continue;
+      expect(suggestModelForProvider(provider, 'openai', stale)).toBe(
+        DEFAULT_JUDGE_MODELS[provider],
+      );
+      expect(suggestModelForProvider(provider, 'openai', stale)).not.toBe(stale);
+    }
+  });
+
+  it('reuses the existing model when the provider is unchanged', () => {
+    // Arbitrary, intentionally non-default models a user might have typed — these
+    // are user input, not our source of truth, so literals are correct here.
+    const customOpenai = 'gpt-4o';
+    const customAnthropic = 'claude-opus-4-8';
+    expect(customOpenai).not.toBe(DEFAULT_JUDGE_MODELS['openai']);
+    expect(suggestModelForProvider('openai', 'openai', customOpenai)).toBe(customOpenai);
+    expect(suggestModelForProvider('anthropic', 'anthropic', customAnthropic)).toBe(
+      customAnthropic,
+    );
+  });
+
+  it('returns empty string for providers without a default (azure-openai)', () => {
+    // Guard the premise: azure-openai genuinely has no entry in the map.
+    expect(DEFAULT_JUDGE_MODELS['azure-openai']).toBeUndefined();
+    expect(suggestModelForProvider('azure-openai')).toBe('');
+    // Even coming from another provider, no default deployment name can be guessed.
+    expect(
+      suggestModelForProvider('azure-openai', 'openai', DEFAULT_JUDGE_MODELS['openai']),
+    ).toBe('');
+  });
+
+  it('falls back to the provider default when existing model is empty', () => {
+    const def = DEFAULT_JUDGE_MODELS['openai'];
+    expect(suggestModelForProvider('openai', 'openai', '')).toBe(def);
+    expect(suggestModelForProvider('openai', 'openai', undefined)).toBe(def);
+  });
+});

--- a/dt-eval-cli/tests/configure.integration.test.ts
+++ b/dt-eval-cli/tests/configure.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { parse as parseYaml } from 'yaml';
+import { DEFAULT_JUDGE_MODELS } from '../src/config/defaults.js';
+
+// Regression for AI-315: `configure --provider X` must persist X's default model,
+// never the OpenAI default that resolveEffectiveConfig injects for a fresh config.
+// Exercises the flag-only path end-to-end (no TTY, no network — flag mode does not probe).
+
+const ROOT = process.cwd(); // package root when vitest runs
+const TSX = join(ROOT, 'node_modules/.bin/tsx');
+const INDEX = join(ROOT, 'src/index.ts');
+
+function runConfigure(provider: string): { provider?: string; model?: string } {
+  const home = mkdtempSync(join(tmpdir(), 'dtcfg-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dtcfg-cwd-'));
+  execFileSync(
+    TSX,
+    ['--no-warnings', INDEX, 'configure',
+      '--provider', provider, '--api-key', 'x',
+      '--env-url', 'https://localhost:9', '--since', '1h'],
+    { cwd, env: { ...process.env, HOME: home, NO_COLOR: '1' }, stdio: 'ignore' },
+  );
+  const file = join(cwd, '.dt-eval.yaml');
+  if (!existsSync(file)) throw new Error(`config not written to ${file}`);
+  const cfg = parseYaml(readFileSync(file, 'utf-8'));
+  return { provider: cfg?.judge?.provider, model: cfg?.judge?.model };
+}
+
+describe('configure --provider (flag mode) default model', () => {
+  beforeAll(() => {
+    if (!existsSync(TSX)) throw new Error('tsx not found — run npm install');
+  });
+
+  it('persists the anthropic default, not the OpenAI default', () => {
+    const cfg = runConfigure('anthropic');
+    expect(cfg.provider).toBe('anthropic');
+    expect(cfg.model).toBe(DEFAULT_JUDGE_MODELS['anthropic']);
+    expect(cfg.model).not.toBe(DEFAULT_JUDGE_MODELS['openai']); // the AI-315 bug
+  }, 30_000);
+
+  it('persists the bedrock default, not the OpenAI default', () => {
+    const cfg = runConfigure('bedrock');
+    expect(cfg.provider).toBe('bedrock');
+    expect(cfg.model).toBe(DEFAULT_JUDGE_MODELS['bedrock']);
+    expect(cfg.model).not.toBe(DEFAULT_JUDGE_MODELS['openai']); // the AI-315 bug
+  }, 30_000);
+
+  it('leaves model unset for azure-openai (deployment name is user-defined)', () => {
+    const cfg = runConfigure('azure-openai');
+    expect(cfg.provider).toBe('azure-openai');
+    expect(cfg.model).toBeUndefined();
+  }, 30_000);
+});


### PR DESCRIPTION
## Problem (AI-315)

The `configure` wizard always suggested **and persisted** the OpenAI default model (`gpt-5-mini`) regardless of the selected provider.

**Root cause:** `resolveEffectiveConfig` injects `judge.model = DEFAULT_JUDGE_MODELS[provider]` for the default provider (`openai`), so `loadConfig()` returned `gpt-5-mini` even for a fresh setup. Every model code path in `configure` then read `existing.judge?.model` blindly.

## Fix

Added `suggestModelForProvider()` (in `config/defaults.ts`) which reuses an existing model **only when the provider is unchanged**, otherwise returns that provider's default — or `''` for `azure-openai`, whose deployment names are user-defined. Wired into all three leaking paths:

1. interactive model-prompt default
2. interactive save fallback
3. flag-only mode save (`configure --provider …`)

## Result (per provider)

| Provider | Model |
|---|---|
| openai | `gpt-5-mini` |
| anthropic | `claude-sonnet-4-6` |
| gemini / vertex | `gemini-3.1-flash-lite` |
| bedrock | `us.anthropic.claude-haiku-4-5-20251001-v1:0` |
| azure-openai | *(unset — deployment name required)* |

## Testing

- Unit tests for `suggestModelForProvider` (`tests/config-defaults.test.ts`).
- Integration test driving the real CLI flag-mode end-to-end (`tests/configure.integration.test.ts`).
- Manually verified the interactive wizard and flag mode for all six providers.
- Full suite: 211/211 green; build + typecheck green.