### PR TITLE
ci: enable release-please node-workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,9 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "pull-request-title-pattern": "chore: release${component} ${version}",
+    "plugins": [
+        "node-workspace"
+    ],
     "packages": {
         "dt-eval-cli": {
             "package-name": "dt-evals",


### PR DESCRIPTION
Adds `"plugins": ["node-workspace"]` to `release-please-config.json`.

`dt-eval-cli` depends on the internal `@dynatrace-oss/dt-eval-lib` (`^0.0.14-alpha`). Because `0.0.x` caret ranges lock to the exact patch, every `dt-eval-lib` release needs that dependency bumped in `dt-eval-cli` — currently a manual follow-up commit (see the earlier `fix(dt-eval-cli): bump dt-eval-lib to 0.0.14-alpha`). The plugin automates this: release-please updates the internal dependency and cuts the dependent's release PR automatically.

 node-workspace respects `separate-pull-requests: true`, so lib and cli still get separate release PRs and normally release in separate runs. It does, however, make the two release PRs coexist, so back-to-back merges can be processed in one run — which is exactly the partial-publish case #165 hardens against. Recommended to merge #165 first, but not required; they can land in either order.

## Scope note

`dt-eval-deploy` also consumes `dt-eval-lib` but is not a release-please package, so it's unaffected — its bump comes from Renovate (#164).

🤖 Generated with [Claude Code](https://claude.com/claude-code)