### PR TITLE
fix(dt-eval-cli): route ingest to env-api on labs tenants

### DIFF
--- a/dt-eval-cli/src/dt/client.ts
+++ b/dt-eval-cli/src/dt/client.ts
@@ -70,22 +70,30 @@ const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 60_000;
 
 /**
- * Translate `*.apps.dynatrace.com` → `*.live.dynatrace.com`.
+ * Rewrite a platform (`.apps.`) host to its classic environment-API host.
  *
  * Modern Dynatrace platform splits its surface across two subdomains:
  *   - `.apps.` hosts the platform-storage / DQL APIs (`/platform/storage/...`).
- *   - `.live.` hosts the classic environment APIs (`/api/v2/...`).
+ *   - the env-api host hosts the classic environment APIs (`/api/v2/...`).
  *
  * Users supply a single `environmentUrl` for the tenant — by convention the
  * `.apps.` form (because DQL is the entry point). For ingest endpoints
  * (`/api/v2/bizevents/ingest`, `/api/v2/metrics/ingest`) we need to redirect
- * to `.live.`, otherwise the apps gateway returns 400 *Invalid app context*.
+ * to the env-api host, otherwise the apps gateway returns 400 *Invalid app
+ * context*.
  *
- * Idempotent on URLs that already point at `.live.` or any other host
+ * The env-api host differs by environment family:
+ *   - Production SaaS: `{env}.apps.dynatrace.com` → `{env}.live.dynatrace.com`.
+ *   - Internal labs (sprint/dev): the env-api simply drops the `apps.` label,
+ *     e.g. `{env}.sprint.apps.dynatracelabs.com` → `{env}.sprint.dynatracelabs.com`.
+ *
+ * Idempotent on URLs that already point at the env-api host or any other host
  * (cluster-managed, on-prem, dev sandboxes), so it's safe to call always.
  */
 function liveSubdomain(url: string): string {
-  return url.replace(/^(https?:\/\/[^/]+?)\.apps\.dynatrace\.com/, '$1.live.dynatrace.com');
+  return url
+    .replace(/^(https?:\/\/[^/]+?)\.apps\.dynatrace\.com/, '$1.live.dynatrace.com')
+    .replace(/^(https?:\/\/[^/]+?)\.apps\.(dynatracelabs\.com)/, '$1.$2');
 }
 
 export class DynatraceClient {
@@ -176,7 +184,7 @@ export class DynatraceClient {
   }
 
   async ingestBizevents(events: object[]): Promise<void> {
-    // Classic env-api on `.live.` subdomain. See `liveSubdomain()` for why.
+    // Classic env-api host. See `liveSubdomain()` for the host rewrite.
     const url = `${this.liveBaseUrl}/api/v2/bizevents/ingest`;
     const response = await fetch(url, {
       method: 'POST',
@@ -194,7 +202,7 @@ export class DynatraceClient {
   }
 
   async ingestMetrics(lines: string): Promise<void> {
-    // Classic env-api on `.live.` subdomain. See `liveSubdomain()` for why.
+    // Classic env-api host. See `liveSubdomain()` for the host rewrite.
     const url = `${this.liveBaseUrl}/api/v2/metrics/ingest`;
     const response = await fetch(url, {
       method: 'POST',

--- a/dt-eval-cli/src/dtctl/index.ts
+++ b/dt-eval-cli/src/dtctl/index.ts
@@ -309,14 +309,18 @@ export function liveSubdomain(url: string): string {
 }
 
 export async function checkBizeventPermission(environmentUrl: string, bearerToken: string): Promise<PermissionCheck> {
-  const isClassic = /\.apps\.dynatrace\.com(\/|$)/i.test(environmentUrl);
+  // Any `.apps.` platform host (production or labs) is rewritten to the classic
+  // env-api by liveSubdomain(); those posts require `storage:events:write`.
+  // Deriving it from the rewrite keeps the two in sync as host families grow.
+  const normalizedUrl = environmentUrl.replace(/\/$/, '');
+  const isClassic = liveSubdomain(normalizedUrl) !== normalizedUrl;
   const scope = isClassic ? 'storage:events:write' : 'openpipeline:bizevents:ingest';
   const label = isClassic
     ? 'Bizevent write (storage:events:write)'
     : 'Bizevent write (openpipeline:bizevents:ingest)';
 
   // Probe the same URL the runtime client posts to.
-  const url = `${liveSubdomain(environmentUrl.replace(/\/$/, ''))}/api/v2/bizevents/ingest`;
+  const url = `${liveSubdomain(normalizedUrl)}/api/v2/bizevents/ingest`;
   try {
     const response = await fetch(url, {
       method: 'POST',

--- a/dt-eval-cli/src/dtctl/index.ts
+++ b/dt-eval-cli/src/dtctl/index.ts
@@ -360,7 +360,9 @@ export async function createPlatformToken(
   name: string,
   scopes: string[],
 ): Promise<PlatformToken> {
-  const url = `${environmentUrl.replace(/\/$/, '')}/api/v2/apiTokens`;
+  // Classic env-api endpoint — route through liveSubdomain() so `.apps.` hosts
+  // (prod and labs) reach the env-api host, not the apps gateway.
+  const url = `${liveSubdomain(environmentUrl.replace(/\/$/, ''))}/api/v2/apiTokens`;
   const response = await fetch(url, {
     method: 'POST',
     headers: { Authorization: authScheme(bearerToken), 'Content-Type': 'application/json' },

--- a/dt-eval-cli/tests/dt/client.test.ts
+++ b/dt-eval-cli/tests/dt/client.test.ts
@@ -206,6 +206,58 @@ describe('DynatraceClient', () => {
     expect(metricsUrl).toBe('https://abc12345.live.dynatrace.com/api/v2/metrics/ingest');
   });
 
+  it('ingest endpoints strip the apps. label for *.apps.dynatracelabs.com (sprint/dev)', async () => {
+    // Internal labs tenants supply a .apps. URL like {env}.sprint.apps.dynatracelabs.com,
+    // but their classic env-api lives at {env}.sprint.dynatracelabs.com (no .apps., no .live.).
+    // Leaving .apps. in place makes ingest hit the apps gateway → 400 "Invalid app context".
+    const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://uim8926h.sprint.apps.dynatracelabs.com',
+      apiToken: PLATFORM_TOKEN,
+    });
+
+    await client.ingestBizevents([{ 'event.type': 'x' }]);
+    await client.ingestMetrics('my.metric 1.0');
+
+    const bizUrl = mockFetch.mock.calls[0]?.[0];
+    const metricsUrl = mockFetch.mock.calls[1]?.[0];
+    expect(bizUrl).toBe('https://uim8926h.sprint.dynatracelabs.com/api/v2/bizevents/ingest');
+    expect(metricsUrl).toBe('https://uim8926h.sprint.dynatracelabs.com/api/v2/metrics/ingest');
+  });
+
+  it('ingest strips the apps. label for the .dev. labs variant too', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://uim8926h.dev.apps.dynatracelabs.com',
+      apiToken: PLATFORM_TOKEN,
+    });
+
+    await client.ingestBizevents([{ 'event.type': 'x' }]);
+
+    expect(mockFetch.mock.calls[0]?.[0]).toBe('https://uim8926h.dev.dynatracelabs.com/api/v2/bizevents/ingest');
+  });
+
+  it('DQL queries stay on .apps. for dynatracelabs tenants', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      makeSuccessResponse({ state: 'SUCCEEDED', result: { records: [] } }),
+    );
+    globalThis.fetch = mockFetch;
+
+    const client = new DynatraceClient({
+      environmentUrl: 'https://uim8926h.sprint.apps.dynatracelabs.com',
+      apiToken: PLATFORM_TOKEN,
+    });
+
+    await client.executeDql('fetch spans | limit 1');
+
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toBe('https://uim8926h.sprint.apps.dynatracelabs.com/platform/storage/query/v1/query:execute');
+  });
+
   it('ingest endpoints leave non-.apps. environmentUrls unchanged', async () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
     globalThis.fetch = mockFetch;

--- a/dt-eval-cli/tests/dtctl/index.test.ts
+++ b/dt-eval-cli/tests/dtctl/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { liveSubdomain } from '../../src/dtctl/index.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { liveSubdomain, createPlatformToken } from '../../src/dtctl/index.js';
 
 describe('liveSubdomain', () => {
   it('rewrites *.apps.dynatrace.com to *.live.dynatrace.com', () => {
@@ -25,5 +25,27 @@ describe('liveSubdomain', () => {
   it('passes through on-prem / cluster URLs unchanged', () => {
     const url = 'https://my-cluster.internal.example.com';
     expect(liveSubdomain(url)).toBe(url);
+  });
+});
+
+describe('createPlatformToken', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('posts /api/v2/apiTokens to the env-api host, not the apps gateway', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'tok-1', token: 'dt0c01.SECRET' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    globalThis.fetch = mockFetch;
+
+    await createPlatformToken('https://uim8926h.sprint.apps.dynatracelabs.com', 'bearer', 'n', ['s']);
+
+    expect(mockFetch.mock.calls[0]?.[0]).toBe('https://uim8926h.sprint.dynatracelabs.com/api/v2/apiTokens');
   });
 });


### PR DESCRIPTION
## Why

Users on internal labs/sprint tenants (`*.apps.dynatracelabs.com`) can't run an eval end-to-end: the BizEvent ingest fails with `400 "Invalid app context"`, even with a platform token that has every scope. Spans get fetched and tasks get judged, then the run dies right before writing results. A production customer hit the same wall.

The token was never the problem. The request was going to the wrong host.

## What was wrong

Ingest posts to the classic environment API at `/api/v2/bizevents/ingest`. DQL queries go to the platform host (`*.apps.*`). Since users configure a single `.apps.` URL, the client rewrites that host to the env-api host for ingest only — that's what `liveSubdomain()` does.

That rewrite only knew the production rule:

```
{env}.apps.dynatrace.com  ->  {env}.live.dynatrace.com
```

For a labs host like `uim8926h.sprint.apps.dynatracelabs.com` it matched nothing and left the URL alone, so ingest hit the **apps gateway** instead of the env-api. The gateway rejects that with `400 "Invalid app context"`. DQL kept working because it's supposed to stay on `.apps.`.

Labs env-api hosts don't become `.live.` — they just drop the `apps.` label. This is confirmed by a working manual ingest and by the fact that `dtctl/index.ts` already carried this exact handling; only the copy in `dt/client.ts` was missed.

```
{env}.sprint.apps.dynatracelabs.com  ->  {env}.sprint.dynatracelabs.com
```

## How

- **`dt/client.ts`:** add the labs rule to `liveSubdomain()` as a second, non-overlapping replace (the production regex requires the literal `dynatrace.com`, so it can't match `dynatracelabs.com`). Refresh the now-inaccurate `.live.` doc and inline comments.
- **`dtctl/index.ts`:** fix the scope label `doctor` shows labs users. It reported `openpipeline:bizevents:ingest`, but the probe is redirected to the classic env-api, which wants `storage:events:write`. `isClassic` now derives from whether `liveSubdomain()` rewrites the host, so the label always matches where the request actually goes.
- **`dtctl/index.ts` (`createPlatformToken`):** it built `/api/v2/apiTokens` (a classic env-api endpoint) from the raw URL, so on any `.apps.` host it would hit the apps gateway too. Routed through `liveSubdomain()` for consistency. This function is exported but currently unused, so it's defensive — no live path hit it, but it was the same footgun waiting to happen.
- **Tests:** regression cases for the sprint and dev labs variants, a check that DQL stays on `.apps.` for labs, and a URL-shape test for `createPlatformToken`.

## Scope check

Traced the write path to be sure the fix actually reaches it. The cross-tenant `destination` tenant (README's documented labs example, `eval-results.dev.apps.dynatracelabs.com`) is a plain `DynatraceClient`, so its ingest goes through the same rewrite — no separate code path. DQL builders correctly stay on `.apps.` and were left alone. `createPlatformToken` was the only other classic env-api URL missing the rewrite.

## Testing

- Full CLI suite green: 206 passed.
- Typecheck clean, build succeeds.

## Auth scheme — verified

The original `400` was a routing error that fired *before* auth, so it left one thing unproven: this client sends `Bearer dt0s16…` for platform tokens, while the reported working curl used `Api-Token dt0s16…`. I verified our scheme by posting a single probe bizevent through the fixed client to a production `.apps.dynatrace.com` tenant with a `dt0s16` platform token: `Bearer` → classic env-api `/api/v2/bizevents/ingest` returns 2xx. So the two halves are both confirmed — the labs *host* by the working curl, the `Bearer` *auth* by this probe. There's no reason auth would differ by env-api host family.

The one combination not yet exercised on a live tenant is `Bearer` + a labs `.dynatracelabs.com` env-api at the same time (I don't have a labs token). A post-merge run on the labs tenant is a cheap final confirmation; a `401`/`403` there would be a separate auth issue, not a regression of this fix.
