### PR TITLE
feat(dt-eval-cli): ai-337 add operation-name span filter

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -300,6 +300,7 @@ judge:
 scope:
   service: travel-assistant
   since: 1h
+  operationNames: [chat, text_completion, generate_content]
   sampling:
     strategy: random
     percent: 10
@@ -320,6 +321,12 @@ alerts:
 
 storeEvaluatedPrompt: false
 ```
+
+By default, the runner keeps only chat/text-generation spans:
+`chat`, `text_completion`, and `generate_content`. Configure
+`scope.operationNames` to narrow or extend that keep-list, for example
+`operationNames: [chat]`. Set it to `[]` only if you intentionally want to
+disable the operation-name filter.
 
 Sampling strategies:
 
@@ -461,6 +468,7 @@ judge:
 scope:
   service: travel-assistant
   since: 1h
+  operationNames: [chat, text_completion, generate_content]
   sampling:
     strategy: latest
     count: 50

--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -21,6 +21,8 @@ export const ALL_METRICS = [
 // Sensible starter set — users can expand via dt-evals configure
 export const DEFAULT_METRICS = ['toxicity', 'relevance', 'faithfulness'];
 
+export const DEFAULT_OPERATION_NAMES = ['chat', 'text_completion', 'generate_content'];
+
 export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {
   dynatrace: Partial<DtEvalConfig['dynatrace']>;
   judge: Partial<DtEvalConfig['judge']>;
@@ -37,6 +39,7 @@ export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {
   },
   scope: {
     since: '1h',
+    operationNames: DEFAULT_OPERATION_NAMES,
     sampling: {
       strategy: 'random',
       percent: 5,

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -243,6 +243,19 @@ export function validateConfig(config: DtEvalConfig): void {
     issues.push('scope.since must be a duration like "1h", "30m", "24h"');
   }
 
+  const operationNames = config.scope?.operationNames as unknown;
+  if (operationNames !== undefined) {
+    if (!Array.isArray(operationNames)) {
+      issues.push('scope.operationNames must be an array of non-empty strings');
+    } else {
+      for (const [i, name] of operationNames.entries()) {
+        if (typeof name !== 'string' || !name.trim()) {
+          issues.push(`scope.operationNames[${i}] must be a non-empty string`);
+        }
+      }
+    }
+  }
+
   const { strategy } = config.scope?.sampling ?? {};
   if (strategy && !['random', 'latest', 'errors-only'].includes(strategy)) {
     issues.push(`scope.sampling.strategy must be one of: random, latest, errors-only`);

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -246,7 +246,7 @@ export function validateConfig(config: DtEvalConfig): void {
   const operationNames = config.scope?.operationNames as unknown;
   if (operationNames !== undefined) {
     if (!Array.isArray(operationNames)) {
-      issues.push('scope.operationNames must be an array of non-empty strings');
+      issues.push('scope.operationNames must be an array of strings (use [] to disable the filter)');
     } else {
       for (const [i, name] of operationNames.entries()) {
         if (typeof name !== 'string' || !name.trim()) {

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -67,6 +67,8 @@ export interface SpanFieldsMap {
 export interface ScopeConfig {
   service?: string; // service.name to filter spans (previously 'app')
   since: string; // e.g. "1h", "6h", "24h"
+  /** GenAI operation names to keep when fetching spans. Empty array disables this filter. */
+  operationNames?: string[];
   sampling?: {
     strategy: 'random' | 'latest' | 'errors-only';
     percent?: number; // for random

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -1,6 +1,7 @@
 import type { GenAiSpan } from './types.js';
 import type { SpanFieldsMap } from '../config/schema.js';
 import { toCandidateList } from '../config/schema.js';
+import { DEFAULT_OPERATION_NAMES } from '../config/defaults.js';
 
 export interface DqlQueryOptions {
   app?: string;     // service/app name to filter spans
@@ -9,6 +10,8 @@ export interface DqlQueryOptions {
   errorsOnly?: boolean;
   /** Custom span attribute candidates. Tried before built-in defaults. */
   spanFields?: SpanFieldsMap;
+  /** GenAI operation names to keep. Empty array disables this filter. */
+  operationNames?: string[];
 }
 
 export type DqlResult = GenAiSpan[];
@@ -49,8 +52,13 @@ function resolveFields(spanFields: SpanFieldsMap | undefined): ResolvedFields {
   };
 }
 
+function dqlStringLiteral(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
   const { app, since, limit = 1000, errorsOnly = false, spanFields } = opts;
+  const operationNames = opts.operationNames ?? DEFAULT_OPERATION_NAMES;
   const fields = resolveFields(spanFields);
 
   // Use explicit from:/to: timeframe — a filter alone leaves Grail's default
@@ -59,6 +67,11 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
 
   // Support both OTel GenAI semconv (gen_ai.system) and OpenLLMetry (gen_ai.provider.name)
   lines.push('| filter isNotNull(gen_ai.system) or isNotNull(gen_ai.provider.name)');
+
+  if (operationNames.length > 0) {
+    const names = operationNames.map(dqlStringLiteral).join(', ');
+    lines.push(`| filter in(gen_ai.operation.name, array(${names}))`);
+  }
 
   if (app) {
     // Match by either service.name (OTel GenAI semconv) or dt.service.name
@@ -94,6 +107,7 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
     'start_time',
     'end_time',
     'status.code',
+    'gen_ai.operation.name',
     'gen_ai.system',
     'gen_ai.provider.name',
     ...fields.input,

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -56,9 +56,29 @@ function dqlStringLiteral(value: string): string {
   return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 }
 
+/**
+ * Resolve the effective operation-name keep-list, applying the default when unset and
+ * trimming each entry so a stray-whitespace config value (e.g. `" chat "`) still matches
+ * the untrimmed operation name on real spans, in both the DQL filter and the parser net.
+ */
+export function resolveOperationNames(operationNames?: string[]): string[] {
+  return (operationNames ?? DEFAULT_OPERATION_NAMES).map(name => name.trim());
+}
+
+/**
+ * Parser-side safety net mirroring the DQL operation-name filter: keep only spans
+ * whose gen_ai.operation.name is in the keep-list. An empty list disables the filter.
+ */
+export function filterSpansByOperationName(spans: GenAiSpan[], operationNames?: string[]): GenAiSpan[] {
+  const keep = resolveOperationNames(operationNames);
+  if (keep.length === 0) return spans;
+  const keepSet = new Set(keep);
+  return spans.filter(span => span.operationName !== undefined && keepSet.has(span.operationName));
+}
+
 export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
   const { app, since, limit = 1000, errorsOnly = false, spanFields } = opts;
-  const operationNames = opts.operationNames ?? DEFAULT_OPERATION_NAMES;
+  const operationNames = resolveOperationNames(opts.operationNames);
   const fields = resolveFields(spanFields);
 
   // Use explicit from:/to: timeframe — a filter alone leaves Grail's default
@@ -284,6 +304,7 @@ export function parseSpanResults(
       userPrompt,
       // gen_ai.system (OTel) or gen_ai.provider.name (OpenLLMetry)
       system: asString(r['gen_ai.system']) ?? asString(r['gen_ai.provider.name']),
+      operationName: asString(r['gen_ai.operation.name']),
       requestModel: pickFirstMatch(r, fields.model)?.value,
       isError: statusCode === 'ERROR' || undefined,
     });

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -8,6 +8,7 @@ export interface GenAiSpan {
   context?: string;           // evaluator context from scope.spanFields.context
   systemInstruction?: string; // gen_ai.system_instruction
   system?: string;            // gen_ai.provider.name (e.g. "openai")
+  operationName?: string;     // gen_ai.operation.name (e.g. "chat", "text_completion")
   requestModel?: string;      // gen_ai.request.model
   /** Latest user-role content extracted from prompt slots or structured messages.
    * Useful for metrics that should score the user's turn alone. */

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -4,7 +4,7 @@ import type { DynatraceClient } from '../dt/client.js';
 import type { DtEvalConfig, MetricEntry, MetricInputs, CanonicalSpanField } from '../config/schema.js';
 import { metricId, metricInputs } from '../config/schema.js';
 import type { GenAiSpan, BizeventPayload } from '../dt/types.js';
-import { buildGenAiSpanQuery, parseSpanResults } from '../dt/dql.js';
+import { buildGenAiSpanQuery, parseSpanResults, filterSpansByOperationName } from '../dt/dql.js';
 import { BizeventWriter, buildBizeventPayload } from '../dt/bizevent.js';
 import { DRIFT_METRIC_ID, runDriftDetection, buildDriftBizevents } from './drift.js';
 import { applySampling } from './sampler.js';
@@ -172,8 +172,15 @@ export async function runEvals(
   logger.timing('DQL fetch', dqlMs, { rawRecords: (rawRecords as unknown[]).length });
 
   const t0Parse = Date.now();
-  const allSpans = parseSpanResults(rawRecords, { spanFields: evalConfig.scope.spanFields });
-  logger.timing('Parse spans', Date.now() - t0Parse, { spans: allSpans.length });
+  const parsedSpans = parseSpanResults(rawRecords, { spanFields: evalConfig.scope.spanFields });
+  // Safety net: re-apply the operation-name keep-list at the parser layer so a DQL
+  // change or unexpected extra records can't leak non-keep-listed operation spans
+  // into evaluation.
+  const allSpans = filterSpansByOperationName(parsedSpans, evalConfig.scope.operationNames);
+  logger.timing('Parse spans', Date.now() - t0Parse, {
+    spans: allSpans.length,
+    dropped: parsedSpans.length - allSpans.length,
+  });
   emit?.({ phase: 'fetched', spans: allSpans.length, durationMs: dqlMs });
 
   // 2. Apply sampling

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -162,6 +162,7 @@ export async function runEvals(
     since,
     errorsOnly: evalConfig.scope.sampling?.strategy === 'errors-only',
     spanFields: evalConfig.scope.spanFields,
+    operationNames: evalConfig.scope.operationNames,
   });
   logger.debug(`DQL query:\n${query}`);
 

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -280,6 +280,45 @@ describe('config', () => {
       expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
     });
 
+    it('allows an empty scope.operationNames list to disable the operation-name filter', () => {
+      const config = makeValidConfig({
+        scope: {
+          since: '1h',
+          operationNames: [],
+          sampling: { strategy: 'random', percent: 100 },
+        },
+      });
+
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('throws when scope.operationNames is not an array', () => {
+      const config = makeValidConfig();
+      (config.scope as unknown as { operationNames: unknown }).operationNames = 'chat';
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues).toContain('scope.operationNames must be an array of non-empty strings');
+      }
+    });
+
+    it('throws when scope.operationNames contains non-string or blank entries', () => {
+      const config = makeValidConfig();
+      (config.scope as unknown as { operationNames: unknown[] }).operationNames = ['chat', '', 42];
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues).toContain('scope.operationNames[1] must be a non-empty string');
+        expect(issues).toContain('scope.operationNames[2] must be a non-empty string');
+      }
+    });
+
     it('passes when only origin/destination are set (no top-level url)', async () => {
       const { resolveEndpoints } = await import('../src/config/schema.js');
       const config = makeValidConfig();

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -301,7 +301,7 @@ describe('config', () => {
         validateConfig(config);
       } catch (err) {
         const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
-        expect(issues).toContain('scope.operationNames must be an array of non-empty strings');
+        expect(issues).toContain('scope.operationNames must be an array of strings (use [] to disable the filter)');
       }
     });
 

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -25,6 +25,29 @@ describe('buildGenAiSpanQuery', () => {
     expect(query).toContain('isNotNull(gen_ai.provider.name)');
   });
 
+  it('filters to chat and text generation operation names by default', () => {
+    const query = buildGenAiSpanQuery({ since: '1h' });
+    expect(query).toContain(
+      '| filter in(gen_ai.operation.name, array("chat", "text_completion", "generate_content"))',
+    );
+  });
+
+  it('uses custom operation names when configured', () => {
+    const query = buildGenAiSpanQuery({
+      since: '1h',
+      operationNames: ['chat', 'custom"operation'],
+    });
+    expect(query).toContain(
+      '| filter in(gen_ai.operation.name, array("chat", "custom\\"operation"))',
+    );
+    expect(query).not.toContain('text_completion');
+  });
+
+  it('does not add an operation-name filter when configured with an empty list', () => {
+    const query = buildGenAiSpanQuery({ since: '1h', operationNames: [] });
+    expect(query).not.toContain('gen_ai.operation.name, array(');
+  });
+
   it('filters by app via service.name (OTel) and dt.service.name (Dynatrace semconv)', () => {
     const query = buildGenAiSpanQuery({ since: '1h', app: 'my-service' });
     expect(query).toContain('service.name == "my-service"');
@@ -72,6 +95,7 @@ describe('buildGenAiSpanQuery', () => {
     expect(query).toContain('gen_ai.output.messages');
     expect(query).not.toContain('gen_ai.output.message,');
     expect(query).toContain('gen_ai.system');
+    expect(query).toContain('gen_ai.operation.name');
     expect(query).toContain('trace.id');
     expect(query).toContain('start_time');
     // OpenLLMetry fields

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildGenAiSpanQuery, parseSpanResults } from '../../src/dt/dql.js';
+import { buildGenAiSpanQuery, parseSpanResults, filterSpansByOperationName } from '../../src/dt/dql.js';
+import type { GenAiSpan } from '../../src/dt/types.js';
 
 describe('buildGenAiSpanQuery', () => {
   it('uses explicit from:/to: timeframe (not a filter clause) for the given since value', () => {
@@ -46,6 +47,13 @@ describe('buildGenAiSpanQuery', () => {
   it('does not add an operation-name filter when configured with an empty list', () => {
     const query = buildGenAiSpanQuery({ since: '1h', operationNames: [] });
     expect(query).not.toContain('gen_ai.operation.name, array(');
+  });
+
+  it('trims stray whitespace around configured operation names', () => {
+    const query = buildGenAiSpanQuery({ since: '1h', operationNames: [' chat ', 'text_completion '] });
+    expect(query).toContain(
+      '| filter in(gen_ai.operation.name, array("chat", "text_completion"))',
+    );
   });
 
   it('filters by app via service.name (OTel) and dt.service.name (Dynatrace semconv)', () => {
@@ -116,6 +124,7 @@ describe('parseSpanResults', () => {
         'gen_ai.output.messages': 'Hi there!',
         'gen_ai.system_instruction': 'Be helpful.',
         'gen_ai.system': 'openai',
+        'gen_ai.operation.name': 'chat',
         'gen_ai.request.model': 'gpt-4o',
         'status.code': 'OK',
       },
@@ -132,6 +141,7 @@ describe('parseSpanResults', () => {
     expect(span.output).toBe('Hi there!');
     expect(span.systemInstruction).toBe('Be helpful.');
     expect(span.system).toBe('openai');
+    expect(span.operationName).toBe('chat');
     expect(span.requestModel).toBe('gpt-4o');
     expect(span.isError).toBeUndefined();
   });
@@ -509,5 +519,52 @@ describe('JSON-stringified message arrays (OTel GenAI evolved form)', () => {
     ];
     const spans = parseSpanResults(records, { spanFields: { input: 'custom.input' } });
     expect(spans[0]!.input).toBe('use this exact input');
+  });
+});
+
+describe('filterSpansByOperationName', () => {
+  const span = (operationName?: string): GenAiSpan => ({
+    traceId: `t-${operationName ?? 'none'}`,
+    input: 'q',
+    output: 'a',
+    operationName,
+  });
+
+  it('keeps only spans whose operationName is in the keep-list', () => {
+    const spans = [span('chat'), span('execute_tool'), span('generate_content')];
+
+    const kept = filterSpansByOperationName(spans, ['chat', 'generate_content']);
+
+    expect(kept.map(s => s.operationName)).toEqual(['chat', 'generate_content']);
+  });
+
+  it('drops spans with no operationName when the filter is active', () => {
+    const spans = [span('chat'), span(undefined)];
+
+    const kept = filterSpansByOperationName(spans, ['chat']);
+
+    expect(kept.map(s => s.operationName)).toEqual(['chat']);
+  });
+
+  it('applies the default keep-list when operationNames is undefined', () => {
+    const spans = [span('chat'), span('embeddings')];
+
+    const kept = filterSpansByOperationName(spans, undefined);
+
+    expect(kept.map(s => s.operationName)).toEqual(['chat']);
+  });
+
+  it('returns all spans unchanged when the keep-list is empty', () => {
+    const spans = [span('chat'), span('execute_tool'), span(undefined)];
+
+    expect(filterSpansByOperationName(spans, [])).toEqual(spans);
+  });
+
+  it('trims keep-list entries so a whitespace-padded config value still matches spans', () => {
+    const spans = [span('chat'), span('execute_tool')];
+
+    const kept = filterSpansByOperationName(spans, [' chat ']);
+
+    expect(kept.map(s => s.operationName)).toEqual(['chat']);
   });
 });

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -71,6 +71,8 @@ function makeDtClient(spans: GenAiSpan[]) {
     'gen_ai.input.messages': s.input,
     'gen_ai.output.messages': s.output,
     'gen_ai.system': s.system,
+    // Default to a kept operation so fixtures survive the operation-name safety net
+    'gen_ai.operation.name': s.operationName ?? 'chat',
     'gen_ai.request.model': s.requestModel,
     'rag.context': s.context,
     'gen_ai.system_instruction': s.systemInstruction,
@@ -135,6 +137,31 @@ describe('runEvals', () => {
 
     const [query] = dtClient.executeDql.mock.calls[0] as [string];
     expect(query).toContain('| filter in(gen_ai.operation.name, array("chat"))');
+  });
+
+  it('drops spans whose operation name is not in the keep-list (parser safety net)', async () => {
+    // Simulate the DQL returning an extra non-model span despite the query filter.
+    const dtClient = makeDtClient([
+      makeSpan({ traceId: 'kept', operationName: 'chat' }),
+      makeSpan({ traceId: 'leaked', operationName: 'execute_tool' }),
+    ]);
+    const config = makeConfig({
+      scope: {
+        since: '1h',
+        operationNames: ['chat'],
+        sampling: { strategy: 'random', percent: 100 },
+      },
+    });
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    // Only the "chat" span survives → 1 span × 2 metrics = 2 evaluations
+    expect(result.spansEvaluated).toBe(1);
+    expect(evaluate).toHaveBeenCalledTimes(2);
   });
 
   it('applies sampling (sample=50 takes ~half)', async () => {

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -117,6 +117,26 @@ describe('runEvals', () => {
     expect(result.resultsWritten).toBe(4);
   });
 
+  it('passes configured operation-name keep-list to the DQL query', async () => {
+    const dtClient = makeDtClient([makeSpan()]);
+    const config = makeConfig({
+      scope: {
+        since: '1h',
+        operationNames: ['chat'],
+        sampling: { strategy: 'random', percent: 100 },
+      },
+    });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    const [query] = dtClient.executeDql.mock.calls[0] as [string];
+    expect(query).toContain('| filter in(gen_ai.operation.name, array("chat"))');
+  });
+
   it('applies sampling (sample=50 takes ~half)', async () => {
     const spans = Array.from({ length: 20 }, (_, i) => makeSpan({ traceId: `trace-${i}` }));
     const dtClient = makeDtClient(spans);


### PR DESCRIPTION
## Summary
- add a YAML-configurable `scope.operationNames` keep-list for GenAI spans
- filter fetched spans by `gen_ai.operation.name` before parsing/evaluation
- document the default chat/text-generation operation names and override behavior

## Validation
- npm test -- tests/dt/dql.test.ts tests/runner/index.test.ts
- npm run build

Closes #158
