### PR TITLE
fix(dt-eval-cli): ai-336 align output messages parsing

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -385,14 +385,13 @@ for end-to-end instrumentation examples.
 Each entry accepts a single attribute or a list of candidates; the first
 non-null value wins, with the built-in defaults appended as fallback.
 
-**Example 1 — explicit legacy output mapping** (only needed for emitters
-that still use the non-semconv singular attribute `gen_ai.output.message`):
+**Example 1 — explicit legacy output mapping**:
 
 ```yaml
 scope:
   service: pydantic-ai-music-agent
   spanFields:
-    output: gen_ai.output.message
+    output: `gen_ai.completion.0.content
 ```
 
 The default output mapping uses `gen_ai.output.messages`. `spanFields` lets

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -374,7 +374,7 @@ For `dt-evals alerts apply` (Dynatrace Workflows), grant these additionally on t
 ### Custom span field mapping
 
 By default, the CLI reads OTel GenAI semconv (`gen_ai.input.messages`,
-`gen_ai.output.messages`, `gen_ai.output.message`, …). It also probes a
+`gen_ai.output.messages`, …). It also probes a
 small set of legacy fallback attributes (`gen_ai.prompt.N.*`,
 `gen_ai.completion.0.content`) for compatibility with older emitters. If
 your spans expose the LLM I/O under different attribute names — for
@@ -385,22 +385,18 @@ for end-to-end instrumentation examples.
 Each entry accepts a single attribute or a list of candidates; the first
 non-null value wins, with the built-in defaults appended as fallback.
 
-**Example 1 — OTel GenAI variant** (some Bedrock / Vertex SDK emitters
-serialize the full message array under the plural attribute
-`gen_ai.output.messages` instead of the singular
-`gen_ai.output.message`):
+**Example 1 — explicit legacy output mapping** (only needed for emitters
+that still use the non-semconv singular attribute `gen_ai.output.message`):
 
 ```yaml
 scope:
   service: pydantic-ai-music-agent
   spanFields:
