### PR TITLE
ci(dt-ai-ingest): add lint, type-check and test workflow (AI-413)

### DIFF
--- a/.github/workflows/ci-ai-ingest.yml
+++ b/.github/workflows/ci-ai-ingest.yml
@@ -1,0 +1,43 @@
+---
+name: CI — dt-ai-ingest
+
+on:
+  pull_request:
+    paths:
+      - "dt-ai-ingest/**"
+      - ".github/workflows/ci-ai-ingest.yml"
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-24.04
+    name: Lint, type-check & test (py${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    defaults:
+      run:
+        shell: bash
+        working-directory: dt-ai-ingest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: "${{ matrix.python-version }}"
+          enable-cache: true
+          cache-dependency-glob: "dt-ai-ingest/uv.lock"
+
+      - name: Install
+        run: uv sync
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Type-check
+        run: uv run mypy src
+
+      - name: Test
+        run: uv run pytest

--- a/.github/workflows/ci-ai-ingest.yml
+++ b/.github/workflows/ci-ai-ingest.yml
@@ -8,6 +8,10 @@ on:
       - ".github/workflows/ci-ai-ingest.yml"
   workflow_dispatch:
 
+# Least-privilege: this workflow only reads the repo (checkout + tooling).
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-24.04

--- a/dt-ai-ingest/pyproject.toml
+++ b/dt-ai-ingest/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
     "Topic :: System :: Monitoring",
 ]

--- a/dt-ai-ingest/src/dt_ai_ingest/_transport.py
+++ b/dt-ai-ingest/src/dt_ai_ingest/_transport.py
@@ -91,11 +91,13 @@ class Transport:
             async with sem:
                 await self._send_chunk(chunk)
 
-        results = await asyncio.gather(*[_guarded(chunk) for chunk in chunks], return_exceptions=True)
+        results = await asyncio.gather(
+            *[_guarded(chunk) for chunk in chunks], return_exceptions=True
+        )
         errors = [e for e in results if isinstance(e, BaseException)]
         if errors:
-        logger.error("%d/%d chunk(s) failed", len(errors), len(chunks))
-        raise errors[0]
+            logger.error("%d/%d chunk(s) failed", len(errors), len(chunks))
+            raise errors[0]
 
     async def _send_chunk(self, chunk: list[dict[str, Any]]) -> None:
         response = await self._request_with_retry(chunk)


### PR DESCRIPTION
## What

Adds a GitHub Actions CI workflow for the **dt-ai-ingest** package (`.github/workflows/ci-ai-ingest.yml`) and fixes a pre-existing syntax error on `main` that was blocking the package from importing at all.

## Why

`dt-ai-ingest` had no CI. On top of that, `main`'s copy of `_transport.py` carried an unindented `if errors:` block (a `SyntaxError` introduced in #178) that broke import of the whole package — so lint, type-check, and tests all failed on `main`. This PR makes the package pass its own checks and wires them into CI so it can't regress silently.

## What's in the CI

Triggered on PRs touching `dt-ai-ingest/**` (and the workflow file), plus manual `workflow_dispatch`. One job on `ubuntu-24.04`, using **uv**, across a **Python 3.11 / 3.12 / 3.13 / 3.14** matrix:

| Step | Command |
| ---- | ------- |
| Install | `uv sync` |
| Lint | `uv run ruff check .` |
| Type-check | `uv run mypy src` (strict, per `pyproject.toml`) |
| Test | `uv run pytest` |

Deliberately minimal — no optional extras installed (parquet tests `importorskip` and skip; mypy overrides cover the missing framework imports), no build/publish (that's `release.yml`), no coverage upload.

## Changes

- **`fix`**: indent the `logger.error` + `raise` under `if errors:` in `_transport.py`, and wrap the `asyncio.gather(...)` call under the 100-col limit.
- **`ci`**: add `ci-ai-ingest.yml`; add Python 3.13 / 3.14 to the `pyproject.toml` classifiers to match the matrix.

## Verified locally (pristine `main` + these changes)

- `ruff check .` — all checks passed
- `mypy src` — success, 7 source files
- `pytest` — 36 passed, 2 skipped (parquet, no pyarrow installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)