### PR TITLE
fix: show evaluator result ratios

### DIFF
--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -73,12 +73,11 @@ export function buildEvaluationResultRows(metrics: string[], result: RunResult):
     const metricResult = byMetric.get(m);
     const total = metricResult?.total ?? 0;
     const successes = metricResult?.successes ?? 0;
-    const errors = metricResult?.errors ?? 0;
+    const passPercentage = total === 0 ? 0 : Math.round((successes / total) * 100);
 
     return [
       m,
-      `${successes}/${total}`,
-      `${errors}/${total}`,
+      `${successes}/${total} (${passPercentage}% passed)`,
       formatDuration(metricResult?.avgDurationMs ?? 0),
     ];
   });
@@ -181,7 +180,7 @@ export function createRunCommand(): Command {
         const metrics = options.metric ? [options.metric] : config.metrics.enabled.map(metricId);
 
         console.log('\nEvaluation results:');
-        const headers = ['Evaluator', 'Results', 'Errors', 'Avg Duration'];
+        const headers = ['Evaluator', 'Results', 'Avg Duration'];
         const rows = buildEvaluationResultRows(metrics, result);
         console.log(renderTable(headers, rows));
 

--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import { loadConfig, validateConfig } from '../../config/index.js';
 import { resolveEndpoints, metricId } from '../../config/schema.js';
 import { DynatraceClient } from '../../dt/client.js';
-import { runEvals, type RunProgressEvent } from '../../runner/index.js';
+import { runEvals, type RunProgressEvent, type RunResult } from '../../runner/index.js';
 import { Spinner } from '../../ui/spinner.js';
 import { renderTable } from '../../ui/table.js';
 import { formatDuration } from '../../ui/format.js';
@@ -65,6 +65,23 @@ function evalErrorHint(messages: string[]): string | null {
   if (/context.*length|maximum.*token|too.*long/.test(combined))
     return 'Hint: input too long for the model. Try a model with a larger context window.';
   return null;
+}
+
+export function buildEvaluationResultRows(metrics: string[], result: RunResult): string[][] {
+  const byMetric = new Map(result.evaluatorResults.map(r => [r.metric, r]));
+  return metrics.map(m => {
+    const metricResult = byMetric.get(m);
+    const total = metricResult?.total ?? 0;
+    const successes = metricResult?.successes ?? 0;
+    const errors = metricResult?.errors ?? 0;
+
+    return [
+      m,
+      `${successes}/${total}`,
+      `${errors}/${total}`,
+      formatDuration(metricResult?.avgDurationMs ?? 0),
+    ];
+  });
 }
 
 export function createRunCommand(): Command {
@@ -164,13 +181,8 @@ export function createRunCommand(): Command {
         const metrics = options.metric ? [options.metric] : config.metrics.enabled.map(metricId);
 
         console.log('\nEvaluation results:');
-        const headers = ['Evaluator', 'Results', 'Errors', 'Duration'];
-        const rows = metrics.map(m => [
-          m,
-          String(Math.floor(result.resultsWritten / metrics.length)),
-          String(result.errors > 0 ? Math.ceil(result.errors / metrics.length) : 0),
-          formatDuration(result.durationMs),
-        ]);
+        const headers = ['Evaluator', 'Results', 'Errors', 'Avg Duration'];
+        const rows = buildEvaluationResultRows(metrics, result);
         console.log(renderTable(headers, rows));
 
         console.log(`\nRun ${result.runId} complete in ${formatDuration(result.durationMs)}`);

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -118,6 +118,18 @@ interface EvaluatorRunStats {
   durationMs: number;
 }
 
+function recordEvaluatorOutcome(stats: EvaluatorRunStats | undefined, succeeded: boolean, durationMs: number): void {
+  if (!stats) return;
+
+  stats.total++;
+  stats.durationMs += durationMs;
+  if (succeeded) {
+    stats.successes++;
+  } else {
+    stats.errors++;
+  }
+}
+
 export type { EvalResult };
 
 export interface DtClients {
@@ -260,12 +272,7 @@ export async function runEvals(
         evalCount++;
         const elapsed = Date.now() - t0;
         logger.debug(`eval [${evalCount}/${tasks.length}] ${task.metric} ${judgeProvider}/${judgeModel} trace=${task.span.traceId.slice(0, 8)}… ${elapsed}ms score=${evalResult.score.value}`);
-        const stats = evaluatorStats.get(task.metric);
-        if (stats) {
-          stats.total++;
-          stats.successes++;
-          stats.durationMs += elapsed;
-        }
+        recordEvaluatorOutcome(evaluatorStats.get(task.metric), true, elapsed);
         emit?.({
           phase: 'eval-completed',
           completed: evalCount,
@@ -279,12 +286,7 @@ export async function runEvals(
         evalCount++;
         evalErrors++;
         const elapsed = Date.now() - t0;
-        const stats = evaluatorStats.get(task.metric);
-        if (stats) {
-          stats.total++;
-          stats.errors++;
-          stats.durationMs += elapsed;
-        }
+        recordEvaluatorOutcome(evaluatorStats.get(task.metric), false, elapsed);
         emit?.({
           phase: 'eval-completed',
           completed: evalCount,

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -56,6 +56,15 @@ export interface RunResult {
   errorSamples: string[];   // deduplicated sample of error messages for user display
   thresholdBreaches: Array<{ metric: string; traceId: string; score: number }>;
   durationMs: number;
+  evaluatorResults: EvaluatorRunResult[];
+}
+
+export interface EvaluatorRunResult {
+  metric: string;
+  successes: number;
+  total: number;
+  errors: number;
+  avgDurationMs: number;
 }
 
 interface EvalTask {
@@ -99,6 +108,14 @@ interface EvalTaskResult {
   evalResult: EvalResult;
   /** The exact input the judge was given — may be a routed subset of span fields. */
   evalInput: EvalInput;
+}
+
+interface EvaluatorRunStats {
+  metric: string;
+  successes: number;
+  total: number;
+  errors: number;
+  durationMs: number;
 }
 
 export type { EvalResult };
@@ -174,6 +191,11 @@ export async function runEvals(
   const tasks: EvalTask[] = maskedSpans.flatMap(span =>
     evalEntries.map(entry => ({ span, metric: metricId(entry), inputs: metricInputs(entry) })),
   );
+  const evaluatorStats = new Map<string, EvaluatorRunStats>();
+  for (const entry of evalEntries) {
+    const id = metricId(entry);
+    evaluatorStats.set(id, { metric: id, successes: 0, total: 0, errors: 0, durationMs: 0 });
+  }
 
   if (opts.dryRun) {
     console.log(JSON.stringify({ runId, tasks: tasks.length, spans: maskedSpans.length, metrics: metricIds }, null, 2));
@@ -185,6 +207,13 @@ export async function runEvals(
       errorSamples: [],
       thresholdBreaches: [],
       durationMs: Date.now() - startTime,
+      evaluatorResults: [...evaluatorStats.values()].map(s => ({
+        metric: s.metric,
+        successes: s.successes,
+        total: s.total,
+        errors: s.errors,
+        avgDurationMs: 0,
+      })),
     };
   }
 
@@ -231,6 +260,12 @@ export async function runEvals(
         evalCount++;
         const elapsed = Date.now() - t0;
         logger.debug(`eval [${evalCount}/${tasks.length}] ${task.metric} ${judgeProvider}/${judgeModel} trace=${task.span.traceId.slice(0, 8)}… ${elapsed}ms score=${evalResult.score.value}`);
+        const stats = evaluatorStats.get(task.metric);
+        if (stats) {
+          stats.total++;
+          stats.successes++;
+          stats.durationMs += elapsed;
+        }
         emit?.({
           phase: 'eval-completed',
           completed: evalCount,
@@ -244,6 +279,12 @@ export async function runEvals(
         evalCount++;
         evalErrors++;
         const elapsed = Date.now() - t0;
+        const stats = evaluatorStats.get(task.metric);
+        if (stats) {
+          stats.total++;
+          stats.errors++;
+          stats.durationMs += elapsed;
+        }
         emit?.({
           phase: 'eval-completed',
           completed: evalCount,
@@ -285,6 +326,13 @@ export async function runEvals(
     .sort((a, b) => b[1] - a[1])
     .slice(0, 3)
     .map(([msg, count]) => count > 1 ? `${msg} (×${count})` : msg);
+  const evaluatorResults: EvaluatorRunResult[] = [...evaluatorStats.values()].map(s => ({
+    metric: s.metric,
+    successes: s.successes,
+    total: s.total,
+    errors: s.errors,
+    avgDurationMs: s.total > 0 ? Math.round(s.durationMs / s.total) : 0,
+  }));
 
   // 8. Write bizevents
   if (!emit) logger.step('Writing bizevents...');
@@ -347,6 +395,7 @@ export async function runEvals(
     errorSamples,
     thresholdBreaches,
     durationMs: Date.now() - startTime,
+    evaluatorResults,
   };
 
   if (!emit) logger.success(`Run complete: ${payloads.length} results written`);

--- a/dt-eval-cli/tests/cli/commands/run.test.ts
+++ b/dt-eval-cli/tests/cli/commands/run.test.ts
@@ -3,7 +3,7 @@ import { buildEvaluationResultRows } from '../../../src/cli/commands/run.js';
 import type { RunResult } from '../../../src/runner/index.js';
 
 describe('buildEvaluationResultRows', () => {
-  it('renders per-evaluator ratios instead of redistributed aggregate counts', () => {
+  it('renders per-evaluator success ratios with a pass percentage', () => {
     const result: RunResult = {
       runId: 'run-test',
       spansEvaluated: 1,
@@ -18,9 +18,10 @@ describe('buildEvaluationResultRows', () => {
       ],
     };
 
-    expect(buildEvaluationResultRows(['toxicity', 'relevance'], result)).toEqual([
-      ['toxicity', '1/1', '0/1', '100ms'],
-      ['relevance', '0/1', '1/1', '200ms'],
+    expect(buildEvaluationResultRows(['toxicity', 'relevance', 'completeness'], result)).toEqual([
+      ['toxicity', '1/1 (100% passed)', '100ms'],
+      ['relevance', '0/1 (0% passed)', '200ms'],
+      ['completeness', '0/0 (0% passed)', '0ms'],
     ]);
   });
 });

--- a/dt-eval-cli/tests/cli/commands/run.test.ts
+++ b/dt-eval-cli/tests/cli/commands/run.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildEvaluationResultRows } from '../../../src/cli/commands/run.js';
+import type { RunResult } from '../../../src/runner/index.js';
+
+describe('buildEvaluationResultRows', () => {
+  it('renders per-evaluator ratios instead of redistributed aggregate counts', () => {
+    const result: RunResult = {
+      runId: 'run-test',
+      spansEvaluated: 1,
+      resultsWritten: 1,
+      errors: 1,
+      errorSamples: ['relevance failed'],
+      thresholdBreaches: [],
+      durationMs: 1000,
+      evaluatorResults: [
+        { metric: 'toxicity', successes: 1, total: 1, errors: 0, avgDurationMs: 100 },
+        { metric: 'relevance', successes: 0, total: 1, errors: 1, avgDurationMs: 200 },
+      ],
+    };
+
+    expect(buildEvaluationResultRows(['toxicity', 'relevance'], result)).toEqual([
+      ['toxicity', '1/1', '0/1', '100ms'],
+      ['relevance', '0/1', '1/1', '200ms'],
+    ]);
+  });
+});

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -270,6 +270,35 @@ describe('runEvals', () => {
     expect(result.resultsWritten).toBe(2);
   });
 
+  it('reports per-evaluator success ratios when one evaluator fails', async () => {
+    evaluate.mockImplementation((prompt: { id: string }) => {
+      if (prompt.id === 'relevance') {
+        return Promise.reject(new Error('relevance failed'));
+      }
+      return Promise.resolve({
+        score: { value: 0.9, label: 'pass' },
+        explanation: { summary: 'Good' },
+      });
+    });
+
+    const spans = [makeSpan({ traceId: 'trace-ratio' })];
+    const dtClient = makeDtClient(spans);
+    const config = makeConfig({ metrics: { enabled: ['toxicity', 'relevance'] } });
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    expect(result.resultsWritten).toBe(1);
+    expect(result.errors).toBe(1);
+    expect(result.evaluatorResults).toEqual([
+      expect.objectContaining({ metric: 'toxicity', successes: 1, total: 1, errors: 0 }),
+      expect.objectContaining({ metric: 'relevance', successes: 0, total: 1, errors: 1 }),
+    ]);
+  });
+
   it('ci mode logs breaches', async () => {
     evaluate.mockResolvedValue({
       score: { value: 0.2, label: 'fail' },


### PR DESCRIPTION
## Summary
- report per-evaluator results as success/total ratios instead of redistributed aggregate counts
- report errors as error/total ratios per evaluator
- relabel evaluator timing to Avg Duration and compute it from evaluator calls
- keep persisted run records unchanged

## Validation
- npm test
- npm run build