### PR TITLE
feat: ingest Ragas evaluation results

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -247,6 +247,29 @@ dt-evals configure --show
 | `evaluators` | List, inspect, test, and manage evaluators |
 | `runs` | View and export historical run records |
 | `schedule` | Create and trigger recurring runs |
+| `ingest ragas <file>` | Ingest Ragas evaluation results exported as JSON |
+
+### Ingest Ragas results
+
+Export the row-oriented result from Python, retaining `user_input` and
+`response` only when you intend to store them:
+
+```python
+result.to_pandas().to_json("ragas-results.json", orient="records")
+```
+
+Ingest each numeric metric as a `gen_ai.evaluation.result` bizevent:
+
+```bash
+dt-evals ingest ragas ragas-results.json --run-id ragas-release-42
+```
+
+The JSON may be the direct array produced by `orient="records"` or an object
+with that array in `scores`. `trace_id` is optional; the CLI generates a stable
+per-row ID when it is absent. Use `--store-evaluated-input` only when storing
+the Ragas `user_input` and `response` is appropriate for the target tenant.
+Numeric scores at or above `0.5` are labeled `pass`; lower scores are labeled
+`fail`.
 
 Global flags:
 

--- a/dt-eval-cli/src/cli/commands/ingest.ts
+++ b/dt-eval-cli/src/cli/commands/ingest.ts
@@ -1,0 +1,51 @@
+import { Command } from 'commander';
+import { randomUUID } from 'node:crypto';
+import { loadConfig } from '../../config/index.js';
+import { resolveEndpoints } from '../../config/schema.js';
+import { DynatraceClient } from '../../dt/client.js';
+import { buildRagasBizevents } from '../../ragas/ingest.js';
+import { logger } from '../../logger/index.js';
+
+export function createIngestCommand(): Command {
+  const cmd = new Command('ingest');
+  cmd.description('Ingest external evaluation results into Dynatrace');
+
+  const ragas = new Command('ragas');
+  ragas
+    .description('Ingest Ragas EvaluationResult JSON exported as row-oriented records')
+    .argument('<file>', 'JSON exported from Ragas EvaluationResult')
+    .option('--config <path>', 'Path to configuration file')
+    .option('--run-id <id>', 'Evaluation run identifier')
+    .option('--store-evaluated-input', 'Include Ragas user_input and response in bizevents')
+    .option('--dry-run', 'Validate and show the event count without ingesting')
+    .action(async (
+      file: string,
+      options: { config?: string; runId?: string; storeEvaluatedInput?: boolean; dryRun?: boolean },
+    ) => {
+      const config = loadConfig({ projectFile: options.config });
+      const { destination } = resolveEndpoints(config.dynatrace);
+      if (!destination.environmentUrl) {
+        throw new Error('Dynatrace destination URL is required (set DT_ENV_URL or dynatrace.environmentUrl)');
+      }
+      if (!destination.apiToken && !options.dryRun) {
+        throw new Error('Dynatrace destination token is required (set DT_API_TOKEN or dynatrace.apiToken)');
+      }
+
+      const runId = options.runId ?? `ragas-${randomUUID()}`;
+      const result = await buildRagasBizevents(file, {
+        runId,
+        storeEvaluatedInput: options.storeEvaluatedInput ?? false,
+      });
+
+      if (!options.dryRun) {
+        await new DynatraceClient(destination).ingestBizevents(result.events);
+      }
+
+      logger.success(
+        `${options.dryRun ? 'Validated' : 'Ingested'} ${result.metricsRead} Ragas metric result(s) from ${result.rowsRead} row(s) with run ID ${runId}`,
+      );
+    });
+
+  cmd.addCommand(ragas);
+  return cmd;
+}

--- a/dt-eval-cli/src/cli/index.ts
+++ b/dt-eval-cli/src/cli/index.ts
@@ -8,6 +8,7 @@ import { createEvaluatorsCommand } from './commands/evaluators.js';
 import { createRunsCommand } from './commands/runs.js';
 import { createValidateCommand } from './commands/validate.js';
 import { createDoctorCommand } from './commands/doctor.js';
