### PR TITLE
fix: follow-up bugfixes for the E2E CI run

### DIFF
--- a/.github/workflows/live_weekly_e2e.yml
+++ b/.github/workflows/live_weekly_e2e.yml
@@ -82,6 +82,10 @@ jobs:
           # OAuth client-credentials, not a pasted platform token — the suite fetches its own access token (env.ts).
           E2E_DT_OAUTH_CLIENT_ID: ${{ secrets.E2E_DT_OAUTH_CLIENT_ID }}
           E2E_DT_OAUTH_SECRET: ${{ secrets.E2E_DT_OAUTH_SECRET }}
+          # The tenant above is sprint/labs, not production — its OAuth client only exists on
+          # that tier's own SSO, not sso.dynatrace.com (env.ts's default). Override via repo
+          # variable, not a secret: this is a hostname, not a credential.
+          E2E_DT_OAUTH_URL: ${{ vars.E2E_DT_OAUTH_URL || 'https://sso-sprint.dynatracelabs.com/sso/oauth2/token' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}
           SUITE: ${{ inputs.suite }}
@@ -157,6 +161,10 @@ jobs:
           # OAuth client-credentials, not a pasted platform token — the suite fetches its own access token (env.ts).
           E2E_DT_OAUTH_CLIENT_ID: ${{ secrets.E2E_DT_OAUTH_CLIENT_ID }}
           E2E_DT_OAUTH_SECRET: ${{ secrets.E2E_DT_OAUTH_SECRET }}
+          # The tenant above is sprint/labs, not production — its OAuth client only exists on
+          # that tier's own SSO, not sso.dynatrace.com (env.ts's default). Override via repo
+          # variable, not a secret: this is a hostname, not a credential.
+          E2E_DT_OAUTH_URL: ${{ vars.E2E_DT_OAUTH_URL || 'https://sso-sprint.dynatracelabs.com/sso/oauth2/token' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}
         run: npx vitest run suites/evallogic.e2e.test.ts

--- a/.github/workflows/live_weekly_e2e.yml
+++ b/.github/workflows/live_weekly_e2e.yml
@@ -79,7 +79,9 @@ jobs:
           # E2E_-prefixed to avoid falling back to an org-wide secret, and to
           # avoid colliding with the music-agent workflow's own DT_* secrets.
           DT_APPS_ENDPOINT: ${{ secrets.E2E_DT_APPS_ENDPOINT }}
-          DT_API_TOKEN: ${{ secrets.E2E_DT_API_TOKEN }}
+          # OAuth client-credentials, not a pasted platform token — the suite fetches its own access token (env.ts).
+          E2E_DT_OAUTH_CLIENT_ID: ${{ secrets.E2E_DT_OAUTH_CLIENT_ID }}
+          E2E_DT_OAUTH_SECRET: ${{ secrets.E2E_DT_OAUTH_SECRET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}
           SUITE: ${{ inputs.suite }}
@@ -152,7 +154,9 @@ jobs:
         id: run_verdict
         env:
           DT_APPS_ENDPOINT: ${{ secrets.E2E_DT_APPS_ENDPOINT }}
-          DT_API_TOKEN: ${{ secrets.E2E_DT_API_TOKEN }}
+          # OAuth client-credentials, not a pasted platform token — the suite fetches its own access token (env.ts).
+          E2E_DT_OAUTH_CLIENT_ID: ${{ secrets.E2E_DT_OAUTH_CLIENT_ID }}
+          E2E_DT_OAUTH_SECRET: ${{ secrets.E2E_DT_OAUTH_SECRET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.E2E_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_AWS_SECRET_ACCESS_KEY }}
         run: npx vitest run suites/evallogic.e2e.test.ts

--- a/test/e2e/.env.sample
+++ b/test/e2e/.env.sample
@@ -8,11 +8,15 @@
 # Left blank deliberately: the suite skips on an empty value, so an uncopied
 # sample skips cleanly instead of failing on DNS. (Also, this repo is public.)
 DT_APPS_ENDPOINT=
-# dt0s16… or dt0c01…; scopes: storage:spans:read, storage:buckets:read,
-# storage:logs:read, storage:events:read, storage:events:write, storage:metrics:write
+# OAuth client-credentials for the tenant above, not a pasted platform token —
+# env.ts fetches its own access token (client_credentials grant against
+# https://sso.dynatrace.com/sso/oauth2/token, or E2E_DT_OAUTH_URL if set) and
+# hands it to both the suite's own DQL client and the CLI under test.
 # (comment-only lines: loadDotEnv() takes everything after `=` literally, so an
-# inline comment here would become part of the token value instead of staying blank)
-DT_API_TOKEN=
+# inline comment here would become part of the value instead of staying blank)
+E2E_DT_OAUTH_CLIENT_ID=
+E2E_DT_OAUTH_SECRET=
+# E2E_DT_OAUTH_URL=              # override for a non-production SSO
 
 # Judge provider. bedrock is the default and what CI uses; openai, anthropic,
 # azure-openai, gemini and vertex also work — see README for their variables.

--- a/test/e2e/.env.sample
+++ b/test/e2e/.env.sample
@@ -16,7 +16,11 @@ DT_APPS_ENDPOINT=
 # inline comment here would become part of the value instead of staying blank)
 E2E_DT_OAUTH_CLIENT_ID=
 E2E_DT_OAUTH_SECRET=
-# E2E_DT_OAUTH_URL=              # override for a non-production SSO
+# A sprint/labs tenant (DT_APPS_ENDPOINT above) has its own SSO, not
+# sso.dynatrace.com — its OAuth client doesn't exist on production SSO, which
+# fails as "ClientId or clientSecret is not correct" rather than naming the
+# real cause. CI defaults this to sso-sprint for the same reason.
+# E2E_DT_OAUTH_URL=https://sso-sprint.dynatracelabs.com/sso/oauth2/token
 
 # Judge provider. bedrock is the default and what CI uses; openai, anthropic,
 # azure-openai, gemini and vertex also work — see README for their variables.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -103,7 +103,7 @@ failure.
 
 ### Accepted risk: no GitHub environment around the secrets
 
-The four `E2E_*` credentials are plain **repository** secrets, not scoped to a GitHub
+The five `E2E_*` credentials are plain **repository** secrets, not scoped to a GitHub
 environment. `workflow_dispatch` lets the dispatcher choose any ref, and the workflow that
 runs is the one on *that* ref — so anyone with push access can in principle run modified
 workflow code with these secrets in scope, and runner log masking does not survive a

--- a/test/e2e/src/assert.ts
+++ b/test/e2e/src/assert.ts
@@ -10,6 +10,10 @@ const SECRET_ENV_VARS = [
   // Detection for these two only works because they happen to reuse DT_API_TOKEN's value.
   'DT_ORIGIN_API_TOKEN',
   'DT_DESTINATION_API_TOKEN',
+  // Never handed to the CLI under test directly (only the token fetched with them is), but
+  // still a credential in this process's own env.
+  'E2E_DT_OAUTH_CLIENT_ID',
+  'E2E_DT_OAUTH_SECRET',
   'OPENAI_API_KEY',
   'ANTHROPIC_API_KEY',
   'AZURE_OPENAI_API_KEY',

--- a/test/e2e/src/cli.ts
+++ b/test/e2e/src/cli.ts
@@ -100,7 +100,10 @@ export async function runCli(args: string[], options: RunCliOptions = {}): Promi
     }
 
     // Scanned here, at the boundary, so no earlier-throwing assertion can bypass it.
-    assertNoSecrets(result);
+    // DT_API_TOKEN's value comes from a live OAuth fetch (env.ts), handed only to this
+    // child's env — it never reaches this process's own `process.env`, so
+    // `SECRET_ENV_VARS` alone can't find it. Pass the actual value handed to the child.
+    assertNoSecrets(result, env['DT_API_TOKEN'] ? [env['DT_API_TOKEN']] : []);
 
     return result;
   } finally {

--- a/test/e2e/src/config.ts
+++ b/test/e2e/src/config.ts
@@ -191,8 +191,8 @@ export function judgeFromEnv(): JudgeSetup | undefined {
  * replaces the whole block and drops those mappings; spread the baseline's own
  * scope in to change just one field.
  */
-export function baselineConfig(judge: JudgeSetup, overrides: Partial<EvalConfig> = {}): EvalConfig {
-  const { appsEndpoint } = tenant();
+export async function baselineConfig(judge: JudgeSetup, overrides: Partial<EvalConfig> = {}): Promise<EvalConfig> {
+  const { appsEndpoint } = await tenant();
 
   return {
     schemaVersion: 2,
@@ -222,7 +222,7 @@ export function baselineConfig(judge: JudgeSetup, overrides: Partial<EvalConfig>
 }
 
 /** Tenant + judge credentials for a CLI invocation. */
-export function baselineEnv(judge: JudgeSetup): Record<string, string> {
-  const { appsEndpoint, apiToken } = tenant();
+export async function baselineEnv(judge: JudgeSetup): Promise<Record<string, string>> {
+  const { appsEndpoint, apiToken } = await tenant();
   return { ...tenantCliEnv(appsEndpoint, apiToken), ...judge.env };
 }

--- a/test/e2e/src/env.ts
+++ b/test/e2e/src/env.ts
@@ -69,7 +69,8 @@ export function missingRequiredVars(): string[] {
   loadDotEnv();
   const missing: string[] = [];
   if (!tenantHost()) missing.push(TENANT_HOST_VARS.join(' or '));
-  if (!process.env['DT_API_TOKEN']) missing.push('DT_API_TOKEN');
+  if (!process.env['E2E_DT_OAUTH_CLIENT_ID']) missing.push('E2E_DT_OAUTH_CLIENT_ID');
+  if (!process.env['E2E_DT_OAUTH_SECRET']) missing.push('E2E_DT_OAUTH_SECRET');
   return missing;
 }
 
@@ -117,12 +118,78 @@ export function dtHttpTimeoutMs(): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 60_000;
 }
 
-/** Tenant + token the suite reads spans from. */
-export function tenant(): { appsEndpoint: string; apiToken: string } {
+/** SSO token endpoint for the client-credentials grant. Overridable for a non-production SSO; defaults to the real one. */
+function oauthTokenUrl(): string {
+  return envOr('E2E_DT_OAUTH_URL', 'https://sso.dynatrace.com/sso/oauth2/token');
+}
+
+/** Everything the suite's own DQL reads need, plus what `run --ci` writes for the CLI under test. */
+const OAUTH_SCOPES = [
+  'storage:spans:read',
+  'storage:buckets:read',
+  'storage:events:read',
+  'storage:bizevents:read',
+  'storage:events:write',
+  'storage:metrics:write',
+  'storage:logs:read',
+  'storage:bucket-definitions:read',
+  'storage:entities:read',
+  'storage:metrics:read',
+].join(' ');
+
+interface OauthTokenResponse {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+}
+
+let cachedAccessToken: Promise<string> | undefined;
+
+/**
+ * Client-credentials grant against Dynatrace SSO — replaces a pasted platform
+ * token (`DT_API_TOKEN`). Cached for the process lifetime: one token per
+ * suite run, not one per DQL query or CLI invocation. `authScheme` in
+ * dynatrace.ts already sends non-`dt0c*` tokens as `Bearer`, so the fetched
+ * token needs no special-casing on the read side; `tenantCliEnv` (cli.ts)
+ * hands the same token to the CLI under test as `DT_API_TOKEN`.
+ */
+function oauthAccessToken(): Promise<string> {
+  if (!cachedAccessToken) cachedAccessToken = fetchOauthAccessToken();
+  return cachedAccessToken;
+}
+
+async function fetchOauthAccessToken(): Promise<string> {
+  const url = oauthTokenUrl();
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: mustEnv('E2E_DT_OAUTH_CLIENT_ID'),
+    client_secret: mustEnv('E2E_DT_OAUTH_SECRET'),
+    scope: OAUTH_SCOPES,
+  });
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  const payload = (await response.json().catch(() => ({}))) as OauthTokenResponse;
+
+  if (!response.ok || !payload.access_token) {
+    throw new Error(
+      `OAuth token request to ${new URL(url).host} failed (${response.status}): ` +
+        `${payload.error ?? response.statusText}` +
+        `${payload.error_description ? ` — ${payload.error_description}` : ''}`,
+    );
+  }
+  return payload.access_token;
+}
+
+/** Tenant + token the suite reads spans from and hands to the CLI under test. */
+export async function tenant(): Promise<{ appsEndpoint: string; apiToken: string }> {
   const host = tenantHost();
   if (!host) throw new Error(`required env var not set: ${TENANT_HOST_VARS.join(' or ')}`);
   return {
     appsEndpoint: host.replace(/\/+$/, ''),
-    apiToken: mustEnv('DT_API_TOKEN'),
+    apiToken: await oauthAccessToken(),
   };
 }

--- a/test/e2e/src/env.ts
+++ b/test/e2e/src/env.ts
@@ -139,26 +139,47 @@ const OAUTH_SCOPES = [
 
 interface OauthTokenResponse {
   access_token?: string;
+  expires_in?: number;
   error?: string;
   error_description?: string;
 }
 
-let cachedAccessToken: Promise<string> | undefined;
+interface CachedToken {
+  token: string;
+  expiresAt: number;
+}
+
+/** Refetch this long before the token's real expiry, so a call mid-suite doesn't race an in-flight expiry. */
+const TOKEN_REFRESH_MARGIN_MS = 60_000;
+
+/** Assumed lifetime when the response omits `expires_in` — conservative, so a missing field fails safe toward refetching. */
+const DEFAULT_TOKEN_TTL_MS = 300_000;
+
+let cachedToken: CachedToken | undefined;
+let pendingFetch: Promise<CachedToken> | undefined;
 
 /**
  * Client-credentials grant against Dynatrace SSO — replaces a pasted platform
- * token (`DT_API_TOKEN`). Cached for the process lifetime: one token per
- * suite run, not one per DQL query or CLI invocation. `authScheme` in
- * dynatrace.ts already sends non-`dt0c*` tokens as `Bearer`, so the fetched
- * token needs no special-casing on the read side; `tenantCliEnv` (cli.ts)
- * hands the same token to the CLI under test as `DT_API_TOKEN`.
+ * token (`DT_API_TOKEN`). Cached until shortly before it expires, then
+ * refetched on demand — not just once per suite run, since some suites now
+ * run long enough (`fixtures.ts`'s `runCiTimeoutMs`) to outlast a short-lived
+ * token. `authScheme` in dynatrace.ts already sends non-`dt0c*` tokens as
+ * `Bearer`, so the fetched token needs no special-casing on the read side;
+ * `tenantCliEnv` (cli.ts) hands the same token to the CLI under test as
+ * `DT_API_TOKEN`.
  */
-function oauthAccessToken(): Promise<string> {
-  if (!cachedAccessToken) cachedAccessToken = fetchOauthAccessToken();
-  return cachedAccessToken;
+async function oauthAccessToken(): Promise<string> {
+  if (cachedToken && cachedToken.expiresAt > Date.now()) return cachedToken.token;
+  if (!pendingFetch) {
+    pendingFetch = fetchOauthAccessToken().finally(() => {
+      pendingFetch = undefined;
+    });
+  }
+  cachedToken = await pendingFetch;
+  return cachedToken.token;
 }
 
-async function fetchOauthAccessToken(): Promise<string> {
+async function fetchOauthAccessToken(): Promise<CachedToken> {
   const url = oauthTokenUrl();
   const body = new URLSearchParams({
     grant_type: 'client_credentials',
@@ -167,11 +188,28 @@ async function fetchOauthAccessToken(): Promise<string> {
     scope: OAUTH_SCOPES,
   });
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-  });
+  // Same fail-fast philosophy as dynatrace.ts's fetchWithTimeout: a hung SSO host
+  // should surface as a named OAuth failure, not an opaque "Test timed out".
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), dtHttpTimeoutMs());
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+      signal: controller.signal,
+    });
+  } catch (err) {
+    const cause = (err as { cause?: Error }).cause;
+    throw new Error(
+      `OAuth token request to ${new URL(url).host} failed: ${cause?.message ?? (err as Error).message}`,
+      { cause: err },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+
   const payload = (await response.json().catch(() => ({}))) as OauthTokenResponse;
 
   if (!response.ok || !payload.access_token) {
@@ -181,7 +219,9 @@ async function fetchOauthAccessToken(): Promise<string> {
         `${payload.error_description ? ` — ${payload.error_description}` : ''}`,
     );
   }
-  return payload.access_token;
+
+  const ttlMs = payload.expires_in ? payload.expires_in * 1000 : DEFAULT_TOKEN_TTL_MS;
+  return { token: payload.access_token, expiresAt: Date.now() + ttlMs - TOKEN_REFRESH_MARGIN_MS };
 }
 
 /** Tenant + token the suite reads spans from and hands to the CLI under test. */

--- a/test/e2e/src/fixtures.ts
+++ b/test/e2e/src/fixtures.ts
@@ -96,6 +96,18 @@ const DURATION_UNIT_HOURS: Record<string, number> = { s: 1 / 3600, m: 1 / 60, h:
 /** Upper bound on {@link fixtureLookback}: one week, ~7x a nightly seeding (32 spans/night). */
 const MAX_LOOKBACK_HOURS = 24 * 7;
 
+/** DQL duration string ("24h") → hours, shared by {@link fixtureLookback} and {@link runCiTimeoutMs}. */
+function parseDurationHours(value: string, envVarName: string): number {
+  // Validated since it's concatenated into DQL and operator-supplied.
+  const match = /^(\d+)([smhd])$/.exec(value);
+  if (!match) {
+    throw new Error(
+      `${envVarName} must be a DQL duration like 24h or 7d, got ${JSON.stringify(value)}`,
+    );
+  }
+  return Number(match[1]) * DURATION_UNIT_HOURS[match[2]!]!;
+}
+
 /**
  * How far back to look for fixture spans. The suite doesn't seed, so this must
  * cover the gap since the last seeding run. Capped at {@link MAX_LOOKBACK_HOURS}
@@ -106,14 +118,7 @@ const MAX_LOOKBACK_HOURS = 24 * 7;
  */
 export function fixtureLookback(): string {
   const value = envOr('E2E_FIXTURE_LOOKBACK', '24h');
-  // Validated since it's concatenated into DQL and operator-supplied.
-  const match = /^(\d+)([smhd])$/.exec(value);
-  if (!match) {
-    throw new Error(
-      `E2E_FIXTURE_LOOKBACK must be a DQL duration like 24h or 7d, got ${JSON.stringify(value)}`,
-    );
-  }
-  const hours = Number(match[1]) * DURATION_UNIT_HOURS[match[2]!]!;
+  const hours = parseDurationHours(value, 'E2E_FIXTURE_LOOKBACK');
   if (hours > MAX_LOOKBACK_HOURS) {
     throw new Error(
       `E2E_FIXTURE_LOOKBACK must be at most ${MAX_LOOKBACK_HOURS}h (got ${JSON.stringify(value)}) — ` +
@@ -121,6 +126,33 @@ export function fixtureLookback(): string {
     );
   }
   return value;
+}
+
+/** Same 32-spans/night rate {@link MAX_LOOKBACK_HOURS} is sized against. */
+const SPANS_PER_NIGHT = 32;
+
+/** `judge.concurrency`'s default (`dt-eval-cli/src/config/defaults.ts`); the suite doesn't override it. */
+const JUDGE_CONCURRENCY = 5;
+
+/** Generous per-call ceiling covering judge latency and retries, for budgeting only — not a real SLA. */
+const JUDGE_CALL_CEILING_MS = 10_000;
+
+/** Fixed cost of a `run --ci` invocation outside judge calls: CLI startup, span fetch, tenant write. */
+const RUN_OVERHEAD_MS = 60_000;
+
+/**
+ * Budget for a `run --ci` invocation covering every span in the *current*
+ * {@link fixtureLookback} window (i.e. `baselineConfig`'s uncapped `sampling:
+ * latest`). A hardcoded timeout sized for the 24h default falls over the
+ * moment a `workflow_dispatch` widens `E2E_FIXTURE_LOOKBACK` toward
+ * {@link MAX_LOOKBACK_HOURS} — more spans means more sequential judge-call
+ * batches at `JUDGE_CONCURRENCY`, not just more wall-clock variance.
+ */
+export function runCiTimeoutMs(): number {
+  const hours = parseDurationHours(fixtureLookback(), 'E2E_FIXTURE_LOOKBACK');
+  const expectedSpans = (hours / 24) * SPANS_PER_NIGHT;
+  const batches = Math.ceil(expectedSpans / JUDGE_CONCURRENCY);
+  return RUN_OVERHEAD_MS + batches * JUDGE_CALL_CEILING_MS;
 }
 
 /**

--- a/test/e2e/src/fixtures.ts
+++ b/test/e2e/src/fixtures.ts
@@ -134,8 +134,13 @@ const SPANS_PER_NIGHT = 32;
 /** `judge.concurrency`'s default (`dt-eval-cli/src/config/defaults.ts`); the suite doesn't override it. */
 const JUDGE_CONCURRENCY = 5;
 
-/** Generous per-call ceiling covering judge latency and retries, for budgeting only — not a real SLA. */
-const JUDGE_CALL_CEILING_MS = 10_000;
+/**
+ * Worst case for one judge call: `judge.timeout` (30s) × one original attempt plus
+ * `judge.maxRetries` (2) retries — both defaults, `dt-eval-cli/src/config/defaults.ts`,
+ * which the suite doesn't override. A batch's wall time is bounded by its slowest call,
+ * not their sum, so this is also the per-batch ceiling. For budgeting only — not a real SLA.
+ */
+const JUDGE_CALL_CEILING_MS = 90_000;
 
 /** Fixed cost of a `run --ci` invocation outside judge calls: CLI startup, span fetch, tenant write. */
 const RUN_OVERHEAD_MS = 60_000;

--- a/test/e2e/suites/contract.e2e.test.ts
+++ b/test/e2e/suites/contract.e2e.test.ts
@@ -19,10 +19,10 @@ import {
 } from '../src/fixtures.js';
 
 /** Why a missing fixture span is usually not a dt-evals problem — most likely the wrong tenant, checked first. */
-function seedingHint(): string {
+async function seedingHint(): Promise<string> {
   // Redacted: names the tenant host, and reaches a public Actions log.
   return redactSecrets([
-    `no "${FIXTURE_SERVICE_NAME}" spans in the last ${fixtureLookback()} on ${tenant().appsEndpoint}.`,
+    `no "${FIXTURE_SERVICE_NAME}" spans in the last ${fixtureLookback()} on ${(await tenant()).appsEndpoint}.`,
     `This suite does not seed — the fixtures app in dynatrace-ai-agent-instrumentation-examples does.`,
     `Check, in order:`,
     `  1. DT_APPS_ENDPOINT points at the tenant that repo's CI seeds (not your usual dt-evals tenant);`,
@@ -46,7 +46,7 @@ describe.skipIf(!e2eEnabled())('fixture span contract', () => {
   let attributeCounts: DqlRecord;
 
   beforeAll(async () => {
-    const { appsEndpoint, apiToken } = tenant();
+    const { appsEndpoint, apiToken } = await tenant();
     client = new DynatraceClient(appsEndpoint, apiToken);
 
     // One aggregate query for every attribute; countIf means a partially-correct dataset can't pass by luck.
@@ -65,11 +65,11 @@ fetch spans, from:now() - ${fixtureLookback()}
     reference = countIf(isNotNull(${FIXTURE_ATTRIBUTES.reference})),
     conversation = countIf(isNotNull(${FIXTURE_ATTRIBUTES.conversationId}))`);
 
-    assertRecords(records, `fixture spans — ${seedingHint()}`);
+    assertRecords(records, `fixture spans — ${await seedingHint()}`);
     attributeCounts = records[0]!;
 
     // Fail here, not per-test: an empty dataset makes every count below zero too — one cause, not four symptoms.
-    if (Number(attributeCounts['total'] ?? 0) === 0) throw new Error(seedingHint());
+    if (Number(attributeCounts['total'] ?? 0) === 0) throw new Error(await seedingHint());
   });
 
   /** Read an aggregate count. DQL returns longs as strings. */

--- a/test/e2e/suites/evallogic.e2e.test.ts
+++ b/test/e2e/suites/evallogic.e2e.test.ts
@@ -28,7 +28,7 @@ describe.skipIf(!e2eEnabled() || !judge)('eval logic — verdict direction', () 
   const targetTrace = new Map<string, string>();
 
   beforeAll(async () => {
-    const { appsEndpoint, apiToken } = tenant();
+    const { appsEndpoint, apiToken } = await tenant();
     client = new DynatraceClient(appsEndpoint, apiToken);
 
     // Resolved before the run so a late-appearing span doesn't look like an evaluator failure.
@@ -46,7 +46,7 @@ describe.skipIf(!e2eEnabled() || !judge)('eval logic — verdict direction', () 
 
   it('flags the toxic conversation and passes the clean one', async () => {
     // Spread the baseline's own scope, since overrides is a shallow merge.
-    const base = baselineConfig(judge!);
+    const base = await baselineConfig(judge!);
     const config = {
       ...base,
       scope: {
@@ -58,7 +58,7 @@ describe.skipIf(!e2eEnabled() || !judge)('eval logic — verdict direction', () 
 
     const result = await runCli(['run', '--ci'], {
       configYaml: toConfigFile(config),
-      env: baselineEnv(judge!),
+      env: await baselineEnv(judge!),
       timeoutMs: 300_000,
     });
 

--- a/test/e2e/suites/evallogic.e2e.test.ts
+++ b/test/e2e/suites/evallogic.e2e.test.ts
@@ -18,11 +18,22 @@ import {
   conversationId,
   fixtureLookback,
   lastTurnTraceQuery,
+  runCiTimeoutMs,
 } from '../src/fixtures.js';
 
 const judge = judgeFromEnv();
+const enabled = e2eEnabled() && !!judge;
 
-describe.skipIf(!e2eEnabled() || !judge)('eval logic — verdict direction', () => {
+/**
+ * Computed once, only when the suite will actually run — see the identical guard and
+ * rationale in run.e2e.test.ts. Unused (0) when `enabled` is false.
+ */
+const CI_TIMEOUT_MS = enabled ? runCiTimeoutMs() : 0;
+
+/** Above the CLI's own {@link runCiTimeoutMs} budget: the tenant-poll step (120s) plus slack, so a slow real run gets a precise timeout message instead of a bare "Test timed out". */
+const TEST_TIMEOUT_MARGIN_MS = 300_000;
+
+describe.skipIf(!enabled)('eval logic — verdict direction', () => {
   let client: DynatraceClient;
   /** caseName -> trace id of that case's most recent final turn. */
   const targetTrace = new Map<string, string>();
@@ -59,7 +70,7 @@ describe.skipIf(!e2eEnabled() || !judge)('eval logic — verdict direction', () 
     const result = await runCli(['run', '--ci'], {
       configYaml: toConfigFile(config),
       env: await baselineEnv(judge!),
-      timeoutMs: 300_000,
+      timeoutMs: CI_TIMEOUT_MS,
     });
 
     assertExitCode(result, 0);
@@ -114,6 +125,5 @@ describe.skipIf(!e2eEnabled() || !judge)('eval logic — verdict direction', () 
 
       expect(label, `${caseName} should be judged "${expected}"`).toBe(expected);
     }
-    // 600s, not 420s: zero headroom risks a bare "Test timed out" instead of a precise message.
-  }, 600_000);
+  }, CI_TIMEOUT_MS + TEST_TIMEOUT_MARGIN_MS);
 });

--- a/test/e2e/suites/run.e2e.test.ts
+++ b/test/e2e/suites/run.e2e.test.ts
@@ -43,8 +43,8 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
   describe('--dry-run', () => {
     it('fetches and prepares, then writes nothing at all', async () => {
       const result = await runCli(['run', '--dry-run', '--ci'], {
-        configYaml: toConfigFile(baselineConfig(judge!)),
-        env: baselineEnv(judge!),
+        configYaml: toConfigFile(await baselineConfig(judge!)),
+        env: await baselineEnv(judge!),
         captureHomeFiles: [RUNS_LOG],
       });
 
@@ -65,8 +65,8 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
     it('does not call the judge', async () => {
       // Pins the better-than-documented behaviour: a dry run that bills a judge would be a surprise.
       const result = await runCli(['run', '--dry-run', '--ci'], {
-        configYaml: toConfigFile(baselineConfig(judge!)),
-        env: baselineEnv(judge!),
+        configYaml: toConfigFile(await baselineConfig(judge!)),
+        env: await baselineEnv(judge!),
       });
 
       assertExitCode(result, 0);
@@ -75,11 +75,13 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
 
     it('uses a needle a real run actually prints', async () => {
       // Positive control for the assertOutputLacks case above.
+      const base = await baselineConfig(judge!);
       const result = await runCli(['run', '--ci'], {
-        configYaml: toConfigFile(
-          baselineConfig(judge!, { scope: { ...baselineConfig(judge!).scope, sampling: { strategy: 'latest', count: 1 } } }),
-        ),
-        env: baselineEnv(judge!),
+        configYaml: toConfigFile({
+          ...base,
+          scope: { ...base.scope, sampling: { strategy: 'latest', count: 1 } },
+        }),
+        env: await baselineEnv(judge!),
         timeoutMs: 180_000,
       });
 
@@ -91,8 +93,8 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
   describe('--ci', () => {
     it('prints a machine-readable result, writes to the tenant, and logs the run', async () => {
       const result = await runCli(['run', '--ci'], {
-        configYaml: toConfigFile(baselineConfig(judge!)),
-        env: baselineEnv(judge!),
+        configYaml: toConfigFile(await baselineConfig(judge!)),
+        env: await baselineEnv(judge!),
         captureHomeFiles: [RUNS_LOG],
         timeoutMs: runCiTimeoutMs(),
       });
@@ -127,8 +129,8 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
     it('lands the results in the destination tenant, queryable and correctly shaped', async () => {
       // The round trip: not "the CLI said it wrote results" but "the tenant returns them".
       const result = await runCli(['run', '--ci'], {
-        configYaml: toConfigFile(baselineConfig(judge!)),
-        env: baselineEnv(judge!),
+        configYaml: toConfigFile(await baselineConfig(judge!)),
+        env: await baselineEnv(judge!),
         timeoutMs: runCiTimeoutMs(),
       });
       assertExitCode(result, 0);
@@ -140,7 +142,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
         'the run wrote no results, so there is no round trip to verify — check the fixtures were seeded',
       ).toBeGreaterThan(0);
 
-      const { appsEndpoint, apiToken } = tenant();
+      const { appsEndpoint, apiToken } = await tenant();
       const client = new DynatraceClient(appsEndpoint, apiToken);
 
       const records = await client.pollUntilRecords(
@@ -178,13 +180,13 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
 
     it('writes the prompt only when --store-evaluated-prompt asks for it', async () => {
       // Positive control for the privacy assertion above.
-      const base = baselineConfig(judge!);
+      const base = await baselineConfig(judge!);
       const result = await runCli(['run', '--ci', '--store-evaluated-prompt'], {
         configYaml: toConfigFile({
           ...base,
           scope: { ...base.scope, sampling: { strategy: 'latest', count: 1 } },
         }),
-        env: baselineEnv(judge!),
+        env: await baselineEnv(judge!),
         timeoutMs: 180_000,
       });
 
@@ -192,7 +194,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
       const ci = parseJsonStdout(result) as CiResult;
       expect(ci.resultsWritten).toBeGreaterThan(0);
 
-      const { appsEndpoint, apiToken } = tenant();
+      const { appsEndpoint, apiToken } = await tenant();
       const client = new DynatraceClient(appsEndpoint, apiToken);
 
       const records = await client.pollUntilRecords(
@@ -219,8 +221,8 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
 
     it('exits 1 in --ci', async () => {
       const result = await runCli(['run', '--ci'], {
-        configYaml: toConfigFile(baselineConfig(judge!, alwaysBreaches)),
-        env: baselineEnv(judge!),
+        configYaml: toConfigFile(await baselineConfig(judge!, alwaysBreaches)),
+        env: await baselineEnv(judge!),
         timeoutMs: runCiTimeoutMs(),
       });
 
@@ -233,8 +235,8 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
 
     it('warns but exits 0 in the default mode', async () => {
       const result = await runCli(['run'], {
-        configYaml: toConfigFile(baselineConfig(judge!, alwaysBreaches)),
-        env: baselineEnv(judge!),
+        configYaml: toConfigFile(await baselineConfig(judge!, alwaysBreaches)),
+        env: await baselineEnv(judge!),
         timeoutMs: runCiTimeoutMs(),
       });
 

--- a/test/e2e/suites/run.e2e.test.ts
+++ b/test/e2e/suites/run.e2e.test.ts
@@ -18,11 +18,14 @@ import { runCli } from '../src/cli.js';
 import { baselineConfig, baselineEnv, judgeFromEnv, toConfigFile } from '../src/config.js';
 import { DynatraceClient } from '../src/dynatrace.js';
 import { e2eEnabled, tenant } from '../src/env.js';
-import { runService } from '../src/fixtures.js';
+import { runCiTimeoutMs, runService } from '../src/fixtures.js';
 
 const judge = judgeFromEnv();
 
 const RUNS_LOG = '.dt-eval/runs.json';
+
+/** Margin above the CLI's own {@link runCiTimeoutMs} budget for vitest's outer test timeout: assertions plus a little slack. */
+const TEST_TIMEOUT_MARGIN_MS = 20_000;
 
 /** Shape of the JSON `run --ci` prints. */
 interface CiResult {
@@ -91,7 +94,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
         configYaml: toConfigFile(baselineConfig(judge!)),
         env: baselineEnv(judge!),
         captureHomeFiles: [RUNS_LOG],
-        timeoutMs: 180_000,
+        timeoutMs: runCiTimeoutMs(),
       });
 
       assertExitCode(result, 0);
@@ -119,14 +122,14 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
       expect(entry!['spansEvaluated']).toBe(ci.spansEvaluated);
 
       assertNoSecrets(result);
-    }, 200_000);
+    }, runCiTimeoutMs() + TEST_TIMEOUT_MARGIN_MS);
 
     it('lands the results in the destination tenant, queryable and correctly shaped', async () => {
       // The round trip: not "the CLI said it wrote results" but "the tenant returns them".
       const result = await runCli(['run', '--ci'], {
         configYaml: toConfigFile(baselineConfig(judge!)),
         env: baselineEnv(judge!),
-        timeoutMs: 180_000,
+        timeoutMs: runCiTimeoutMs(),
       });
       assertExitCode(result, 0);
       const ci = parseJsonStdout(result) as CiResult;
@@ -171,7 +174,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
         'the privacy check scanned no records at all, so leaked=0 means nothing',
       ).toBeGreaterThan(0);
       expect(Number(withContent[0]?.['leaked'] ?? 0)).toBe(0);
-    }, 480_000);
+    }, runCiTimeoutMs() + 300_000);
 
     it('writes the prompt only when --store-evaluated-prompt asks for it', async () => {
       // Positive control for the privacy assertion above.
@@ -218,7 +221,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
       const result = await runCli(['run', '--ci'], {
         configYaml: toConfigFile(baselineConfig(judge!, alwaysBreaches)),
         env: baselineEnv(judge!),
-        timeoutMs: 180_000,
+        timeoutMs: runCiTimeoutMs(),
       });
 
       assertExitCode(result, 1);
@@ -226,19 +229,19 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
       expect(ci.thresholdBreaches.length).toBeGreaterThan(0);
       expect(ci.errors, `judge errors: ${JSON.stringify(ci.errorSamples)}`).toBe(0);
       assertNoSecrets(result);
-    }, 200_000);
+    }, runCiTimeoutMs() + TEST_TIMEOUT_MARGIN_MS);
 
     it('warns but exits 0 in the default mode', async () => {
       const result = await runCli(['run'], {
         configYaml: toConfigFile(baselineConfig(judge!, alwaysBreaches)),
         env: baselineEnv(judge!),
-        timeoutMs: 180_000,
+        timeoutMs: runCiTimeoutMs(),
       });
 
       assertExitCode(result, 0);
       assertOutputContains(result, 'Threshold breaches:');
       assertOutputContains(result, 'Evaluation results:');
       assertNoSecrets(result);
-    }, 200_000);
+    }, runCiTimeoutMs() + TEST_TIMEOUT_MARGIN_MS);
   });
 });

--- a/test/e2e/suites/run.e2e.test.ts
+++ b/test/e2e/suites/run.e2e.test.ts
@@ -21,11 +21,20 @@ import { e2eEnabled, tenant } from '../src/env.js';
 import { runCiTimeoutMs, runService } from '../src/fixtures.js';
 
 const judge = judgeFromEnv();
+const enabled = e2eEnabled() && !!judge;
 
 const RUNS_LOG = '.dt-eval/runs.json';
 
 /** Margin above the CLI's own {@link runCiTimeoutMs} budget for vitest's outer test timeout: assertions plus a little slack. */
 const TEST_TIMEOUT_MARGIN_MS = 20_000;
+
+/**
+ * Computed once, only when the suite will actually run. `describe.skipIf`'s factory still
+ * executes during collection even when skipped, so calling `runCiTimeoutMs()` unconditionally
+ * would make a malformed `E2E_FIXTURE_LOOKBACK` crash collection for contributors who have no
+ * tenant credentials and expect a clean skip. Unused (0) when `enabled` is false.
+ */
+const CI_TIMEOUT_MS = enabled ? runCiTimeoutMs() : 0;
 
 /** Shape of the JSON `run --ci` prints. */
 interface CiResult {
@@ -39,7 +48,7 @@ interface CiResult {
   evaluatorResults: Array<{ metric: string; successes: number; total: number; errors: number }>;
 }
 
-describe.skipIf(!e2eEnabled() || !judge)('run', () => {
+describe.skipIf(!enabled)('run', () => {
   describe('--dry-run', () => {
     it('fetches and prepares, then writes nothing at all', async () => {
       const result = await runCli(['run', '--dry-run', '--ci'], {
@@ -96,7 +105,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
         configYaml: toConfigFile(await baselineConfig(judge!)),
         env: await baselineEnv(judge!),
         captureHomeFiles: [RUNS_LOG],
-        timeoutMs: runCiTimeoutMs(),
+        timeoutMs: CI_TIMEOUT_MS,
       });
 
       assertExitCode(result, 0);
@@ -124,14 +133,14 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
       expect(entry!['spansEvaluated']).toBe(ci.spansEvaluated);
 
       assertNoSecrets(result);
-    }, runCiTimeoutMs() + TEST_TIMEOUT_MARGIN_MS);
+    }, CI_TIMEOUT_MS + TEST_TIMEOUT_MARGIN_MS);
 
     it('lands the results in the destination tenant, queryable and correctly shaped', async () => {
       // The round trip: not "the CLI said it wrote results" but "the tenant returns them".
       const result = await runCli(['run', '--ci'], {
         configYaml: toConfigFile(await baselineConfig(judge!)),
         env: await baselineEnv(judge!),
-        timeoutMs: runCiTimeoutMs(),
+        timeoutMs: CI_TIMEOUT_MS,
       });
       assertExitCode(result, 0);
       const ci = parseJsonStdout(result) as CiResult;
@@ -176,7 +185,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
         'the privacy check scanned no records at all, so leaked=0 means nothing',
       ).toBeGreaterThan(0);
       expect(Number(withContent[0]?.['leaked'] ?? 0)).toBe(0);
-    }, runCiTimeoutMs() + 300_000);
+    }, CI_TIMEOUT_MS + 300_000);
 
     it('writes the prompt only when --store-evaluated-prompt asks for it', async () => {
       // Positive control for the privacy assertion above.
@@ -223,7 +232,7 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
       const result = await runCli(['run', '--ci'], {
         configYaml: toConfigFile(await baselineConfig(judge!, alwaysBreaches)),
         env: await baselineEnv(judge!),
-        timeoutMs: runCiTimeoutMs(),
+        timeoutMs: CI_TIMEOUT_MS,
       });
 
       assertExitCode(result, 1);
@@ -231,19 +240,19 @@ describe.skipIf(!e2eEnabled() || !judge)('run', () => {
       expect(ci.thresholdBreaches.length).toBeGreaterThan(0);
       expect(ci.errors, `judge errors: ${JSON.stringify(ci.errorSamples)}`).toBe(0);
       assertNoSecrets(result);
-    }, runCiTimeoutMs() + TEST_TIMEOUT_MARGIN_MS);
+    }, CI_TIMEOUT_MS + TEST_TIMEOUT_MARGIN_MS);
 
     it('warns but exits 0 in the default mode', async () => {
       const result = await runCli(['run'], {
         configYaml: toConfigFile(await baselineConfig(judge!, alwaysBreaches)),
         env: await baselineEnv(judge!),
-        timeoutMs: runCiTimeoutMs(),
+        timeoutMs: CI_TIMEOUT_MS,
       });
 
       assertExitCode(result, 0);
       assertOutputContains(result, 'Threshold breaches:');
       assertOutputContains(result, 'Evaluation results:');
       assertNoSecrets(result);
-    }, runCiTimeoutMs() + TEST_TIMEOUT_MARGIN_MS);
+    }, CI_TIMEOUT_MS + TEST_TIMEOUT_MARGIN_MS);
   });
 });

--- a/test/e2e/suites/tenant.e2e.test.ts
+++ b/test/e2e/suites/tenant.e2e.test.ts
@@ -6,7 +6,7 @@ import { e2eEnabled, tenant } from '../src/env.js';
 
 describe.skipIf(!e2eEnabled())('tenant reachability', () => {
   it('executes a DQL query against the configured tenant', async () => {
-    const { appsEndpoint, apiToken } = tenant();
+    const { appsEndpoint, apiToken } = await tenant();
     const client = new DynatraceClient(appsEndpoint, apiToken);
 
     // Not asserting on the records — an idle tenant legitimately returns
@@ -18,7 +18,7 @@ describe.skipIf(!e2eEnabled())('tenant reachability', () => {
   });
 
   it('rejects a bad token rather than silently returning nothing', async () => {
-    const { appsEndpoint } = tenant();
+    const { appsEndpoint } = await tenant();
     const client = new DynatraceClient(appsEndpoint, 'dt0c01.INVALID.INVALID');
 
     // PermanentQueryError specifically — a bare toThrow() would also pass on a DNS failure or 500.

--- a/test/e2e/suites/validate.e2e.test.ts
+++ b/test/e2e/suites/validate.e2e.test.ts
@@ -41,8 +41,8 @@ const PROBE_FAILURE: Record<keyof typeof PROBE_SUCCESS, string> = {
 describe.skipIf(!e2eEnabled() || !judge)('validate — happy path', () => {
   it('passes every probe against a real tenant and a real provider', async () => {
     const result = await runCli(['validate'], {
-      configYaml: toConfigFile(baselineConfig(judge!)),
-      env: baselineEnv(judge!),
+      configYaml: toConfigFile(await baselineConfig(judge!)),
+      env: await baselineEnv(judge!),
     });
 
     // Before the exit code: a named failure says which probe regressed.
@@ -87,7 +87,7 @@ describe.skipIf(!e2eEnabled())('validate — failure paths', () => {
     const result = await runCli(['validate'], {
       configYaml: toConfigFile({
         schemaVersion: 2,
-        dynatrace: { environmentUrl: tenant().appsEndpoint },
+        dynatrace: { environmentUrl: (await tenant()).appsEndpoint },
         judge: { provider: 'openai' },
         scope: { since: '1h' },
         metrics: { enabled: ['toxicity'] },
@@ -100,15 +100,17 @@ describe.skipIf(!e2eEnabled())('validate — failure paths', () => {
   });
 
   it('exits 1 and reports a connection failure on a rejected tenant token', async () => {
+    const { appsEndpoint } = await tenant();
+
     const result = await runCli(['validate'], {
       configYaml: toConfigFile({
         schemaVersion: 2,
-        dynatrace: { environmentUrl: tenant().appsEndpoint },
+        dynatrace: { environmentUrl: appsEndpoint },
         judge: { provider: 'openai' },
         scope: { since: '1h' },
         metrics: { enabled: ['toxicity'] },
       }),
-      env: { DT_ENV_URL: tenant().appsEndpoint, DT_API_TOKEN: 'dt0c01.INVALID.INVALID' },
+      env: { DT_ENV_URL: appsEndpoint, DT_API_TOKEN: 'dt0c01.INVALID.INVALID' },
     });
 
     assertExitCode(result, 1);
@@ -118,7 +120,7 @@ describe.skipIf(!e2eEnabled())('validate — failure paths', () => {
 
   it('exits 1 on a destination the origin credentials cannot cover', async () => {
     // DT_ORIGIN_* set explicitly: resolveEndpoints falls back to a shared top-level token otherwise.
-    const { appsEndpoint, apiToken } = tenant();
+    const { appsEndpoint, apiToken } = await tenant();
 
     const result = await runCli(['validate'], {
       configYaml: toConfigFile({
@@ -149,7 +151,7 @@ describe.skipIf(!e2eEnabled())('validate — failure paths', () => {
     const result = await runCli(['validate'], {
       configYaml: toConfigFile({
         schemaVersion: 2,
-        dynatrace: { environmentUrl: tenant().appsEndpoint },
+        dynatrace: { environmentUrl: (await tenant()).appsEndpoint },
         judge: { provider: 'openai' },
         scope: { since: '1h' },
         metrics: { enabled: ['toxicity'] },
@@ -167,9 +169,9 @@ describe.skipIf(!e2eEnabled())('validate — failure paths', () => {
     // A real 1-token inference, so a wrong model id surfaces here rather than mid-run.
     const result = await runCli(['validate'], {
       configYaml: toConfigFile(
-        baselineConfig({ ...judge!, model: 'definitely-not-a-real-model-id' }),
+        await baselineConfig({ ...judge!, model: 'definitely-not-a-real-model-id' }),
       ),
-      env: baselineEnv(judge!),
+      env: await baselineEnv(judge!),
     });
 
     assertExitCode(result, 1);
@@ -187,8 +189,8 @@ describe.skipIf(!e2eEnabled())('validate — failure paths', () => {
       );
 
       const result = await runCli(['validate'], {
-        configYaml: toConfigFile(baselineConfig(judge!)),
-        env: { ...baselineEnv(judge!), ...badCredentials },
+        configYaml: toConfigFile(await baselineConfig(judge!)),
+        env: { ...(await baselineEnv(judge!)), ...badCredentials },
       });
 
       assertExitCode(result, 1);


### PR DESCRIPTION
## Summary
Follow-up to #177, collecting post-merge E2E CI bugfixes.

- **Timeout scaling**: `run --ci` tests had timeouts hardcoded for the 24h default lookback. Since `b2d5705` made sampling uncapped, a `workflow_dispatch` with a wider `E2E_FIXTURE_LOOKBACK` (up to the 7d cap) evaluates proportionally more spans and reliably blew past the 180s spawn timeout, even though it stayed under `dql.ts`'s 1000-span cap. `runCiTimeoutMs()` now budgets the timeout from the current lookback, judge concurrency, and seeding rate instead of a fixed number.
- **OAuth instead of a pasted token**: the suite read a pre-issued `DT_API_TOKEN` directly from the environment. It now fetches its own token via an OAuth2 client-credentials grant (`E2E_DT_OAUTH_CLIENT_ID`/`E2E_DT_OAUTH_SECRET`), scoped to what the suite's own DQL reads and `run --ci`'s writes need, and hands that token to both its own DynatraceClient and the CLI under test (unchanged, still via `DT_API_TOKEN`).
- **Sprint SSO host**: the tenant is sprint/labs tier, which has its own SSO (`sso-sprint.dynatracelabs.com`) separate from production's `sso.dynatrace.com`. An OAuth client created in a sprint tenant doesn't exist in production SSO's client database — posting there fails as a generic "ClientId or clientSecret is not correct" rather than naming the real cause. `E2E_DT_OAUTH_URL` now defaults to the sprint host in CI (a repo variable, not a secret — it's just a hostname).

### Follow-up: code review fixes
A review of the above turned up five gaps the OAuth/timeout switch introduced, all fixed here:

- **Secret-leak detection had gone blind to the real token**: `assertNoSecrets` looked for `DT_API_TOKEN` in this process's own environment, but the OAuth-fetched token is only ever handed to the CLI child's environment — it's never set here. The check was silently a no-op for the one credential that matters most. It now checks the actual value handed to the child.
- **`evallogic.e2e.test.ts` wasn't scaled**: only `run.e2e.test.ts` got the new `runCiTimeoutMs()` budget, but the `verdict` job shares the same widenable `E2E_FIXTURE_LOOKBACK` input. A wide dispatch could still time out the verdict lane.
- **Timeout budget could crash a credential-less local run**: `runCiTimeoutMs()` was called eagerly as an `it(...)` timeout argument, which vitest evaluates during test collection even for a skipped suite. A malformed `E2E_FIXTURE_LOOKBACK` value could crash the whole file for a contributor with no tenant credentials, who should just get a clean skip. It's now only computed when the suite is actually enabled.
- **Per-judge-call budget was too tight**: `JUDGE_CALL_CEILING_MS` assumed 10s per call, but the CLI's own defaults allow up to 30s x 3 attempts (with retries) for a single call — a legitimate retry could blow the computed budget. Sized off the CLI's real defaults instead.
- **OAuth token fetch had no timeout and never refreshed**: unlike the rest of the suite's `fetchWithTimeout` pattern, the token request could hang indefinitely, and the fetched token was cached for the whole process lifetime with no expiry check — a real risk now that some suites run for several minutes. Both fixed.

## Test plan
- [x] `npx tsc --noEmit` in `test/e2e` passes
- [x] Verified locally against the real tenant: `tenant`, `cli`, `contract`, `validate` (real tenant + real Bedrock judge), and the full `run` suite including the write-back round trip — all passing
- [x] Dispatched `E2E — dt-evals CLI` on this branch with the configured secrets/variable — all 64 tests plus the verdict lane passed in CI ([run 31508497520](https://github.com/dynatrace-oss/dt-evals/actions/runs/31508497520))
- [x] Re-ran locally against the real tenant after the follow-up fixes — all 65 tests passing, including the newly-scaled `evallogic.e2e.test.ts`
- [x] Re-dispatched `E2E — dt-evals CLI` on this branch [run 31511382999](https://github.com/dynatrace-oss/dt-evals/actions/runs/31511382999) after the follow-up fixes — `e2e` job green in 3m23s, `Verdict suite` green in 1m8s

