### PR TITLE
fix(dt-eval-lib): guard prompt-field release regressions (AI-317)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,5 +103,11 @@ jobs:
           - name: Build
             run: npm run build
 
+          - name: Resolve npm dist-tag
+            id: npm-tag
+            run: |
+              TAG=$(node -p "const version = require('./package.json').version; const prerelease = version.split('-')[1]; prerelease ? prerelease.split('.')[0] : 'latest'")
+              echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
           - name: Publish package
-            run: npm publish --access public --tag latest
+            run: npm publish --access public --tag "${{ steps.npm-tag.outputs.tag }}"

--- a/dt-eval-lib/tests/engine.test.ts
+++ b/dt-eval-lib/tests/engine.test.ts
@@ -303,6 +303,15 @@ describe("evaluate() — input validation", () => {
     ).resolves.toBeDefined();
   });
 
+  it.each([
+    BuiltInMetric.Fluency,
+    BuiltInMetric.Faithfulness,
+    BuiltInMetric.Hallucination,
+    BuiltInMetric.FactualAccuracy,
+  ])("does not require context-like fields for %s", async (metric) => {
+    await expect(evaluate(metric, baseInput, baseConfig)).resolves.toBeDefined();
+  });
+
   it("error message lists missing fields", async () => {
     try {
       await evaluate(BuiltInMetric.Faithfulness, { input: "What is Paris?" }, baseConfig);


### PR DESCRIPTION
## Problem

The current `dt-eval-lib` source on `main` no longer requires `context` for `fluency`, `faithfulness`, and `hallucination`, and no longer requires `expectedOutput` for `factual-accuracy`. However, the last published lib release still exposes the older prompt requirements in the shipped artifact.

That leaves us with two gaps:
- no focused regression coverage for the exact runtime symptom users are hitting
- prerelease packages are still published with the `latest` dist-tag, which makes npm resolution/version inspection confusing

## Fix

- add `dt-eval-lib` regression coverage that exercises the runtime validation path and proves these metrics work without the old context-like fields
- publish prerelease npm packages to their prerelease dist-tag (for example `alpha`) instead of always using `latest`

## Result

- this branch adds a releasable `fix(dt-eval-lib)` change so the lib can cut a fresh release from the current `main` contents
- the new test guards the exact validation behavior that regressed in the shipped package
- future alpha releases will no longer overwrite or masquerade as `latest`

## Testing

- `cd dt-eval-lib && npm test -- tests/engine.test.ts`