### PR TITLE
fix(dt-eval-cli): bump dt-eval-lib to 0.0.15-alpha

### DIFF
--- a/dt-eval-cli/package-lock.json
+++ b/dt-eval-cli/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
         "@aws-sdk/client-bedrock-runtime": "^3.0.0",
-        "@dynatrace-oss/dt-eval-lib": "^0.0.14-alpha",
+        "@dynatrace-oss/dt-eval-lib": "^0.0.15-alpha",
         "@google/genai": "^1.0.0",
         "@inquirer/prompts": "^7.10.1",
         "@types/figlet": "^1.7.0",
@@ -33,47 +33,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "../dt-eval-lib": {
-      "name": "@dynatrace-oss/dt-eval-lib",
-      "version": "0.0.12-alpha",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "devDependencies": {
-        "@anthropic-ai/sdk": "^0.32.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1031.0",
-        "@biomejs/biome": "2.4.9",
-        "@google/genai": "^1.0.0",
-        "dotenv": "^17.3.1",
-        "openai": "^4.73.0",
-        "tsup": "^8.3.0",
-        "tsx": "^4.21.0",
-        "typescript": "^5.7.0",
-        "vitest": "^4.1.4"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@anthropic-ai/sdk": "^0.32.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.0.0",
-        "@google/genai": "^1.0.0",
-        "openai": "^4.73.0"
-      },
-      "peerDependenciesMeta": {
-        "@anthropic-ai/sdk": {
-          "optional": true
-        },
-        "@aws-sdk/client-bedrock-runtime": {
-          "optional": true
-        },
-        "@google/genai": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -827,9 +786,9 @@
       }
     },
     "node_modules/@dynatrace-oss/dt-eval-lib": {
-      "version": "0.0.14-alpha",
-      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.14-alpha.tgz",
-      "integrity": "sha512-/w2otxiPKpMB+iqmzS1+UzeCA3X1iNCpX5+NzqFssLyDqu+lY+TvlvbfuO0Ton3+xTjofgyEkVSqA0czOc6GxQ==",
+      "version": "0.0.15-alpha",
+      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.15-alpha.tgz",
+      "integrity": "sha512-ow5qBNwWlrvi26/bOGiCyJGZ+mYAhWOy07OZzr6H9n44t+h9lsVK2l4rkaoWT1eW3D8P0j+z8NQE5JKxDJPcwg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
     "@aws-sdk/client-bedrock-runtime": "^3.0.0",
-    "@dynatrace-oss/dt-eval-lib": "^0.0.14-alpha",
+    "@dynatrace-oss/dt-eval-lib": "^0.0.15-alpha",
     "@google/genai": "^1.0.0",
     "@inquirer/prompts": "^7.10.1",
     "@types/figlet": "^1.7.0",


### PR DESCRIPTION
## Summary
- dt-eval-lib released 0.0.15-alpha on 2026-07-24 (#155), but dt-eval-cli's dependency pin was never bumped — `^0.0.14-alpha` doesn't auto-update across patches under SemVer's pre-1.0 rules, so the new lib version sat unused.
- `npm install` also removed a stale `../dt-eval-lib` extraneous entry left over in package-lock.json from an old local override.

## Test plan
- [x] `npm install` in dt-eval-cli resolves `@dynatrace-oss/dt-eval-lib` to `0.0.15-alpha`
- [x] `npm run build` succeeds against the new lib version
- [ ] CI (ci-cli.yml, e2e-pr-checks.yml) green