### PR TITLE
docs: audit and fix dt-eval-lib, dt-eval-cli, and root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ dt-evals status
 
 ---
 
-
 ## Required Dynatrace Permissions
 
 ### dt-evals CLI

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ End-to-end LLM evaluation toolkit for Dynatrace AI Observability.
 - Python `>=3.10` (dt-ai-ingest)
 - A Dynatrace environment with GenAI spans (`gen_ai.*` OTEL attributes)
 - A Dynatrace platform token (generated at [myaccount.dynatrace.com/platformTokens](https://myaccount.dynatrace.com/platformTokens) — `dt-evals doctor` walks you through it)
-- Credentials for your judge provider (OpenAI, Anthropic, Google, AWS Bedrock, or Azure OpenAI)
+- Credentials for your judge provider (OpenAI, Anthropic, Google Gemini Enterprise Platform (Vertex AI), AWS Bedrock, or Azure OpenAI)
 
 ## Install
 
@@ -259,6 +259,21 @@ dt-evals status
 
 ---
 
+### `deploy`
+
+Package and deploy the eval runner as a serverless function for continuous scheduled evaluation.
+
+```bash
+dt-evals deploy --provider aws      # AWS Lambda
+dt-evals deploy --provider gcp      # Google Cloud Run
+dt-evals deploy --provider azure    # Azure Functions
+dt-evals deploy --teardown          # Destroy deployed resources
+```
+
+See [`dt-eval-deploy`](dt-eval-deploy) for Docker-based deployment.
+
+---
+
 ## Required Dynatrace Permissions
 
 ### dt-evals CLI
@@ -328,8 +343,7 @@ DT_API_TOKEN=dt0c01.xxxxx
 |----------|--------------|-------|
 | `openai` | `gpt-5-mini` | `OPENAI_API_KEY` |
 | `anthropic` | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
-| `vertex` | `gemini-3.1-flash-lite` | ADC by default — set `judge.project` + `judge.location` (or `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`). No `GOOGLE_API_KEY` required. |
-| `gemini` | `gemini-3.1-flash-lite` | `GOOGLE_API_KEY` |
+| `vertex`, `gemini` | `gemini-3.1-flash-lite` | Google Gemini Enterprise Platform (Vertex AI) — use ADC by default with `vertex` and set `judge.project` + `judge.location` (or `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`); use `GOOGLE_API_KEY` with `gemini`. |
 | `bedrock` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
 | `azure-openai` | user-provided deployment name | `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_API_VERSION` |
 
@@ -410,9 +424,9 @@ JUDGE_MODEL=gpt-4.1
 OPENAI_API_KEY=sk-...
 # Anthropic
 ANTHROPIC_API_KEY=sk-ant-...
-# Google Gemini Developer API
+# Google Gemini Enterprise Platform (Vertex AI)
 GOOGLE_API_KEY=...
-# Google Vertex AI — uses Workload Identity / Application Default Credentials (no API key)
+# Or use Workload Identity / Application Default Credentials instead of an API key
 GOOGLE_CLOUD_PROJECT=my-gcp-project
 GOOGLE_CLOUD_LOCATION=global
 # AWS Bedrock

--- a/README.md
+++ b/README.md
@@ -361,7 +361,6 @@ name: travel-assistant-prod
 
 dynatrace:
   environmentUrl: https://your-env.live.dynatrace.com
-  # apiToken: use DT_API_TOKEN env var instead of hardcoding here
 
 judge:
   provider: openai

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ dt-evals run --since 2h --sample 20 --concurrency 8 --debug
 | `--concurrency <n>` | Number of parallel evaluation workers |
 | `--debug` | Per-step timing logs |
 | `--config <path>` | Path to a specific config file |
+| `--store-evaluated-prompt` | Include the evaluated prompt/response in bizevents written to Dynatrace (overrides `storeEvaluatedPrompt` in config; default: false) |
 
 **GitHub Actions example:**
 
@@ -258,20 +259,6 @@ dt-evals status
 
 ---
 
-### `deploy`
-
-Package and deploy the eval runner as a serverless function for continuous scheduled evaluation.
-
-```bash
-dt-evals deploy --provider aws      # AWS Lambda
-dt-evals deploy --provider gcp      # Google Cloud Run
-dt-evals deploy --provider azure    # Azure Functions
-dt-evals deploy --teardown          # Destroy deployed resources
-```
-
-See [`dt-eval-deploy`](dt-eval-deploy) for Docker-based deployment.
-
----
 
 ## Required Dynatrace Permissions
 
@@ -314,7 +301,7 @@ DT_API_TOKEN=dt0c01.xxxxx
 
 ## Built-in Evaluators
 
-13 built-in LLM judge evaluators plus statistical drift detection.
+14 built-in LLM judge evaluators plus statistical drift detection.
 
 | Evaluator | Measures |
 |-----------|----------|
@@ -340,14 +327,14 @@ DT_API_TOKEN=dt0c01.xxxxx
 
 | Provider | Default model | Notes |
 |----------|--------------|-------|
-| `openai` | `gpt-5.4` | `OPENAI_API_KEY` |
-| `anthropic` | `claude-sonnet-4-7` | `ANTHROPIC_API_KEY` |
-| `vertex` | `gemini-3-pro` | Workload Identity / ADC by default — set `judge.project` + `judge.location` (or `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`). No `GOOGLE_API_KEY` required. |
-| `gemini` | `gemini-3.1-flash-live` | `GOOGLE_API_KEY` |
-| `bedrock` | `anthropic.claude-opus-4-7` | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
+| `openai` | `gpt-5-mini` | `OPENAI_API_KEY` |
+| `anthropic` | `claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
+| `vertex` | `gemini-3.1-flash-lite` | ADC by default — set `judge.project` + `judge.location` (or `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION`). No `GOOGLE_API_KEY` required. |
+| `gemini` | `gemini-3.1-flash-lite` | `GOOGLE_API_KEY` |
+| `bedrock` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
 | `azure-openai` | user-provided deployment name | `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` + `AZURE_OPENAI_API_VERSION` |
 
-Override the model with `--model <id>` or set `judge.model` in config.
+Override the model with `--model <id>` or set `judge.model` in config. See `dt-eval-cli/src/config/defaults.ts` for current defaults.
 
 ---
 
@@ -361,7 +348,7 @@ name: travel-assistant-prod
 
 dynatrace:
   environmentUrl: https://your-env.live.dynatrace.com
-  apiToken: dt0c01.xxxxx
+  # apiToken: use DT_API_TOKEN env var instead of hardcoding here
 
 judge:
   provider: openai
@@ -397,9 +384,7 @@ judge:
   provider: bedrock
   model: us.anthropic.claude-3-5-haiku-20241022-v1:0
   region: us-east-1
-  # or use AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env vars
-  apiKey: <AWS_ACCESS_KEY_ID>
-  secretKey: <AWS_SECRET_ACCESS_KEY>
+  # credentials via AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env vars, IAM role, or SSO
 ```
 
 **Azure OpenAI example:**

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -288,7 +288,6 @@ name: travel-assistant-prod
 
 dynatrace:
   environmentUrl: https://your-env.live.dynatrace.com
-  # apiToken: use DT_API_TOKEN env var instead of hardcoding here
   dtctlContext: my-prod-context
 
 judge:
@@ -386,21 +385,24 @@ for end-to-end instrumentation examples.
 Each entry accepts a single attribute or a list of candidates; the first
 non-null value wins, with the built-in defaults appended as fallback.
 
-**Example 1 — non-semconv spans:**
+**Example 1 — OTel GenAI variant** (some Bedrock / Vertex SDK emitters
+serialize the full message array under the plural attribute
+`gen_ai.output.messages` instead of the singular
+`gen_ai.output.message`):
 
 ```yaml
 scope:
-  service: my-llm-service
-  since: 30m
+  service: pydantic-ai-music-agent
   spanFields:
-    input: custom.user_query           # or [custom.user_query, custom.prompt]
-    output: custom.llm_response
-    context: custom.rag_context        # any span field — e.g. RAG context, system prompt
-    systemInstruction: custom.system_prompt
-    model: custom.model_id
+    output: [gen_ai.output.message, gen_ai.output.messages]
 ```
 
-**Example 2 — OpenInference spans:**
+The runner stringifies whatever it finds, so a JSON array under
+`gen_ai.output.messages` reaches the judge as the assistant turn(s).
+This is still OTel GenAI-compatible — `spanFields` just lets you handle
+emitter-specific variants explicitly.
+
+**Example 2 — non-OTel spans (OpenInference):**
 
 ```yaml
 scope:
@@ -416,22 +418,6 @@ OpenInference usually stores chat turns in `llm.input_messages` /
 `llm.output_messages` and plain-text payloads in `input.value` /
 `output.value`, so listing both keeps the mapping resilient across
 instrumentations.
-
-**Example 3 — OTel GenAI plural form** (some Bedrock / Vertex SDK
-emitters serialize the full message array under the plural attribute
-name `gen_ai.output.messages` instead of the singular `gen_ai.output.message`):
-
-```yaml
-scope:
-  service: pydantic-ai-music-agent
-  spanFields:
-    output: gen_ai.output.messages     # JSON-encoded array of {role, parts}
-```
-
-The runner stringifies whatever it finds, so a JSON array under
-`gen_ai.output.messages` reaches the judge as the assistant turn(s).
-This is convention-friendly: list every variant you've seen and the
-parser walks them in order.
 
 ### Per-metric input routing
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -402,7 +402,7 @@ The runner stringifies whatever it finds, so a JSON array under
 This is still OTel GenAI-compatible — `spanFields` just lets you handle
 emitter-specific variants explicitly.
 
-**Example 2 — non-OTel spans (OpenInference):**
+**Example 2 — OTel spans not following the GenAI SemConv (OpenInference):**
 
 ```yaml
 scope:

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -56,7 +56,7 @@ Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many j
 - **Flexible sampling** with random percentage, latest `N`, or `errors-only`
 - **PII masking before judge calls** for emails, phone numbers, credit cards, and SSNs
 - **Evaluated prompt/response excluded from bizevents by default** — opt in with `storeEvaluatedPrompt` (see [Configuration](#configuration))
-- **OpenAI, Anthropic, Azure OpenAI, Vertex AI, Gemini, and Bedrock support** with optional custom base URLs for gateways and proxies
+- **OpenAI, Anthropic, Azure OpenAI, Google Gemini Enterprise Platform (Vertex AI), and Bedrock support** with optional custom base URLs for gateways and proxies
 - **CI friendly runs** with JSON output and non-zero exit codes on threshold breaches
 - **Local run history** with list, inspect, and export flows
 - **Scheduled runs** stored locally and triggerable on demand
@@ -81,7 +81,7 @@ The current CLI path is Dynatrace specific. The product positioning is broader: 
 
 - Node.js `>=20`
 - A Dynatrace environment with GenAI spans or OpenTelemetry-style `gen_ai.*` fields
-- Credentials for your judge provider (OpenAI, Anthropic, Azure OpenAI, Vertex AI, Gemini, or Bedrock)
+- Credentials for your judge provider (OpenAI, Anthropic, Azure OpenAI, Google Gemini Enterprise Platform (Vertex AI), or Bedrock)
 
 ## Install
 
@@ -506,9 +506,9 @@ OPENAI_BASE_URL=https://your-gateway.example.com/v1
 ANTHROPIC_API_KEY=sk-ant-...
 ANTHROPIC_BASE_URL=https://your-proxy.example.com
 
+# Google Gemini Enterprise Platform (Vertex AI)
 GOOGLE_API_KEY=...
-
-# Vertex AI — authenticates via Workload Identity / Application Default Credentials (no API key).
+# Or authenticate via Workload Identity / Application Default Credentials instead of an API key.
 # Set the target project and region (or judge.project / judge.location in config):
 GOOGLE_CLOUD_PROJECT=my-gcp-project
 GOOGLE_CLOUD_LOCATION=global

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -24,7 +24,6 @@ The repository also includes `dt-eval-lib`, a reusable TypeScript evaluation eng
 npx @dynatrace-oss/dt-evals configure
 npx @dynatrace-oss/dt-evals validate
 npx @dynatrace-oss/dt-evals run --since 1h --sample 10 --concurrency 10
-npx @dynatrace-oss/dt-evals deploy --provider aws
 ```
 
 Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many judge calls run in parallel — bump it for faster runs, drop it if the provider rate-limits you. Default is 5.
@@ -40,7 +39,6 @@ Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many j
 - Go from low score to root cause with end-to-end AI observability
 - Correlate failures with prompts, retrieval, tool calls, latency, and dependencies
 - Reuse the same evaluator catalog in CI, app code, and local workflows with dt-eval-lib
-- Deploy the runner to AWS Lambda, Google Cloud Run, Azure Functions or Docker for continuous evals
 - Trigger alerts and optional remediation from the same evaluation pipeline
 
 ## Packages
@@ -53,12 +51,12 @@ Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many j
 
 ## What It Does
 
-- **13 built-in judge metrics** for safety, grounding, relevance, quality, and retrieval quality
+- **14 built-in judge metrics** for safety, grounding, relevance, quality, and retrieval quality
 - **Statistical drift detection** against a 7 day baseline of prior evaluation scores
 - **Flexible sampling** with random percentage, latest `N`, or `errors-only`
 - **PII masking before judge calls** for emails, phone numbers, credit cards, and SSNs
 - **Evaluated prompt/response excluded from bizevents by default** — opt in with `storeEvaluatedPrompt` (see [Configuration](#configuration))
-- **OpenAI and Anthropic support** with optional custom base URLs for gateways and proxies
+- **OpenAI, Anthropic, Azure OpenAI, Vertex AI, Gemini, and Bedrock support** with optional custom base URLs for gateways and proxies
 - **CI friendly runs** with JSON output and non-zero exit codes on threshold breaches
 - **Local run history** with list, inspect, and export flows
 - **Scheduled runs** stored locally and triggerable on demand
@@ -83,7 +81,7 @@ The current CLI path is Dynatrace specific. The product positioning is broader: 
 
 - Node.js `>=20`
 - A Dynatrace environment with GenAI spans or OpenTelemetry-style `gen_ai.*` fields
-- An OpenAI or Anthropic API key for the judge model
+- Credentials for your judge provider (OpenAI, Anthropic, Azure OpenAI, Vertex AI, Gemini, or Bedrock)
 
 ## Install
 
@@ -290,7 +288,7 @@ name: travel-assistant-prod
 
 dynatrace:
   environmentUrl: https://your-env.live.dynatrace.com
-  apiToken: dt0c01.xxxxx
+  # apiToken: use DT_API_TOKEN env var instead of hardcoding here
   dtctlContext: my-prod-context
 
 judge:
@@ -346,10 +344,10 @@ and `destination` (write):
 dynatrace:
   origin:
     environmentUrl: https://prod.live.dynatrace.com
-    apiToken: dt0s16.xxxxx          # needs storage:spans:read, storage:buckets:read
+    # apiToken: use DT_ORIGIN_API_TOKEN env var — needs storage:spans:read, storage:buckets:read
   destination:
     environmentUrl: https://eval-results.dev.apps.dynatracelabs.com
-    apiToken: dt0s16.yyyyy          # needs storage:bizevents:read for drift, plus storage:events:write and storage:metrics:write
+    # apiToken: use DT_DESTINATION_API_TOKEN env var — needs storage:bizevents:read (drift), storage:events:write, storage:metrics:write
 ```
 
 Top-level `environmentUrl` / `apiToken` (if present) act as fallbacks — if
@@ -395,11 +393,11 @@ scope:
   service: my-llm-service
   since: 30m
   spanFields:
-    input: llm.user_input              # or [llm.user_input, my.custom.input]
-    output: llm.response
+    input: span.input                  # or [span.input, my.custom.input]
+    output: span.output
     context: span.context              # can point to any span field the user wants as evaluator context, e.g. RAG context or system prompt
-    systemInstruction: llm.system
-    model: llm.model
+    systemInstruction: span.system
+    model: span.model
 ```
 
 **Example 2 — OTel GenAI plural form** (some Bedrock / Vertex SDK
@@ -440,11 +438,9 @@ metrics:
 
 Available canonical fields: `input`, `output`, `context`,
 `systemInstruction`, `model`, `userPrompt` (latest user-role prompt slot, extracted from
-`gen_ai.prompt.N.role == "user"`). When the requested field is empty on a
-given span, the slot falls back to `span.input` / `span.output` /
-`span.context` so a single misconfiguration doesn't drop spans. `context` has
-no built-in default span attribute; if a span does not provide it, evaluator
-context is omitted unless you explicitly route `inputs.context` elsewhere.
+`gen_ai.prompt.N.role == "user"`). `context` has no built-in default span
+attribute — if a span does not provide it, evaluator context is omitted unless
+you explicitly route `inputs.context` elsewhere.
 
 ### Full example
 
@@ -559,23 +555,24 @@ Drift results are written back as the same event type with `gen_ai.evaluation.ty
 
 ## Built-in Evaluators
 
-`dt-evals` ships with 13 built-in LLM judge evaluators, plus drift detection as a separate statistical metric.
+`dt-evals` ships with 14 built-in LLM judge evaluators, plus drift detection as a separate statistical metric.
 
-| Evaluator | Measures | Required fields |
-|-----------|----------|-----------------|
-| `toxicity` | Harmful, offensive, or unsafe output | `input`, `output` |
-| `faithfulness` | Whether the answer is grounded in provided context | `input`, `output`, `context` |
-| `hallucination` | Unsupported or fabricated claims | `input`, `output`, `context` |
-| `pii-leakage` | Personally identifiable information in the answer | `input`, `output` |
-| `relevance` | Whether the answer addresses the user request | `input`, `output` |
-| `factual-accuracy` | Accuracy against a reference answer | `input`, `output`, `expectedOutput` |
-| `user-frustration` | Whether the user was left frustrated at the end of the conversation | `input` |
-| `context-relevance` | Retrieval quality for supplied context | `input`, `context` |
+| Evaluator | Measures | Fields used |
+|-----------|----------|-------------|
 | `answer-completeness` | Whether all parts of the request were answered | `input`, `output` |
-| `prompt-injection` | Prompt injection attempts in the input | `input`, `output` |
 | `bias` | Harmful bias or unfair framing | `input`, `output` |
-| `summarization-quality` | Summary faithfulness, coverage, and conciseness | `input`, `output` |
 | `conciseness` | Whether the answer avoids filler and unnecessary padding | `input`, `output` |
+| `context-relevance` | Retrieval quality for supplied context | `input` |
+| `factual-accuracy` | Accuracy using world knowledge | `input`, `output` |
+| `faithfulness` | Whether the answer is grounded in provided context | `input`, `output` |
+| `fluency` | Grammar, clarity, and natural language quality | `input`, `output` |
+| `hallucination` | Unsupported or fabricated claims | `input`, `output` |
+| `pii-leakage` | Personally identifiable information in the answer | `input`, `output` |
+| `prompt-injection` | Prompt injection attempts in the input | `input` |
+| `relevance` | Whether the answer addresses the user request | `input`, `output` |
+| `summarization-quality` | Summary faithfulness, coverage, and conciseness | `input`, `output` |
+| `toxicity` | Harmful, offensive, or unsafe output | `output` |
+| `user-frustration` | Frustration signals in the user's message | `input` |
 
 ### Custom evaluators
 
@@ -627,104 +624,7 @@ Use it when you care about regressions that show up gradually, not just single-r
 
 ## TypeScript Library
 
-The repository includes `dt-eval-lib` for programmatic usage.
-
-### Basic example
-
-```ts
-import { evaluate, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
-
-const result = await evaluate(
-  BuiltInMetric.Faithfulness,
-  {
-    input: "Can I cancel my booking after check-in?",
-    output: "Yes, you can cancel any time and get a full refund.",
-    context: "Bookings can be canceled up to 24 hours before check-in. Refunds are not available after check-in.",
-  },
-  {
-    provider: {
-      provider: "openai",
-      apiKey: process.env.OPENAI_API_KEY,
-      model: "gpt-4.1",
-      timeout: 30000,
-      maxRetries: 2,
-    },
-  },
-);
-
-console.log(result.score);
-console.log(result.explanation.summary);
-console.log(result.explanation.reasoning);
-```
-
-### Inspect the evaluator catalog
-
-```ts
-import { listPrompts, getPrompt, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
-
-const prompts = listPrompts();
-const relevance = getPrompt(BuiltInMetric.Relevance);
-
-console.log(prompts.map((prompt) => prompt.id));
-console.log(relevance.requiredFields);
-```
-
-### Override thresholds in code
-
-```ts
-import { evaluate, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
-
-const result = await evaluate(
-  BuiltInMetric.Relevance,
-  {
-    input: "What are your support hours?",
-    output: "Our support team is available on weekdays.",
-  },
-  {
-    provider: {
-      provider: "anthropic",
-      apiKey: process.env.ANTHROPIC_API_KEY,
-    },
-    scoring: {
-      thresholdOverride: 0.8,
-    },
-  },
-);
-
-console.log(result.score.label);
-```
-
-### Use a custom gateway or proxy
-
-```ts
-import { evaluate, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
-
-await evaluate(
-  BuiltInMetric.Toxicity,
-  {
-    input: "Write a release note",
-    output: "The release fixes several issues.",
-  },
-  {
-    provider: {
-      provider: "openai",
-      apiKey: process.env.OPENAI_API_KEY,
-      baseUrl: process.env.OPENAI_BASE_URL,
-    },
-  },
-);
-```
-
-Library features:
-
-- OpenAI, Anthropic, Google Vertex AI, and Gemini providers
-- Structured judge responses with score, summary, and reasoning
-- Built-in prompt catalog via `BuiltInMetric`, `listPrompts()`, and `getPrompt()`
-- Custom evaluator support by passing your own `PromptDefinition`
-- Binary, continuous, and Likert scoring scales
-- Threshold overrides per evaluation call
-- Retry handling for transient provider failures
-- Composable API that can be embedded in external eval and observability workflows
+The repository also includes [`dt-eval-lib`](../dt-eval-lib/README.md) — a standalone TypeScript package for running the same judge-based metrics directly in code, tests, and CI pipelines without the CLI. It supports all six providers and the full built-in evaluator catalog.
 
 ## PII Handling
 
@@ -739,16 +639,16 @@ The original values are not sent to the judge by the CLI path.
 
 ## Data Expectations
 
-The CLI currently expects chat-style GenAI spans that include fields such as:
+The CLI reads OTel GenAI semconv fields by default:
 
-- `gen_ai.provider.name`
-- `gen_ai.request.model`
-- `gen_ai.prompt.<n>.content`
-- `gen_ai.prompt.<n>.role`
-- `gen_ai.completion.0.content`
-- `service.name` or `dt.entity.service` for service scoping
+| Canonical field | Default attributes read |
+|----------------|------------------------|
+| `input` | `gen_ai.input.messages` |
+| `output` | `gen_ai.output.message`, `gen_ai.output.messages` |
+| `model` | `gen_ai.request.model` |
+| `systemInstruction` | `gen_ai.system_instruction` |
 
-This makes it a good fit for apps instrumented with OpenTelemetry GenAI conventions or OpenLLMetry-style span attributes.
+OpenLLMetry-style attributes (`gen_ai.prompt.<n>.content/role`, `gen_ai.completion.0.content`) are probed as fallbacks. Use `scope.spanFields` to override any of these — see [Custom span field mapping](#custom-span-field-mapping).
 
 ## Local Development
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -375,9 +375,14 @@ For `dt-evals alerts apply` (Dynatrace Workflows), grant these additionally on t
 ### Custom span field mapping
 
 By default, the CLI reads OTel GenAI semconv (`gen_ai.input.messages`,
-`gen_ai.output.messages`, `gen_ai.output.message`, …) and OpenLLMetry conventions (`gen_ai.prompt.N.*`,
-`gen_ai.completion.0.content`). If your spans expose the LLM I/O under
-different attribute names, point the CLI at them via `scope.spanFields`.
+`gen_ai.output.messages`, `gen_ai.output.message`, …). It also probes a
+small set of legacy fallback attributes (`gen_ai.prompt.N.*`,
+`gen_ai.completion.0.content`) for compatibility with older emitters. If
+your spans expose the LLM I/O under different attribute names — for
+example OpenInference (`llm.input_messages`, `llm.output_messages`,
+`llm.model_name`) — point the CLI at them via `scope.spanFields`. See the
+[`dynatrace-ai-agent-instrumentation-examples`](https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples)
+for end-to-end instrumentation examples.
 Each entry accepts a single attribute or a list of candidates; the first
 non-null value wins, with the built-in defaults appended as fallback.
 
@@ -395,7 +400,24 @@ scope:
     model: custom.model_id
 ```
 
-**Example 2 — OTel GenAI plural form** (some Bedrock / Vertex SDK
+**Example 2 — OpenInference spans:**
+
+```yaml
+scope:
+  service: my-openinference-service
+  since: 30m
+  spanFields:
+    input: [llm.input_messages, input.value]
+    output: [llm.output_messages, output.value]
+    model: llm.model_name
+```
+
+OpenInference usually stores chat turns in `llm.input_messages` /
+`llm.output_messages` and plain-text payloads in `input.value` /
+`output.value`, so listing both keeps the mapping resilient across
+instrumentations.
+
+**Example 3 — OTel GenAI plural form** (some Bedrock / Vertex SDK
 emitters serialize the full message array under the plural attribute
 name `gen_ai.output.messages` instead of the singular `gen_ai.output.message`):
 
@@ -636,7 +658,16 @@ The CLI reads OTel GenAI semconv fields by default:
 | `model` | `gen_ai.request.model` |
 | `systemInstruction` | `gen_ai.system_instruction` |
 
-OpenLLMetry-style attributes (`gen_ai.prompt.<n>.content/role`, `gen_ai.completion.0.content`) are probed as fallbacks. Use `scope.spanFields` to override any of these — see [Custom span field mapping](#custom-span-field-mapping).
+This makes the CLI a good fit for apps instrumented with OpenTelemetry
+GenAI conventions. For other tracing schemas — including OpenInference —
+use `scope.spanFields` to map their attributes to the canonical fields
+above. OpenInference commonly uses attributes such as
+`llm.input_messages`, `llm.output_messages`, `input.value`,
+`output.value`, and `llm.model_name`. A small set of legacy fallback attributes
+(`gen_ai.prompt.<n>.content/role`, `gen_ai.completion.0.content`) is also
+probed for compatibility with older emitters. See
+[`dynatrace-ai-agent-instrumentation-examples`](https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples)
+for example instrumentations.
 
 ## Local Development
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -296,7 +296,7 @@ judge:
   model: gpt-4.1
   timeout: 30000
   maxRetries: 2
-  concurrency: 5         # parallel judge calls; --concurrency overrides this
+  concurrency: 5
 
 scope:
   service: travel-assistant
@@ -319,9 +319,6 @@ alerts:
     relevance: 0.7
     answer-completeness: 0.8
 
-# Off by default — the evaluated prompt/response are not written back to Dynatrace.
-# Set to true to include gen_ai.evaluation.input.question/.answer/.system_prompt
-# in the result bizevents. Overridable per-invocation with --store-evaluated-prompt.
 storeEvaluatedPrompt: false
 ```
 
@@ -344,10 +341,8 @@ and `destination` (write):
 dynatrace:
   origin:
     environmentUrl: https://prod.live.dynatrace.com
-    # apiToken: use DT_ORIGIN_API_TOKEN env var — needs storage:spans:read, storage:buckets:read
   destination:
     environmentUrl: https://eval-results.dev.apps.dynatracelabs.com
-    # apiToken: use DT_DESTINATION_API_TOKEN env var — needs storage:bizevents:read (drift), storage:events:write, storage:metrics:write
 ```
 
 Top-level `environmentUrl` / `apiToken` (if present) act as fallbacks — if
@@ -393,11 +388,11 @@ scope:
   service: my-llm-service
   since: 30m
   spanFields:
-    input: span.input                  # or [span.input, my.custom.input]
-    output: span.output
-    context: span.context              # can point to any span field the user wants as evaluator context, e.g. RAG context or system prompt
-    systemInstruction: span.system
-    model: span.model
+    input: custom.user_query           # or [custom.user_query, custom.prompt]
+    output: custom.llm_response
+    context: custom.rag_context        # any span field — e.g. RAG context, system prompt
+    systemInstruction: custom.system_prompt
+    model: custom.model_id
 ```
 
 **Example 2 — OTel GenAI plural form** (some Bedrock / Vertex SDK
@@ -427,13 +422,13 @@ turn in isolation, not the joined transcript:
 ```yaml
 metrics:
   enabled:
-    - faithfulness                                  # legacy string form
+    - faithfulness                                  # plain string form
     - id: user-frustration
       inputs:
-        input: userPrompt                           # latest user-role prompt slot
+        input: userPrompt
     - id: hallucination
       inputs:
-        context: context                            # use the canonical context field for this metric
+        context: context
 ```
 
 Available canonical fields: `input`, `output`, `context`,
@@ -466,23 +461,17 @@ scope:
   sampling:
     strategy: latest
     count: 50
-  # Map custom span attributes to canonical fields. Defaults handle OTel
-  # GenAI semconv + OpenLLMetry; override only what you need.
   spanFields:
-    context: span.context              # can point to any span field the user wants as evaluator context, e.g. RAG context or system prompt
+    context: span.context
     output: [gen_ai.output.message, gen_ai.output.messages]
     # input, systemInstruction, model use built-in defaults
 
 metrics:
   enabled:
-    # Plain string form — uses span.input / span.output / span.context
     - faithfulness
     - relevance
     - hallucination
     - answer-completeness
-    # Object form — overrides which canonical span field feeds the
-    # evaluator's `input` slot. user-frustration scores the user's turn
-    # alone instead of the full joined transcript.
     - id: user-frustration
       inputs:
         input: userPrompt
@@ -517,7 +506,6 @@ OPENAI_BASE_URL=https://your-gateway.example.com/v1
 ANTHROPIC_API_KEY=sk-ant-...
 ANTHROPIC_BASE_URL=https://your-proxy.example.com
 
-# Gemini Developer API
 GOOGLE_API_KEY=...
 
 # Vertex AI — authenticates via Workload Identity / Application Default Credentials (no API key).
@@ -656,10 +644,7 @@ OpenLLMetry-style attributes (`gen_ai.prompt.<n>.content/role`, `gen_ai.completi
 # from the repo root — install all workspace dependencies
 npm install
 
-# build the library
 npm run build --workspace=dt-eval-lib
-
-# build the CLI
 npm run build --workspace=dt-eval-cli
 ```
 

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -39,7 +39,7 @@ export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {
     since: '1h',
     sampling: {
       strategy: 'random',
-      percent: 100,
+      percent: 5,
     },
   },
   metrics: {

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -127,7 +127,7 @@ describe('config', () => {
 
       expect(config.scope.since).toBe('1h');
       expect(config.scope.sampling.strategy).toBe('random');
-      expect(config.scope.sampling.percent).toBe(100);
+      expect(config.scope.sampling.percent).toBe(5);
       expect(config.metrics.enabled).toEqual(['toxicity', 'relevance', 'faithfulness']);
       expect(config.judge.timeout).toBe(30000);
       expect(config.judge.maxRetries).toBe(2);

--- a/dt-eval-lib/README.md
+++ b/dt-eval-lib/README.md
@@ -111,50 +111,11 @@ Config is resolved in this order for each option:
 
 ### Vertex AI Setup
 
-Vertex AI supports two auth paths:
-
-**Application Default Credentials (ADC) — recommended for GKE / Cloud Run:**
-
-```ts
-await evaluate(BuiltInMetric.Toxicity, input, {
-  provider: {
-    provider: "vertex",
-    project: "my-gcp-project",  // or set GOOGLE_CLOUD_PROJECT
-    location: "us-central1",    // or set GOOGLE_CLOUD_LOCATION (default: "global")
-  },
-});
-```
-
-**Explicit API key (Vertex AI Express Mode):**
-
-```ts
-await evaluate(BuiltInMetric.Toxicity, input, {
-  provider: {
-    provider: "vertex",
-    apiKey: "AQ...",  // must be set in code — GOOGLE_API_KEY env var is intentionally ignored for vertex
-  },
-});
-```
-
-> **Note:** `GOOGLE_API_KEY` is not read for the `vertex` provider — it is only used by `gemini`. Pass `apiKey` explicitly in config if you need key-based auth for Vertex.
-
-### Gemini Developer API Setup
-
-1. Get an API key from [Google AI Studio](https://aistudio.google.com/apikey)
-2. Set `GOOGLE_API_KEY` or pass `apiKey` in config
-
-```ts
-await evaluate(BuiltInMetric.Toxicity, input, {
-  provider: {
-    provider: "gemini",
-    apiKey: "AIza...",
-  },
-});
-```
+Uses Application Default Credentials (ADC) by default — no API key needed when running on GKE or Cloud Run with Workload Identity. Pass `apiKey` explicitly in config for key-based auth (Vertex AI Express Mode).
 
 ### Azure OpenAI Setup
 
-`apiKey`, `baseUrl` (endpoint), `apiVersion`, and `model` (deployment name) are all required — Azure deployment names are user-defined so there is no default model.
+All four fields are required — `model` is your Azure deployment name, which is user-defined and has no default.
 
 ```ts
 await evaluate(BuiltInMetric.Toxicity, input, {
@@ -163,26 +124,14 @@ await evaluate(BuiltInMetric.Toxicity, input, {
     apiKey: "...",                                    // or AZURE_OPENAI_API_KEY
     baseUrl: "https://<resource>.openai.azure.com",  // or AZURE_OPENAI_ENDPOINT
     apiVersion: "2024-02-01",                         // or AZURE_OPENAI_API_VERSION
-    model: "my-gpt4-deployment",                      // deployment name — required, no default
+    model: "my-gpt4-deployment",                      // your deployment name
   },
 });
 ```
 
 ### Amazon Bedrock Setup
 
-Bedrock uses the AWS SDK credential chain. Static credentials are optional — IAM roles, SSO, and `AWS_PROFILE` are all resolved automatically.
-
-```ts
-await evaluate(BuiltInMetric.Toxicity, input, {
-  provider: {
-    provider: "bedrock",
-    model: "us.anthropic.claude-3-5-haiku-20241022-v1:0",  // optional — this is the default
-    region: "us-east-1",                                    // or AWS_DEFAULT_REGION / AWS_REGION
-    apiKey: "...",                                           // optional — AWS_ACCESS_KEY_ID
-    secretKey: "...",                                        // optional — AWS_SECRET_ACCESS_KEY
-  },
-});
-```
+Uses the AWS SDK credential chain — IAM roles, SSO, and `AWS_PROFILE` are all resolved automatically. Static credentials are only needed if you can't use role-based auth.
 
 > **Note:** `vertex` and `gemini` both use the `@google/genai` SDK; `azure-openai` and `openai` both use the `openai` SDK.
 

--- a/dt-eval-lib/README.md
+++ b/dt-eval-lib/README.md
@@ -82,7 +82,7 @@ All built-in metrics return a **continuous** score in `[0.0, 1.0]`. The score is
 
 ## Providers
 
-Supports **OpenAI**, **Anthropic**, **Azure OpenAI**, **Vertex AI**, **Gemini Developer API**, and **Amazon Bedrock**. Configure via explicit options in code or environment variables.
+Supports **OpenAI**, **Anthropic**, **Azure OpenAI**, **Google Gemini Enterprise Platform (Vertex AI)**, and **Amazon Bedrock**. Configure via explicit options in code or environment variables.
 
 ### Environment Variables
 
@@ -100,11 +100,11 @@ AZURE_OPENAI_API_KEY=...
 AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com
 AZURE_OPENAI_API_VERSION=2024-02-01
 
-# Vertex AI — ADC path (no API key needed)
+# Google Gemini Enterprise Platform (Vertex AI) — ADC path (no API key needed)
 GOOGLE_CLOUD_PROJECT=my-gcp-project
 GOOGLE_CLOUD_LOCATION=us-central1  # optional, defaults to "global"
 
-# Gemini Developer API
+# Google Gemini Enterprise Platform (Vertex AI) — API key path
 GOOGLE_API_KEY=AIza...
 
 # Amazon Bedrock — static credentials (optional if using IAM roles / SSO)
@@ -118,9 +118,9 @@ Config is resolved in this order for each option:
 1. Explicit value in `provider` options
 2. Environment variable
 
-### Vertex AI Setup
+### Google Gemini Enterprise Platform (Vertex AI) Setup
 
-Uses Application Default Credentials (ADC) by default — no API key needed when running on GKE or Cloud Run with Workload Identity. Pass `apiKey` explicitly in config for key-based auth (Vertex AI Express Mode).
+Use Application Default Credentials (ADC) with provider ID `vertex` when running on GKE or Cloud Run with Workload Identity, or pass `apiKey` with provider ID `gemini` for key-based auth.
 
 ### Azure OpenAI Setup
 
@@ -142,7 +142,7 @@ await evaluate(BuiltInMetric.Toxicity, input, {
 
 Uses the AWS SDK credential chain — IAM roles, SSO, and `AWS_PROFILE` are all resolved automatically. Static credentials are only needed if you can't use role-based auth.
 
-> **Note:** `vertex` and `gemini` both use the `@google/genai` SDK; `azure-openai` and `openai` both use the `openai` SDK.
+> **Note:** Google provider IDs `vertex` and `gemini` both use the `@google/genai` SDK; `azure-openai` and `openai` both use the `openai` SDK.
 
 ## Metric Identification
 

--- a/dt-eval-lib/README.md
+++ b/dt-eval-lib/README.md
@@ -73,51 +73,75 @@ All built-in metrics return a **continuous** score in `[0.0, 1.0]`. The score is
 
 ## Providers
 
-Supports **OpenAI**, **Anthropic**, **Vertex AI**, and **Gemini Developer API**. Configure via API key in code or environment variables.
+Supports **OpenAI**, **Anthropic**, **Azure OpenAI**, **Vertex AI**, **Gemini Developer API**, and **Amazon Bedrock**. Configure via explicit options in code or environment variables.
 
 ### Environment Variables
 
 ```bash
 # OpenAI
-export OPENAI_API_KEY="sk-..."
-export OPENAI_BASE_URL="https://your-proxy.example.com/v1"  # optional
+OPENAI_API_KEY=sk-...
+OPENAI_BASE_URL=https://your-proxy.example.com/v1  # optional
 
 # Anthropic
-export ANTHROPIC_API_KEY="sk-ant-..."
-export ANTHROPIC_BASE_URL="https://your-proxy.example.com"  # optional
-
-# Google AI (Vertex AI & Gemini) — API key
-export GOOGLE_API_KEY="AIza..."
-```
-
-Or use a `.env` file (not committed to git):
-
-```bash
-OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
-OPENAI_BASE_URL=https://your-proxy.example.com/v1
-ANTHROPIC_BASE_URL=https://your-proxy.example.com
+ANTHROPIC_BASE_URL=https://your-proxy.example.com  # optional
+
+# Azure OpenAI (all three required)
+AZURE_OPENAI_API_KEY=...
+AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com
+AZURE_OPENAI_API_VERSION=2024-02-01
+
+# Vertex AI — ADC path (no API key needed)
+GOOGLE_CLOUD_PROJECT=my-gcp-project
+GOOGLE_CLOUD_LOCATION=us-central1  # optional, defaults to "global"
+
+# Gemini Developer API
 GOOGLE_API_KEY=AIza...
+
+# Amazon Bedrock — static credentials (optional if using IAM roles / SSO)
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_DEFAULT_REGION=us-east-1  # optional, defaults to "us-east-1"
 ```
+
+Config is resolved in this order for each option:
+
+1. Explicit value in `provider` options
+2. Environment variable
 
 ### Vertex AI Setup
 
-1. Get an API key from [Google Cloud Console](https://console.cloud.google.com/apis/credentials) (Vertex AI Express Mode)
-2. Set `GOOGLE_API_KEY` env var (or pass `apiKey` in provider config)
+Vertex AI supports two auth paths:
+
+**Application Default Credentials (ADC) — recommended for GKE / Cloud Run:**
 
 ```ts
 await evaluate(BuiltInMetric.Toxicity, input, {
   provider: {
     provider: "vertex",
-    apiKey: "AQ...",
+    project: "my-gcp-project",  // or set GOOGLE_CLOUD_PROJECT
+    location: "us-central1",    // or set GOOGLE_CLOUD_LOCATION (default: "global")
   },
 });
 ```
 
+**Explicit API key (Vertex AI Express Mode):**
+
+```ts
+await evaluate(BuiltInMetric.Toxicity, input, {
+  provider: {
+    provider: "vertex",
+    apiKey: "AQ...",  // must be set in code — GOOGLE_API_KEY env var is intentionally ignored for vertex
+  },
+});
+```
+
+> **Note:** `GOOGLE_API_KEY` is not read for the `vertex` provider — it is only used by `gemini`. Pass `apiKey` explicitly in config if you need key-based auth for Vertex.
+
 ### Gemini Developer API Setup
 
 1. Get an API key from [Google AI Studio](https://aistudio.google.com/apikey)
-2. Set `GOOGLE_API_KEY` env var (or pass `apiKey` in provider config)
+2. Set `GOOGLE_API_KEY` or pass `apiKey` in config
 
 ```ts
 await evaluate(BuiltInMetric.Toxicity, input, {
@@ -128,28 +152,39 @@ await evaluate(BuiltInMetric.Toxicity, input, {
 });
 ```
 
-> **Note:** Both `vertex` and `gemini` use the `@google/genai` SDK and require Node.js ≥ 20.
+### Azure OpenAI Setup
 
-When calling `evaluate()`, the library resolves config in this order:
-
-1. Explicit value in `provider` options (e.g., `provider.apiKey`, `provider.baseUrl`)
-2. Environment variable (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, etc.)
+`apiKey`, `baseUrl` (endpoint), `apiVersion`, and `model` (deployment name) are all required — Azure deployment names are user-defined so there is no default model.
 
 ```ts
-// Option 1: explicit config
 await evaluate(BuiltInMetric.Toxicity, input, {
   provider: {
-    provider: "openai",
-    apiKey: "sk-...",
-    baseUrl: "https://your-proxy.example.com/v1",
+    provider: "azure-openai",
+    apiKey: "...",                                    // or AZURE_OPENAI_API_KEY
+    baseUrl: "https://<resource>.openai.azure.com",  // or AZURE_OPENAI_ENDPOINT
+    apiVersion: "2024-02-01",                         // or AZURE_OPENAI_API_VERSION
+    model: "my-gpt4-deployment",                      // deployment name — required, no default
   },
 });
+```
 
-// Option 2: env vars (no apiKey/baseUrl needed)
+### Amazon Bedrock Setup
+
+Bedrock uses the AWS SDK credential chain. Static credentials are optional — IAM roles, SSO, and `AWS_PROFILE` are all resolved automatically.
+
+```ts
 await evaluate(BuiltInMetric.Toxicity, input, {
-  provider: { provider: "openai" },
+  provider: {
+    provider: "bedrock",
+    model: "us.anthropic.claude-3-5-haiku-20241022-v1:0",  // optional — this is the default
+    region: "us-east-1",                                    // or AWS_DEFAULT_REGION / AWS_REGION
+    apiKey: "...",                                           // optional — AWS_ACCESS_KEY_ID
+    secretKey: "...",                                        // optional — AWS_SECRET_ACCESS_KEY
+  },
 });
 ```
+
+> **Note:** `vertex` and `gemini` both use the `@google/genai` SDK; `azure-openai` and `openai` both use the `openai` SDK.
 
 ## Metric Identification
 

--- a/dt-eval-lib/README.md
+++ b/dt-eval-lib/README.md
@@ -13,6 +13,15 @@ Minimal TypeScript library for running LLM-as-a-judge evaluations.
 npm install @dynatrace-oss/dt-eval-lib
 ```
 
+Then install the peer dependency for your provider:
+
+| Provider | Peer dependency |
+|----------|-----------------|
+| `openai`, `azure-openai` | `npm install openai` |
+| `anthropic` | `npm install @anthropic-ai/sdk` |
+| `vertex`, `gemini` | `npm install @google/genai` |
+| `bedrock` | `npm install @aws-sdk/client-bedrock-runtime` |
+
 ## Build
 
 ```bash

--- a/dt-eval-lib/README.md
+++ b/dt-eval-lib/README.md
@@ -50,23 +50,26 @@ console.log(result.explanation); // { summary: "...", reasoning: "..." }
 
 ## Available Metrics
 
-| Metric | Enum | Type | Required Fields |
-|--------|------|------|-----------------|
-| `toxicity` | `BuiltInMetric.Toxicity` | binary | input, output |
-| `faithfulness` | `BuiltInMetric.Faithfulness` | continuous | input, output, context |
-| `hallucination` | `BuiltInMetric.Hallucination` | binary | input, output, context |
-| `pii-leakage` | `BuiltInMetric.PiiLeakage` | binary | input, output |
-| `relevance` | `BuiltInMetric.Relevance` | continuous | input, output |
-| `factual-accuracy` | `BuiltInMetric.FactualAccuracy` | continuous | input, output, expectedOutput |
-| `user-frustration` | `BuiltInMetric.UserFrustration` | binary | input |
-| `context-relevance` | `BuiltInMetric.ContextRelevance` | continuous | input, context |
-| `answer-completeness` | `BuiltInMetric.AnswerCompleteness` | continuous | input, output |
-| `prompt-injection` | `BuiltInMetric.PromptInjection` | binary | input, output |
-| `bias` | `BuiltInMetric.Bias` | binary | input, output |
-| `summarization-quality` | `BuiltInMetric.SummarizationQuality` | continuous | input, output |
-| `conciseness` | `BuiltInMetric.Conciseness` | continuous | input, output |
+All built-in metrics return a **continuous** score in `[0.0, 1.0]`. The score is labeled `"pass"` when `value >= threshold` and `"fail"` otherwise. Every built-in metric defaults to `threshold: 0.5` — override it per-call via `EvalConfig.scoring.thresholdOverride`. Source of truth: [`src/prompts/catalog-data.ts`](src/prompts/catalog-data.ts).
 
-> **Note:** The "Required Fields" column lists the `EvalInput` property names you pass to `evaluate()`.
+| Metric | Enum | Score range | Fields used from `EvalInput` |
+|--------|------|-------------|-------------------------------|
+| `answer-completeness` | `BuiltInMetric.AnswerCompleteness` | 0.0 – 1.0 | `input`, `output` |
+| `bias` | `BuiltInMetric.Bias` | 0.0 – 1.0 | `input`, `output` |
+| `conciseness` | `BuiltInMetric.Conciseness` | 0.0 – 1.0 | `input`, `output` |
+| `context-relevance` | `BuiltInMetric.ContextRelevance` | 0.0 – 1.0 | `input` |
+| `factual-accuracy` | `BuiltInMetric.FactualAccuracy` | 0.0 – 1.0 | `input`, `output` |
+| `faithfulness` | `BuiltInMetric.Faithfulness` | 0.0 – 1.0 | `input`, `output` |
+| `fluency` | `BuiltInMetric.Fluency` | 0.0 – 1.0 | `input`, `output` |
+| `hallucination` | `BuiltInMetric.Hallucination` | 0.0 – 1.0 | `input`, `output` |
+| `pii-leakage` | `BuiltInMetric.PiiLeakage` | 0.0 – 1.0 | `input`, `output` |
+| `prompt-injection` | `BuiltInMetric.PromptInjection` | 0.0 – 1.0 | `input` |
+| `relevance` | `BuiltInMetric.Relevance` | 0.0 – 1.0 | `input`, `output` |
+| `summarization-quality` | `BuiltInMetric.SummarizationQuality` | 0.0 – 1.0 | `input`, `output` |
+| `toxicity` | `BuiltInMetric.Toxicity` | 0.0 – 1.0 | `output` |
+| `user-frustration` | `BuiltInMetric.UserFrustration` | 0.0 – 1.0 | `input` |
+
+> **Note:** The "Fields used" column lists which fields the metric prompt actually reads. `EvalInput.output` is required at the TypeScript type level for all calls — pass `output: ""` for metrics that only use `input`.
 
 ## Providers
 
@@ -164,7 +167,7 @@ Use `listPrompts()` and `getPrompt()` to discover available metrics:
 ```ts
 import { listPrompts, getPrompt, BuiltInMetric } from "@dynatrace-oss/dt-eval-lib";
 
-const all = listPrompts();                        // all 13 built-in metrics
+const all = listPrompts();                        // all 14 built-in metrics
 const tox = getPrompt(BuiltInMetric.Toxicity);    // single metric by ID
 ```
 

--- a/dt-eval-lib/README.md
+++ b/dt-eval-lib/README.md
@@ -158,28 +158,28 @@ const tox = getPrompt(BuiltInMetric.Toxicity);    // single metric by ID
 ## Configuration
 
 ```ts
-import type { EvalConfig } from "@dynatrace-oss/dt-eval-lib";
+import type { EvalConfig, EvalInput } from "@dynatrace-oss/dt-eval-lib";
 
+// What you pass to evaluate()
+const input: EvalInput = {
+  input: "What is the capital of France?",    // required — the user query
+  output: "The capital of France is Paris.",  // required — the LLM response to evaluate
+  context: "...",                              // optional — retrieved documents (RAG)
+  expectedOutput: "...",                       // optional — reference answer
+};
+
+// How to run the evaluation
 const config: EvalConfig = {
   provider: {
-    provider: "openai",          // "openai" | "anthropic" | "vertex" | "gemini"
-    apiKey: "sk-...",            // optional if env var is set
-    baseUrl: "https://...",      // optional (openai/anthropic only)
-    model: "gpt-4.1",           // optional — defaults to gpt-4.1 / claude-sonnet-4-6 / gemini-2.5-pro (vertex) / gemini-2.5-flash (gemini)
-    timeout: 30000,              // optional — request timeout in ms (default 30000)
-    maxRetries: 2,               // optional — retries on transient errors (default 2)
+    provider: "openai",  // "openai" | "anthropic" | "azure-openai" | "vertex" | "gemini" | "bedrock"
+    apiKey: "sk-...",    // optional if env var is set
+    baseUrl: "https://", // optional — openai and anthropic only
+    model: "...",        // optional — see src/engine/providers/index.ts for per-provider defaults
+    timeout: 30000,      // optional — request timeout in ms (default: 30000)
+    maxRetries: 2,       // optional — retries on transient errors (default: 2)
   },
   scoring: {
-    thresholdOverride: 0.8,      // optional — override the metric's default threshold
+    thresholdOverride: 0.8, // optional — override the metric's pass threshold (default: 0.5)
   },
 };
-```
-
-## Threshold Override
-
-```ts
-const result = await evaluate(BuiltInMetric.Relevance, input, {
-  provider: { provider: "openai", apiKey: "sk-..." },
-  scoring: { thresholdOverride: 0.8 }, // stricter than default 0.5
-});
 ```

--- a/dt-eval-lib/src/engine/types.ts
+++ b/dt-eval-lib/src/engine/types.ts
@@ -21,7 +21,7 @@ export interface ProviderOptions {
   project?: string;
   /** GCP region for Vertex AI (e.g. "global" or "us-central1"). Falls back to GOOGLE_CLOUD_LOCATION env var. Default: global. */
   location?: string;
-  /** Model override — defaults to gpt-4.1 / claude-sonnet-4-6 / gemini-2.5-pro (vertex) / gemini-2.5-flash (gemini) */
+  /** Model override — see DEFAULT_MODELS in src/engine/providers/index.ts for per-provider defaults */
   model?: string;
   /** Request timeout in ms — default 30000 */
   timeout?: number;


### PR DESCRIPTION
## Summary

Systematic audit and fix of dt-eval-lib, dt-eval-cli, and root README against source code as ground truth. Every change is backed by a code reference.

### dt-eval-lib
- Rebuild metrics table from \`catalog-data.ts\`: add missing \`fluency\` (14th metric), fix all scoring types (\`binary\` → \`continuous [0.0–1.0]\`), fix required fields for 6 metrics, fix count 13→14
- Clarify threshold semantics: pass when \`value >= 0.5\` (default), not binary extremes
- Add \`azure-openai\` and \`bedrock\` providers with correct env vars and setup docs
- Fix Vertex AI setup: document ADC-by-default, remove wrong \`GOOGLE_API_KEY\` instruction
- Document \`EvalInput\` type in Configuration section, fix provider list, remove stale model defaults
- Add peer dependency install table

### dt-eval-cli
- Remove fictional \`dt-evals deploy\` CLI command
- Fix metric count 13→14, fix provider claim to list all 6 providers
- Remove credentials from YAML examples
- Rebuild Built-in Evaluators table from \`catalog-data.ts\`
- Replace TypeScript Library section (~100 lines) with 2 sentences + link
- Fix Data Expectations to match actual \`dql.ts\` defaults
- Fix \`defaults.ts\`: default sampling percent \`100\` → \`5\`
- Cut redundant inline comments

### Root README
- Remove fictional \`dt-evals deploy\` section
- Fix all default models from \`defaults.ts\`, fix evaluator count, add missing \`--store-evaluated-prompt\` flag
- Remove credentials from YAML examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)