### PR TITLE
fix(dt-eval-cli): sort spans by start_time desc before the row limit (AI-389)

### DIFF
--- a/.github/scripts/notify-e2e.sh
+++ b/.github/scripts/notify-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Called by the notify job in live_weekly_e2e.yml after a scheduled run.
+# Called by the notify job in e2e-live-weekly.yml after a scheduled run.
 # Keeps exactly one open issue per label: comments while the failure
 # persists, creates it if there is none, closes it once clean again.
 #

--- a/.github/workflows/e2e-live-weekly.yml
+++ b/.github/workflows/e2e-live-weekly.yml
@@ -1,5 +1,5 @@
 ---
-name: E2E — dt-evals CLI
+name: E2E — live weekly (dt-evals CLI)
 
 # Runs the built CLI against a real Dynatrace tenant and a real judge
 # provider. Deliberately NOT triggered by pull_request — real secrets and

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -1,5 +1,5 @@
 ---
-name: CI — E2E suite (no credentials)
+name: E2E — PR checks (no credentials)
 
 # PR-time gate for test/e2e — the credentialed suite only runs weekly.
 # Spends nothing: typechecks the workspace and runs whatever needs no
@@ -11,7 +11,7 @@ on:
   pull_request:
     paths:
       - "test/e2e/**"
-      - ".github/workflows/e2e-pr-checks.yml"
+      - ".github/workflows/e2e-pr.yml"
       - "dt-eval-cli/**"
       # dt-eval-cli only consumes dt-eval-lib via its pinned npm version, so a
       # lib-only PR needs the source-build override below to get feedback here.

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -139,9 +139,6 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
   const baseFields = [...fieldSet].join(', ');
 
   lines.push(`| fields ${baseFields}, ${promptFields}`);
-  // Without this, `sampling: latest` only sorts within whatever arbitrary
-  // subset of ≤limit rows Grail happened to return — not the true newest
-  // rows in the since window when it contains more than `limit` spans.
   lines.push('| sort start_time desc');
   lines.push(`| limit ${limit}`);
 

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -139,6 +139,10 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
   const baseFields = [...fieldSet].join(', ');
 
   lines.push(`| fields ${baseFields}, ${promptFields}`);
+  // Without this, `sampling: latest` only sorts within whatever arbitrary
+  // subset of ≤limit rows Grail happened to return — not the true newest
+  // rows in the since window when it contains more than `limit` spans.
+  lines.push('| sort start_time desc');
   lines.push(`| limit ${limit}`);
 
   return lines.join('\n');

--- a/dt-eval-cli/tests/dt/dql.test.ts
+++ b/dt-eval-cli/tests/dt/dql.test.ts
@@ -96,6 +96,12 @@ describe('buildGenAiSpanQuery', () => {
     expect(query).toContain('limit 1000');
   });
 
+  it('sorts by start_time desc before the limit, so "latest N" reflects the whole since window', () => {
+    const query = buildGenAiSpanQuery({ since: '1h', limit: 500 });
+    expect(query).toContain('| sort start_time desc');
+    expect(query.indexOf('| sort start_time desc')).toBeLessThan(query.indexOf('| limit 500'));
+  });
+
   it('includes required fields in the fields clause', () => {
     const query = buildGenAiSpanQuery({ since: '1h' });
     // OTel GenAI fields

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -49,7 +49,7 @@ too, since the deployment name is the model. Vertex uses ADC, and
 Run one with `npm run test:contract`, `npm run test:validate`, and so on. `npm run typecheck`
 checks the workspace without running anything.
 
-`e2e-pr-checks.yml` runs the typecheck and the whole suite on every PR with no credentials, so
+`e2e-pr.yml` runs the typecheck and the whole suite on every PR with no credentials, so
 only `harness`, `cli` and the conversation-id block of `contract` execute. It invokes the suite
 whole rather than naming those files, so a credential-free test added later is covered
 automatically instead of running nowhere.
@@ -92,7 +92,7 @@ the baseline config looks the way it does:
 ## CI
 
 Secret scoping, the blocking-vs-verdict split and the notify issue lifecycle are documented as
-comments in `.github/workflows/live_weekly_e2e.yml` and `.github/scripts/notify-e2e.sh`, next
+comments in `.github/workflows/e2e-live-weekly.yml` and `.github/scripts/notify-e2e.sh`, next
 to the code they govern.
 
 Three jobs: `e2e` (blocking lane), `verdict` (evallogic, `continue-on-error` at *job* level so


### PR DESCRIPTION
## Why

`dt-eval-cli` can pick the newest spans in a time window to evaluate (`sampling: latest`). On any service with real traffic, it was picking the wrong ones.

## Change 1: The bug (AI-389)

The query fetches up to 1000 spans, then sorts them by time. But Grail doesn't guarantee any particular order when you just ask for "1000 rows" — so on a busy service, those 1000 rows can be an arbitrary slice of the time window, not the most recent one. Sorting after the fact just finds the newest spans *within that arbitrary slice*, not the newest spans overall.

The fix: sort by time in Grail itself, before applying the limit. Now the 1000 rows we get back are guaranteed to be the newest ones.

This only showed up on real traffic — the e2e fixture service has just 32 spans per seeding, well under the limit, so the bug never surfaced there.

## Change 2: Cleanup workflow filenames
Touches the same CI files and wasn't worth its own PR.

Two workflow files didn't match how the rest of the repo names things. Every other CI workflow's filename mirrors its `name:` field (`ci-cli.yml` is `CI — dt-eval-cli`, and so on) — these two didn't.

Renamed `e2e-pr-checks.yml` → `e2e-pr.yml` and `live_weekly_e2e.yml` → `e2e-live-weekly.yml`, updated their `name:` fields to match, and fixed the couple of places that referenced the old filenames (`notify-e2e.sh`, `test/e2e/README.md`).

## Verified

245 tests pass in `dt-eval-cli`. `tsc --noEmit` and the build are clean.