### PR TITLE
ci: add renovate configuration for the monorepo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "semanticCommitType": "deps",
+  "semanticCommitScope": null,
+  "timezone": "Europe/Vienna",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"]
+  },
+  "packageRules": [
+    {
+      "description": "Group non-major devDependencies across all npm packages",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm dev dependencies (non-major)"
+    },
+    {
+      "description": "Group AWS SDK v3 packages together",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@aws-sdk/**"],
+      "groupName": "aws-sdk"
+    },
+    {
+      "description": "Label major SDK bumps for review; keep them separate",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@anthropic-ai/sdk",
+        "@google/genai",
+        "openai",
+        "typescript"
+      ],
+      "matchUpdateTypes": ["major"],
+      "labels": ["dependencies", "major", "breaking"]
+    },
+    {
+      "description": "Group GitHub Actions digest and version updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group Python (dt-ai-ingest) non-major updates",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python dependencies (non-major)"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Introduces a repo-wide `renovate.json` at the repository root. The repo currently has **no dependency automation** (no Renovate, no Dependabot), so declared dependencies aren't tracked at all.

## Coverage

Renovate auto-detects all ecosystems in the monorepo:

| Ecosystem | Manifests |
|---|---|
| npm | `dt-eval-lib`, `dt-eval-cli`, `dt-eval-deploy` |
| pep621 (hatchling) | `dt-ai-ingest/pyproject.toml` |
| Dockerfile | `dt-eval-deploy/Dockerfile` |
| GitHub Actions | `.github/workflows/*` |

## Config choices

- **Semantic commits**: type `deps`, no scope — so PR titles pass the existing `amannn/action-semantic-pull-request` check (`deps` is an allowed type; `deps` is *not* an allowed scope, hence scope disabled) and land in the release-please **📦 Dependencies** changelog section.
- **Pin GitHub Actions to digests** (`helpers:pinGitHubActionDigests`) — matches the existing SHA-pinned workflows.
- **Grouping**: non-major npm dev deps, AWS SDK v3, GitHub Actions, and non-major Python updates each grouped into single PRs to cut noise.
- **Major SDK bumps** (`@anthropic-ai/sdk`, `@google/genai`, `openai`, `typescript`) kept as separate PRs labelled `major`/`breaking` for manual review — these are known-breaking (e.g. `@anthropic-ai/sdk` 0.32 → 0.115).
- Weekly schedule, monthly lockfile maintenance, and a Dependency Dashboard issue.

## Notes

- Onboarding: once merged, Renovate (if the app is installed on the org) will open its dashboard issue and a first batch of PRs. Several updates are currently out of range and will surface immediately — notably the 4 major SDK/TS bumps above.
- Config validated with `renovate-config-validator` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)