### PR TITLE
fix(dt-eval-cli): bump dt-eval-lib to 0.0.14-alpha

### DIFF
--- a/dt-eval-cli/package-lock.json
+++ b/dt-eval-cli/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
         "@aws-sdk/client-bedrock-runtime": "^3.0.0",
-        "@dynatrace-oss/dt-eval-lib": "^0.0.13-alpha",
+        "@dynatrace-oss/dt-eval-lib": "^0.0.14-alpha",
         "@google/genai": "^1.0.0",
         "@inquirer/prompts": "^7.10.1",
         "@types/figlet": "^1.7.0",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@dynatrace-oss/dt-eval-lib": {
-      "version": "0.0.13-alpha",
-      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.13-alpha.tgz",
-      "integrity": "sha512-7KsSb96oY5H2L/0HrEo1zXt6k6OQgsT9T/F28mJHmpAV0dRk1eOHehcWoBD+wQGxU9d9qdRnN4Kp5+o3bTC3WQ==",
+      "version": "0.0.14-alpha",
+      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.14-alpha.tgz",
+      "integrity": "sha512-/w2otxiPKpMB+iqmzS1+UzeCA3X1iNCpX5+NzqFssLyDqu+lY+TvlvbfuO0Ton3+xTjofgyEkVSqA0czOc6GxQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
     "@aws-sdk/client-bedrock-runtime": "^3.0.0",
-    "@dynatrace-oss/dt-eval-lib": "^0.0.13-alpha",
+    "@dynatrace-oss/dt-eval-lib": "^0.0.14-alpha",
     "@google/genai": "^1.0.0",
     "@inquirer/prompts": "^7.10.1",
     "@types/figlet": "^1.7.0",


### PR DESCRIPTION
## Problem

`dt-evals` still depends on `@dynatrace-oss/dt-eval-lib@^0.0.13-alpha`, which means the CLI release line does not explicitly pick up the newly released `0.0.14-alpha` library containing the required-fields alignment and related runtime fixes.

## Fix

- bump `@dynatrace-oss/dt-eval-lib` from `^0.0.13-alpha` to `^0.0.14-alpha` in `dt-eval-cli/package.json`
- refresh `dt-eval-cli/package-lock.json` so `npm ci` resolves the same released tarball in CI and local installs

## Testing

- `cd dt-eval-cli && npm run build`
- `cd dt-eval-cli && npm test`