### PR TITLE
ci: enable release-please node-workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,9 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "pull-request-title-pattern": "chore: release${component} ${version}",
+    "plugins": [
+        "node-workspace"
+    ],
     "packages": {
         "dt-eval-cli": {
             "package-name": "dt-evals",


### PR DESCRIPTION
## What

Adds `"plugins": ["node-workspace"]` to `release-please-config.json`.

## Why

`dt-eval-cli` depends on the internal `@dynatrace-oss/dt-eval-lib` (`^0.0.14-alpha`). Because `0.0.x` caret ranges lock to the exact patch, every `dt-eval-lib` release requires bumping that dependency in `dt-eval-cli`.

The `node-workspace` plugin makes release-please detect this internal dependency and **bump it in the same release run** — so a `dt-eval-lib` release also updates (and version-bumps) `dt-eval-cli` in one release PR, instead of waiting for a follow-up dependency PR.

## ⚠️ Interaction to be aware of

This means `dt-eval-lib` and `dt-eval-cli` will now frequently **co-release in the same run**. The existing `publish-npm` job in `release.yml` builds its `build-config` with a `forEach` that **overwrites the config each iteration**, so only the *last* released package in `paths_released` actually gets published — the other would be silently skipped.

This bug is pre-existing but becomes much more likely to trigger with co-releases. It should be fixed (loop over all released packages / matrix the publish job) either here or as an immediate follow-up.

## Scope note

`dt-eval-deploy` also consumes `dt-eval-lib` but is **not** a release-please package (not published), so it is unaffected — its bump still comes from Renovate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)