### PR TITLE
ci: add renovate configuration for the monorepo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "semanticCommitType": "deps",
+  "semanticCommitScope": null,
+  "timezone": "Europe/Vienna",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"]
+  },
+  "packageRules": [
+    {
+      "description": "Group non-major devDependencies across all npm packages",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm dev dependencies (non-major)"
+    },
+    {
+      "description": "Group AWS SDK v3 packages together",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@aws-sdk/**"],
+      "groupName": "aws-sdk"
+    },
+    {
+      "description": "Label major SDK bumps for review; keep them separate",
+      "matchManagers": ["npm"],
+      "matchPackageNames": [
+        "@anthropic-ai/sdk",
+        "@google/genai",
+        "openai",
+        "typescript"
+      ],
+      "matchUpdateTypes": ["major"],
+      "labels": ["dependencies", "major", "breaking"]
+    },
+    {
+      "description": "Group GitHub Actions digest and version updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group Python (dt-ai-ingest) non-major updates",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "python dependencies (non-major)"
+    }
+  ]
+}


### PR DESCRIPTION
Introduces a repo-wide `renovate.json` (the repo currently has no dependency automation).

Covers all ecosystems: npm (`dt-eval-lib`, `dt-eval-cli`, `dt-eval-deploy`), pep621/`dt-ai-ingest`, the `dt-eval-deploy` Dockerfile, and GitHub Actions.

- Semantic commit type `deps` (no scope) — passes the semantic-PR-title check and lands in the release-please 📦 Dependencies changelog section.
- Pins GitHub Actions to digests (`helpers:pinGitHubActionDigests`), matching existing SHA-pinned workflows.
- Groups non-major npm dev deps, AWS SDK v3, Actions, and Python minor/patch updates.
- Major SDK bumps (`@anthropic-ai/sdk`, `@google/genai`, `openai`, `typescript`) kept separate and labelled for review.
- Validated with `renovate-config-validator`.

Independent of the release-automation PRs. Requires the Renovate GitHub App to be installed on the org to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)