### PR TITLE
fix(dt-eval-cli): remove batch head-of-line blocking in eval runner

### DIFF
--- a/dt-eval-cli/src/runner/batch.ts
+++ b/dt-eval-cli/src/runner/batch.ts
@@ -17,7 +17,7 @@ export async function processBatch<T, R>(
   handler: (item: T) => Promise<R>,
   config?: Partial<BatchConfig>,
 ): Promise<Array<BatchItemResult<T, R>>> {
-  const { concurrency } = { ...DEFAULT_BATCH_CONFIG, ...config };
+  const concurrency = config?.concurrency ?? DEFAULT_BATCH_CONFIG.concurrency;
   if (!Number.isInteger(concurrency) || concurrency <= 0) {
     throw new Error(`concurrency must be a positive integer, got ${concurrency}`);
   }

--- a/dt-eval-cli/src/runner/batch.ts
+++ b/dt-eval-cli/src/runner/batch.ts
@@ -1,6 +1,5 @@
 export interface BatchConfig {
   concurrency: number; // default 5
-  batchSize: number;   // default 10
 }
 
 export interface BatchItemResult<T, R> {
@@ -11,7 +10,6 @@ export interface BatchItemResult<T, R> {
 
 const DEFAULT_BATCH_CONFIG: BatchConfig = {
   concurrency: 5,
-  batchSize: 10,
 };
 
 export async function processBatch<T, R>(

--- a/dt-eval-cli/src/runner/batch.ts
+++ b/dt-eval-cli/src/runner/batch.ts
@@ -20,32 +20,29 @@ export async function processBatch<T, R>(
   config?: Partial<BatchConfig>,
 ): Promise<Array<BatchItemResult<T, R>>> {
   const { concurrency } = { ...DEFAULT_BATCH_CONFIG, ...config };
-  const results: Array<BatchItemResult<T, R>> = [];
+  if (!Number.isInteger(concurrency) || concurrency <= 0) {
+    throw new Error(`concurrency must be a positive integer, got ${concurrency}`);
+  }
 
-  // Process with concurrency limit using a semaphore-like approach
-  const queue = [...items];
-  const inFlight: Promise<void>[] = [];
+  const results = new Array<BatchItemResult<T, R>>(items.length);
+  let nextIndex = 0;
 
-  async function processItem(item: T): Promise<void> {
-    try {
-      const result = await handler(item);
-      results.push({ item, result });
-    } catch (err) {
-      results.push({
-        item,
-        error: err instanceof Error ? err : new Error(String(err)),
-      });
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      const item = items[index]!;
+      try {
+        results[index] = { item, result: await handler(item) };
+      } catch (err) {
+        results[index] = {
+          item,
+          error: err instanceof Error ? err : new Error(String(err)),
+        };
+      }
     }
   }
 
-  // Chunk into groups and run concurrently within each group
-  for (let i = 0; i < items.length; i += concurrency) {
-    const batch = items.slice(i, i + concurrency);
-    const batchPromises = batch.map(item => processItem(item));
-    await Promise.all(batchPromises);
-  }
-
-  // Maintain original order
-  void inFlight;
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
   return results;
 }

--- a/dt-eval-cli/tests/runner/batch.test.ts
+++ b/dt-eval-cli/tests/runner/batch.test.ts
@@ -79,6 +79,30 @@ describe('processBatch', () => {
     expect(maxConcurrent).toBeLessThanOrEqual(3);
   });
 
+  it('starts new work as soon as a worker becomes available', async () => {
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    const started: number[] = [];
+
+    const run = processBatch(
+      [1, 2, 3],
+      async n => {
+        started.push(n);
+        if (n === 1) await firstBlocked;
+        return n;
+      },
+      { concurrency: 2 },
+    );
+
+    await vi.waitFor(() => expect(started).toEqual([1, 2, 3]));
+    releaseFirst();
+
+    const results = await run;
+    expect(results.map(r => r.result)).toEqual([1, 2, 3]);
+  });
+
   it('handles non-Error thrown values by wrapping them in Error', async () => {
     const items = [1];
     const handler = async (_n: number) => {
@@ -106,5 +130,10 @@ describe('processBatch', () => {
 
     await processBatch(items, handler);
     expect(maxConcurrent).toBeLessThanOrEqual(5);
+  });
+
+  it('rejects invalid concurrency', async () => {
+    await expect(processBatch([1], async n => n, { concurrency: 0 }))
+      .rejects.toThrow('concurrency must be a positive integer');
   });
 });

--- a/dt-eval-cli/tests/runner/batch.test.ts
+++ b/dt-eval-cli/tests/runner/batch.test.ts
@@ -132,8 +132,11 @@ describe('processBatch', () => {
     expect(maxConcurrent).toBeLessThanOrEqual(5);
   });
 
-  it('rejects invalid concurrency', async () => {
-    await expect(processBatch([1], async n => n, { concurrency: 0 }))
-      .rejects.toThrow('concurrency must be a positive integer');
-  });
+  it.each([0, -1, 2.5, NaN])(
+    "rejects invalid concurrency: %s",
+    async invalid => {
+      await expect(processBatch([1], async n => n, { concurrency: invalid }))
+        .rejects.toThrow("concurrency must be a positive integer");
+    },
+  );
 });


### PR DESCRIPTION
Closes #152

## Summary

This PR only changes the eval runner batching logic and its tests.

## Code changes

- `dt-eval-cli/src/runner/batch.ts`
  - replace fixed-group batching with a work-conserving worker pool
  - preserve result ordering while starting new work as soon as a worker becomes free
  - reject invalid `concurrency` values
- `dt-eval-cli/tests/runner/batch.test.ts`
  - add coverage for work-conserving dispatch
  - add coverage for invalid concurrency

## Why this helps

The previous implementation waited for a whole batch group to finish before starting the next one. That created idle worker slots whenever one item in the group was slower than the others. The new worker-pool implementation keeps available slots busy until the queue is drained, which improves throughput without changing eval behavior.

## Validation

- targeted runner tests
- CLI build