-    output: [gen_ai.output.message, gen_ai.output.messages]
+    output: gen_ai.output.message
 ```
 
-The runner stringifies whatever it finds, so a JSON array under
-`gen_ai.output.messages` reaches the judge as the assistant turn(s).
-This is still OTel GenAI-compatible — `spanFields` just lets you handle
-emitter-specific variants explicitly.
+The default output mapping uses `gen_ai.output.messages`. `spanFields` lets
+you opt into legacy or emitter-specific attributes explicitly.
 
 **Example 2 — OTel spans not following the GenAI SemConv (OpenInference):**
 
@@ -471,7 +467,6 @@ scope:
     count: 50
   spanFields:
     context: span.context
-    output: [gen_ai.output.message, gen_ai.output.messages]
     # input, systemInstruction, model use built-in defaults
 
 metrics:
@@ -640,7 +635,7 @@ The CLI reads OTel GenAI semconv fields by default:
 | Canonical field | Default attributes read |
 |----------------|------------------------|
 | `input` | `gen_ai.input.messages` |
-| `output` | `gen_ai.output.message`, `gen_ai.output.messages` |
+| `output` | `gen_ai.output.messages` |
 | `model` | `gen_ai.request.model` |
 | `systemInstruction` | `gen_ai.system_instruction` |
 

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -21,7 +21,7 @@ const PROMPT_SLOTS = 3;
 // candidates are prepended to these so the user's choice wins, but the
 // defaults remain as a fallback.
 const DEFAULT_INPUT_FIELDS = ['gen_ai.input.messages'];
-const DEFAULT_OUTPUT_FIELDS = ['gen_ai.output.message', 'gen_ai.output.messages', 'gen_ai.completion.0.content'];
+const DEFAULT_OUTPUT_FIELDS = ['gen_ai.output.messages', 'gen_ai.completion.0.content'];
 const DEFAULT_CONTEXT_FIELDS: string[] = [];
 const DEFAULT_SYSTEM_INSTRUCTION_FIELDS = ['gen_ai.system_instruction'];
 const DEFAULT_MODEL_FIELDS = ['gen_ai.request.model'];

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -4,7 +4,7 @@ export interface GenAiSpan {
   startTime?: string;
   endTime?: string;
   input: string;              // evaluator input after span-field/default parsing
-  output: string;             // gen_ai.output.message
+  output: string;             // parsed evaluator output
   context?: string;           // evaluator context from scope.spanFields.context
   systemInstruction?: string; // gen_ai.system_instruction
   system?: string;            // gen_ai.provider.name (e.g. "openai")

--- a/dt-eval-cli/tests/dt/client.test.ts
+++ b/dt-eval-cli/tests/dt/client.test.ts
@@ -58,7 +58,7 @@ describe('DynatraceClient', () => {
   });
 
   it('executeDql returns records when state=SUCCEEDED immediately', async () => {
-    const records = [{ 'trace.id': 'abc', 'gen_ai.input.messages': 'q', 'gen_ai.output.message': 'a' }];
+    const records = [{ 'trace.id': 'abc', 'gen_ai.input.messages': 'q', 'gen_ai.output.messages': 'a' }];
     globalThis.fetch = vi.fn().mockResolvedValue(
       makeSuccessResponse({ state: 'SUCCEEDED', result: { records } }),
     );

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -69,7 +69,8 @@ describe('buildGenAiSpanQuery', () => {
     const query = buildGenAiSpanQuery({ since: '1h' });
     // OTel GenAI fields
     expect(query).toContain('gen_ai.input.messages');
-    expect(query).toContain('gen_ai.output.message');
+    expect(query).toContain('gen_ai.output.messages');
+    expect(query).not.toContain('gen_ai.output.message,');
     expect(query).toContain('gen_ai.system');
     expect(query).toContain('trace.id');
     expect(query).toContain('start_time');
@@ -88,7 +89,7 @@ describe('parseSpanResults', () => {
         'span.id': 'span001',
         'start_time': '2026-03-01T10:00:00Z',
         'gen_ai.input.messages': '[{"role":"user","content":"Hello"}]',
-        'gen_ai.output.message': 'Hi there!',
+        'gen_ai.output.messages': 'Hi there!',
         'gen_ai.system_instruction': 'Be helpful.',
         'gen_ai.system': 'openai',
         'gen_ai.request.model': 'gpt-4o',
@@ -144,7 +145,7 @@ describe('parseSpanResults', () => {
       {
         'trace.id': 'trace-min',
         'gen_ai.input.messages': 'question',
-        'gen_ai.output.message': 'answer',
+        'gen_ai.output.messages': 'answer',
       },
     ];
 
@@ -160,8 +161,8 @@ describe('parseSpanResults', () => {
 
   it('skips records with no traceId', () => {
     const records = [
-      { 'gen_ai.input.messages': 'q', 'gen_ai.output.message': 'a' },
-      { 'trace.id': 'valid-trace', 'gen_ai.input.messages': 'q2', 'gen_ai.output.message': 'a2' },
+      { 'gen_ai.input.messages': 'q', 'gen_ai.output.messages': 'a' },
+      { 'trace.id': 'valid-trace', 'gen_ai.input.messages': 'q2', 'gen_ai.output.messages': 'a2' },
     ];
 
     const spans = parseSpanResults(records);
@@ -176,7 +177,7 @@ describe('parseSpanResults', () => {
       'string',
       42,
       // valid record with both input and output
-      { 'trace.id': 'valid', 'gen_ai.input.messages': 'q', 'gen_ai.output.message': 'a' },
+      { 'trace.id': 'valid', 'gen_ai.input.messages': 'q', 'gen_ai.output.messages': 'a' },
     ];
     const spans = parseSpanResults(records as unknown[]);
     expect(spans).toHaveLength(1);
@@ -188,7 +189,7 @@ describe('parseSpanResults', () => {
       {
         'trace.id': 'err-trace',
         'gen_ai.input.messages': 'q',
-        'gen_ai.output.message': 'a',
+        'gen_ai.output.messages': 'a',
         'status.code': 'ERROR',
       },
     ];
@@ -206,7 +207,7 @@ describe('parseSpanResults', () => {
       {
         'trace.id': 'obj-input',
         'gen_ai.input.messages': [{ role: 'user', content: 'Hello' }],
-        'gen_ai.output.message': 'Hi',
+        'gen_ai.output.messages': 'Hi',
       },
     ];
 
@@ -219,7 +220,7 @@ describe('parseSpanResults', () => {
       {
         'trace.id': 'provider-trace',
         'gen_ai.input.messages': 'q',
-        'gen_ai.output.message': 'a',
+        'gen_ai.output.messages': 'a',
         'gen_ai.provider.name': 'anthropic',
       },
     ];
@@ -247,7 +248,7 @@ describe('parseSpanResults', () => {
       {
         'trace.id': 'no-user',
         'gen_ai.input.messages': 'something',
-        'gen_ai.output.message': 'reply',
+        'gen_ai.output.messages': 'reply',
       },
     ];
     expect(parseSpanResults(records)[0]!.userPrompt).toBeUndefined();
@@ -269,6 +270,22 @@ describe('parseSpanResults', () => {
     expect(spans).toHaveLength(1);
     expect(spans[0]!.output).toBe('Here is your answer.');
   });
+
+  it('does not use legacy gen_ai.output.message unless explicitly configured', () => {
+    const records = [
+      {
+        'trace.id': 'legacy-output',
+        'gen_ai.input.messages': '[{"role":"user","content":"What is 2+2?"}]',
+        'gen_ai.output.message': 'Legacy answer.',
+      },
+    ];
+    expect(parseSpanResults(records)).toHaveLength(0);
+
+    const spans = parseSpanResults(records, { spanFields: { output: 'gen_ai.output.message' } });
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.output).toBe('Legacy answer.');
+  });
+
 });
 
 describe('spanFields configuration', () => {
@@ -289,7 +306,7 @@ describe('spanFields configuration', () => {
     });
     expect(query).toContain('llm.response');
     expect(query).toContain('custom.completion');
-    expect(query).toContain('gen_ai.output.message');
+    expect(query).toContain('gen_ai.output.messages');
   });
 
   it('buildGenAiSpanQuery includes user-supplied context candidate in fields clause', () => {
@@ -306,7 +323,7 @@ describe('spanFields configuration', () => {
         'trace.id': 'custom-input-trace',
         'llm.user_input': 'hello from non-semconv span',
         'gen_ai.input.messages': 'this should not win',
-        'gen_ai.output.message': 'a',
+        'gen_ai.output.messages': 'a',
       },
     ];
     const spans = parseSpanResults(records, { spanFields: { input: 'llm.user_input' } });
@@ -318,7 +335,7 @@ describe('spanFields configuration', () => {
       {
         'trace.id': 'fallback-trace',
         'gen_ai.input.messages': 'default input',
-        'gen_ai.output.message': 'a',
+        'gen_ai.output.messages': 'a',
       },
     ];
     const spans = parseSpanResults(records, { spanFields: { input: 'not.present' } });
@@ -342,7 +359,7 @@ describe('spanFields configuration', () => {
       {
         'trace.id': 'custom-model',
         'gen_ai.input.messages': 'q',
-        'gen_ai.output.message': 'a',
+        'gen_ai.output.messages': 'a',
         'llm.model': 'claude-sonnet',
       },
     ];
@@ -355,7 +372,7 @@ describe('spanFields configuration', () => {
       {
         'trace.id': 'custom-context',
         'gen_ai.input.messages': 'q',
-        'gen_ai.output.message': 'a',
+        'gen_ai.output.messages': 'a',
         'rag.context': 'retrieved facts',
       },
     ];
@@ -406,7 +423,7 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
             ],
           },
         ]),
-        'gen_ai.output.message': 'Second answer',
+        'gen_ai.output.messages': 'Second answer',
       },
     ];
     const spans = parseSpanResults(records);
@@ -422,7 +439,7 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
           { role: 'system', content: 'sys instructions' },
           { role: 'user', content: 'hello' },
         ]),
-        'gen_ai.output.message': 'hi back',
+        'gen_ai.output.messages': 'hi back',
       },
     ];
     const spans = parseSpanResults(records);
@@ -435,7 +452,7 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
       {
         'trace.id': 'plain',
         'gen_ai.input.messages': 'just a plain question',
-        'gen_ai.output.message': 'an answer',
+        'gen_ai.output.messages': 'an answer',
       },
     ];
     const spans = parseSpanResults(records);
@@ -450,7 +467,7 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
         'trace.id': 'mixed',
         'gen_ai.system_instruction': 'explicit system',
         'gen_ai.input.messages': inputJson,
-        'gen_ai.output.message': 'answer',
+        'gen_ai.output.messages': 'answer',
       },
     ];
     const spans = parseSpanResults(records);
@@ -463,7 +480,7 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
         'trace.id': 'custom-structured-input',
         'custom.input': 'use this exact input',
         'gen_ai.input.messages': inputJson,
-        'gen_ai.output.message': 'answer',
+        'gen_ai.output.messages': 'answer',
       },
     ];
     const spans = parseSpanResults(records, { spanFields: { input: 'custom.input' } });

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -69,7 +69,7 @@ function makeDtClient(spans: GenAiSpan[]) {
     'span.id': s.spanId,
     timestamp: s.timestamp,
     'gen_ai.input.messages': s.input,
-    'gen_ai.output.message': s.output,
+    'gen_ai.output.messages': s.output,
     'gen_ai.system': s.system,
     'gen_ai.request.model': s.requestModel,
     'rag.context': s.context,


### PR DESCRIPTION
## Summary

- remove non-semconv `gen_ai.output.message` from default output candidates
- keep `gen_ai.output.messages` as the default output source
- keep legacy singular output support available only through explicit `scope.spanFields.output`

## Validation

- `npm test`
- `npm run build`

Closes #157.
