### PR TITLE
fix: persist complete custom evaluator scoring

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -577,6 +577,48 @@ Drift results are written back as the same event type with `gen_ai.evaluation.ty
 | `summarization-quality` | Summary faithfulness, coverage, and conciseness | `input`, `output` |
 | `conciseness` | Whether the answer avoids filler and unnecessary padding | `input`, `output` |
 
+### Custom evaluators
+
+You can create a custom judge metric with `dt-evals evaluators add`, then
+enable it in `metrics.enabled` like any built-in evaluator.
+
+**Example custom evaluator definition** (created by the interactive wizard
+and stored locally):
+
+```json
+{
+  "id": "answer-style",
+  "version": "1",
+  "name": "Answer Style",
+  "description": "Checks whether the answer is concise, direct, and well structured.",
+  "prompt": "Evaluate the answer style for this request. User request: {{input}} Answer: {{output}} Return a continuous score from 0.0 to 1.0.",
+  "requiredFields": ["input", "output"],
+  "scoring": {
+    "type": "continuous",
+    "range": [0, 1],
+    "threshold": 0.7
+  }
+}
+```
+
+Enable it in your eval config:
+
+```yaml
+metrics:
+  enabled:
+    - faithfulness
+    - answer-style
+```
+
+Useful commands:
+
+```bash
+dt-evals evaluators add
+dt-evals evaluators list
+dt-evals evaluators show answer-style
+dt-evals evaluators test answer-style
+```
+
 ### Drift detection
 
 `drift` compares current score distributions against a 7 day baseline of prior evaluation events.

--- a/dt-eval-cli/src/cli/commands/custom-scoring.ts
+++ b/dt-eval-cli/src/cli/commands/custom-scoring.ts
@@ -1,0 +1,23 @@
+import {
+  BINARY_SCALE,
+  CONTINUOUS_SCALE,
+  LIKERT_SCALE,
+} from '@dynatrace-oss/dt-eval-lib';
+import type { ScoringScale, ScoringScaleType } from '@dynatrace-oss/dt-eval-lib';
+
+export function buildCustomScoring(
+  type: ScoringScaleType,
+  threshold: number,
+): ScoringScale {
+  const base =
+    type === 'binary'
+      ? BINARY_SCALE
+      : type === 'likert'
+        ? LIKERT_SCALE
+        : CONTINUOUS_SCALE;
+
+  return {
+    ...base,
+    threshold,
+  };
+}

--- a/dt-eval-cli/src/cli/commands/evaluators.ts
+++ b/dt-eval-cli/src/cli/commands/evaluators.ts
@@ -5,6 +5,7 @@ import { loadConfig } from '../../config/index.js';
 import { renderTable } from '../../ui/table.js';
 import { Spinner } from '../../ui/spinner.js';
 import { logger } from '../../logger/index.js';
+import { buildCustomScoring } from './custom-scoring.js';
 
 export function createEvaluatorsCommand(): Command {
   const cmd = new Command('evaluators');
@@ -112,10 +113,10 @@ export function createEvaluatorsCommand(): Command {
         description: description || name,
         prompt: template,
         requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expectedOutput')[],
-        scoring: {
-          type: scoringType as 'continuous' | 'binary' | 'likert',
+        scoring: buildCustomScoring(
+          scoringType as 'continuous' | 'binary' | 'likert',
           threshold,
-        } as Parameters<typeof createCustomPrompt>[0]['scoring'],
+        ),
       });
       logger.success(`Custom evaluator "${id}" created`);
     } catch (err) {

--- a/dt-eval-cli/src/cli/commands/prompts.ts
+++ b/dt-eval-cli/src/cli/commands/prompts.ts
@@ -5,6 +5,7 @@ import { loadConfig } from '../../config/index.js';
 import { renderTable } from '../../ui/table.js';
 import { Spinner } from '../../ui/spinner.js';
 import { logger } from '../../logger/index.js';
+import { buildCustomScoring } from './custom-scoring.js';
 
 export function createPromptsCommand(): Command {
   const cmd = new Command('prompts');
@@ -112,10 +113,10 @@ export function createPromptsCommand(): Command {
         description: description || name,
         prompt: template,
         requiredFields: requiredFields as ('input' | 'output' | 'context' | 'expectedOutput')[],
-        scoring: {
-          type: scoringType as 'continuous' | 'binary' | 'likert',
+        scoring: buildCustomScoring(
+          scoringType as 'continuous' | 'binary' | 'likert',
           threshold,
-        } as Parameters<typeof createCustomPrompt>[0]['scoring'],
+        ),
       });
       logger.success(`Custom prompt "${id}" created`);
     } catch (err) {

--- a/dt-eval-cli/tests/cli/custom-scoring.test.ts
+++ b/dt-eval-cli/tests/cli/custom-scoring.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildCustomScoring } from '../../src/cli/commands/custom-scoring.js';
+
+describe('buildCustomScoring', () => {
+  it('builds a continuous scale with the default range', () => {
+    expect(buildCustomScoring('continuous', 0.7)).toEqual({
+      type: 'continuous',
+      range: [0, 1],
+      threshold: 0.7,
+    });
+  });
+
+  it('builds a binary scale with the default range', () => {
+    expect(buildCustomScoring('binary', 1)).toEqual({
+      type: 'binary',
+      range: [0, 1],
+      threshold: 1,
+    });
+  });
+
+  it('builds a likert scale with labels intact', () => {
+    expect(buildCustomScoring('likert', 4)).toEqual({
+      type: 'likert',
+      range: [1, 5],
+      threshold: 4,
+      labels: {
+        1: 'Very Poor',
+        2: 'Poor',
+        3: 'Average',
+        4: 'Good',
+        5: 'Excellent',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- persist full scoring scales for custom evaluators and prompts created from the CLI
- add a focused test for custom scoring defaults
- document a custom evaluator example in the CLI README

## Why
The interactive custom evaluator flow stored only `scoring.type` and `scoring.threshold`. Evaluation later expects a complete scoring scale, including `range`, so custom evaluators could be created but fail at runtime.

## Validation
- `cd dt-eval-cli && npm test -- --run tests/cli/custom-scoring.test.ts`