+import { createIngestCommand } from './commands/ingest.js';
 import { configureLogger } from '../logger/index.js';
 import { printBanner } from '../ui/banner.js';
 
@@ -55,6 +56,7 @@ export function createCli(): Command {
   program.addCommand(createEvaluatorsCommand());
   program.addCommand(createRunsCommand());
   program.addCommand(createScheduleCommand());
+  program.addCommand(createIngestCommand());
 
   return program;
 }

--- a/dt-eval-cli/src/ragas/ingest.ts
+++ b/dt-eval-cli/src/ragas/ingest.ts
@@ -1,0 +1,138 @@
+import { readFile } from 'node:fs/promises';
+
+export interface RagasIngestOptions {
+  runId: string;
+  storeEvaluatedInput: boolean;
+}
+
+export interface RagasIngestResult {
+  events: object[];
+  rowsRead: number;
+  metricsRead: number;
+}
+
+interface RagasRow {
+  trace_id?: unknown;
+  traceId?: unknown;
+  user_input?: unknown;
+  response?: unknown;
+  scores?: unknown;
+  [key: string]: unknown;
+}
+
+const NON_METRIC_FIELDS = new Set([
+  'trace_id',
+  'traceId',
+  'span_id',
+  'spanId',
+  'user_input',
+  'response',
+  'retrieved_contexts',
+  'reference_contexts',
+  'reference',
+  'rubric',
+  'metadata',
+  'scores',
+]);
+
+function asRecord(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(message);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseRows(value: unknown): RagasRow[] {
+  if (Array.isArray(value)) {
+    return value.map((row, index) => asRecord(row, `Ragas row ${index} must be an object`));
+  }
+
+  const document = asRecord(value, 'Ragas JSON must be an array of result rows or an object with a "scores" array');
+  if (!Array.isArray(document.scores)) {
+    throw new Error('Ragas JSON object must contain a "scores" array');
+  }
+  return document.scores.map((row, index) => asRecord(row, `Ragas score row ${index} must be an object`));
+}
+
+function metricId(name: string): string {
+  return `ragas.${name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')}`;
+}
+
+function scoreLabel(score: number): 'pass' | 'fail' {
+  return score >= 0.5 ? 'pass' : 'fail';
+}
+
+function readScores(row: RagasRow): Array<[string, number]> {
+  const nestedScores = row.scores === undefined ? {} : asRecord(row.scores, '"scores" must be an object');
+  const candidates = { ...row, ...nestedScores };
+
+  return Object.entries(candidates)
+    .filter(([name, value]) => !NON_METRIC_FIELDS.has(name) && typeof value === 'number')
+    .map(([name, value]) => {
+      if (!Number.isFinite(value)) {
+        throw new Error(`Ragas metric "${name}" must be a finite number`);
+      }
+      return [name, value];
+    });
+}
+
+/**
+ * Convert JSON exported from `EvaluationResult.to_pandas().to_json(orient="records")`
+ * (or an object containing its rows in `scores`) into Dynatrace bizevents.
+ */
+export async function buildRagasBizevents(
+  filePath: string,
+  options: RagasIngestOptions,
+): Promise<RagasIngestResult> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(filePath, 'utf-8'));
+  } catch (err) {
+    throw new Error(`Unable to read Ragas JSON from ${filePath}: ${(err as Error).message}`);
+  }
+
+  const rows = parseRows(parsed);
+  const events: object[] = [];
+
+  for (const [rowIndex, row] of rows.entries()) {
+    const traceId = typeof row.trace_id === 'string'
+      ? row.trace_id
+      : typeof row.traceId === 'string'
+        ? row.traceId
+        : `ragas-${options.runId}-${rowIndex}`;
+    const userInput = typeof row.user_input === 'string' ? row.user_input : undefined;
+    const response = typeof row.response === 'string' ? row.response : undefined;
+
+    for (const [name, score] of readScores(row)) {
+      events.push({
+        'event.type': 'gen_ai.evaluation.result',
+        'event.provider': 'ragas',
+        'trace_id': traceId,
+        'timestamp': new Date().toISOString(),
+        'gen_ai.evaluation.name': name,
+        'gen_ai.evaluation.type': 'external',
+        'gen_ai.evaluation.version': 'ragas',
+        'gen_ai.evaluation.spec_id': metricId(name),
+        'gen_ai.evaluation.scoring_format': score >= 0 && score <= 1 ? 'score_0_to_1' : 'numeric',
+        'gen_ai.evaluation.score.value': score,
+        'gen_ai.evaluation.score.label': scoreLabel(score),
+        'gen_ai.evaluation.explanation': `Ragas ${name} score`,
+        'gen_ai.evaluation.method': 'ragas',
+        'dt.eval.run_id': options.runId,
+        'gen_ai.eval.client': 'dt-eval-cli',
+        ...(options.storeEvaluatedInput && userInput
+          ? { 'gen_ai.evaluation.input.question': userInput }
+          : {}),
+        ...(options.storeEvaluatedInput && response
+          ? { 'gen_ai.evaluation.input.answer': response }
+          : {}),
+      });
+    }
+  }
+
+  if (events.length === 0) {
+    throw new Error('Ragas JSON contains no numeric metric scores');
+  }
+
+  return { events, rowsRead: rows.length, metricsRead: events.length };
+}

--- a/dt-eval-cli/tests/ragas/ingest.test.ts
+++ b/dt-eval-cli/tests/ragas/ingest.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildRagasBizevents } from '../../src/ragas/ingest.js';
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => rm(directory, { recursive: true, force: true })));
+});
+
+async function writeResult(content: unknown): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'dt-evals-ragas-'));
+  directories.push(directory);
+  const path = join(directory, 'result.json');
+  await writeFile(path, JSON.stringify(content), 'utf-8');
+  return path;
+}
+
+describe('buildRagasBizevents', () => {
+  it('maps row-oriented Ragas metrics and omits inputs by default', async () => {
+    const file = await writeResult([{
+      trace_id: 'trace-123',
+      user_input: 'Where is Paris?',
+      response: 'Paris is in France.',
+      faithfulness: 0.8,
+      answer_relevancy: 0.4,
+    }]);
+
+    const result = await buildRagasBizevents(file, {
+      runId: 'ragas-test',
+      storeEvaluatedInput: false,
+    });
+
+    expect(result).toMatchObject({ rowsRead: 1, metricsRead: 2 });
+    expect(result.events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        trace_id: 'trace-123',
+        'gen_ai.evaluation.name': 'faithfulness',
+        'gen_ai.evaluation.spec_id': 'ragas.faithfulness',
+        'gen_ai.evaluation.score.value': 0.8,
+        'gen_ai.evaluation.score.label': 'pass',
+        'dt.eval.run_id': 'ragas-test',
+      }),
+      expect.objectContaining({
+        'gen_ai.evaluation.name': 'answer_relevancy',
+        'gen_ai.evaluation.score.label': 'fail',
+      }),
+    ]));
+    expect(result.events[0]).not.toHaveProperty('gen_ai.evaluation.input.question');
+  });
+
+  it('accepts scores nested in a Ragas result document', async () => {
+    const file = await writeResult({
+      scores: [{ user_input: 'Question', response: 'Answer', scores: { custom_metric: 1 } }],
+    });
+
+    const result = await buildRagasBizevents(file, {
+      runId: 'ragas-test',
+      storeEvaluatedInput: true,
+    });
+
+    expect(result.events).toEqual([
+      expect.objectContaining({
+        trace_id: 'ragas-ragas-test-0',
+        'gen_ai.evaluation.name': 'custom_metric',
+        'gen_ai.evaluation.input.question': 'Question',
+        'gen_ai.evaluation.input.answer': 'Answer',
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `dt-evals ingest ragas <file>` for row-oriented Ragas JSON exports
- map every numeric Ragas metric to a Dynatrace GenAI evaluation bizevent
- document the export and privacy-safe ingestion flow

## Validation
- `npm test -- --run tests/ragas/ingest.test.ts`
- `npm run build`
- ingested the local fixture with the configured Dynatrace token (run ID `ragas-local-e2e-20260812`)

The local `examples/ragas-results.json` fixture remains uncommitted as requested.