### PR TITLE
feat(dt-eval-cli): wire deterministic evaluators (config, runner, telemetry)

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           npm ci
           npm install ../dt-eval-lib
+          npm run typecheck
           npm run build
 
       - name: Install E2E dependencies

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -283,7 +283,7 @@ Config is resolved in this order:
 ### Example config
 
 ```yaml
-schemaVersion: 2
+schemaVersion: 3
 name: travel-assistant-prod
 
 dynatrace:
@@ -311,6 +311,17 @@ metrics:
     - hallucination
     - relevance
     - answer-completeness
+    - id: valid-json
+      method: json_schema
+      params:
+        schema:
+          type: object
+          required: [answer]
+    - id: no-refusal
+      method: must_not_contain
+      params:
+        keywords: ["i cannot help", "i'm sorry"]
+        mode: any
     - drift
 
 alerts:
@@ -320,6 +331,24 @@ alerts:
     answer-completeness: 0.8
 
 storeEvaluatedPrompt: false
+```
+
+String entries and object entries without `method` use the configured
+LLM-as-judge provider. Deterministic entries set `method` to `exact_match`,
+`regex`, `must_not_match`, `json_schema`, `must_contain`, or
+`must_not_contain`. `exact_match` also requires an `inputs.expectedOutput`
+route to a canonical span field:
+
+```yaml
+metrics:
+  enabled:
+    - id: exact-answer
+      method: exact_match
+      params:
+        caseSensitive: false
+        trim: true
+      inputs:
+        expectedOutput: context
 ```
 
 By default, the runner keeps only chat/text-generation spans:
@@ -453,7 +482,7 @@ A complete `.dt-eval.yaml` combining everything — schema bump, custom
 span field mapping, per-metric input routing, sampling, alerts:
 
 ```yaml
-schemaVersion: 2
+schemaVersion: 3
 name: travel-assistant-prod
 
 dynatrace:
@@ -485,6 +514,11 @@ metrics:
     - id: user-frustration
       inputs:
         input: userPrompt
+    - id: no-refusal
+      method: must_not_contain
+      params:
+        keywords: ["i cannot help", "i'm sorry"]
+        mode: any
 
 alerts:
   thresholds:

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -2,7 +2,7 @@
 # Copy this file to <your-service>.dt-eval.yaml and fill in your values.
 # Run: dt-eval run --config <your-service>.dt-eval.yaml
 
-schemaVersion: 1
+schemaVersion: 3
 
 # Human-readable name shown in run output and stored in Dynatrace bizevents.
 name: my-ai-service-prod
@@ -88,6 +88,19 @@ metrics:
     - bias                  # Demographic or ideological bias
     - summarization-quality # Quality of summaries vs. source document
     - conciseness           # Avoids unnecessary verbosity
+
+    # Deterministic metrics (no LLM call):
+    - id: valid-json
+      method: json_schema
+      params:
+        schema:
+          type: object
+          required: [answer]
+    - id: no-refusal
+      method: must_not_contain
+      params:
+        keywords: ["i cannot help", "i'm sorry"]
+        mode: any
 
     # Statistical drift detection (no LLM call — compares current vs. baseline scores in DT):
     - drift

--- a/dt-eval-cli/package-lock.json
+++ b/dt-eval-cli/package-lock.json
@@ -15,10 +15,12 @@
         "@google/genai": "^1.0.0",
         "@inquirer/prompts": "^7.10.1",
         "@types/figlet": "^1.7.0",
+        "ajv": "^8.20.0",
         "commander": "^12.0.0",
         "figlet": "^1.11.0",
         "openai": "^4.73.0",
         "picocolors": "^1.1.1",
+        "recheck": "^4.5.0",
         "yaml": "^2.4.0"
       },
       "bin": {
@@ -159,6 +161,7 @@
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1045.0.tgz",
       "integrity": "sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1262,6 +1265,7 @@
       "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "google-auth-library": "^10.3.0",
         "p-retry": "^4.6.2",
@@ -1675,6 +1679,18 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.2.tgz",
+      "integrity": "sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1825,9 +1841,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1845,9 +1858,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1865,9 +1875,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1885,9 +1892,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1905,9 +1909,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1925,9 +1926,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3078,6 +3076,22 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3442,6 +3456,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3511,6 +3526,28 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -3945,6 +3982,12 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -4109,9 +4152,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4133,9 +4173,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4157,9 +4194,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4181,9 +4215,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4443,6 +4474,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -4530,6 +4562,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4579,6 +4612,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -4666,6 +4700,93 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/recheck": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/recheck/-/recheck-4.5.0.tgz",
+      "integrity": "sha512-kPnbOV6Zfx9a25AZ++28fI1q78L/UVRQmmuazwVRPfiiqpMs+WbOU69Shx820XgfKWfak0JH75PUvZMFtRGSsw==",
+      "license": "MIT",
+      "dependencies": {
+        "synckit": "0.9.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "recheck-jar": "4.5.0",
+        "recheck-linux-x64": "4.5.0",
+        "recheck-macos-arm64": "4.5.0",
+        "recheck-macos-x64": "4.5.0",
+        "recheck-windows-x64": "4.5.0"
+      }
+    },
+    "node_modules/recheck-jar": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/recheck-jar/-/recheck-jar-4.5.0.tgz",
+      "integrity": "sha512-Ad7oCQmY8cQLzd3QVNXjzZ+S6MbImGhR4AaW2yiGzteOfMV45522rt6nSzFyt8p3mCEaMcm/4MoZrMSxUcCbrA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/recheck-linux-x64": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/recheck-linux-x64/-/recheck-linux-x64-4.5.0.tgz",
+      "integrity": "sha512-52kXsR/v+IbGIKYYFZfSZcgse/Ci9IA2HnuzrtvRRcfODkcUGe4n72ESQ8nOPwrdHFg9i4j9/YyPh1HWWgpJ6A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/recheck-macos-arm64": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/recheck-macos-arm64/-/recheck-macos-arm64-4.5.0.tgz",
+      "integrity": "sha512-qIyK3dRuLkORQvv0b59fZZRXweSmjjWaoA4K8Kgifz0anMBH4pqsDV6plBlgjcRmW9yC12wErIRzifREaKnk2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/recheck-macos-x64": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/recheck-macos-x64/-/recheck-macos-x64-4.5.0.tgz",
+      "integrity": "sha512-1wp/eiLxcjC/Ex4wurlrS/LGzt8IiF4TiK5sEjldu4HVAKdNCnnmsS9a5vFpfcikDz4ZuZlLlTi1VbQTxHlwZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/recheck-windows-x64": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/recheck-windows-x64/-/recheck-windows-x64-4.5.0.tgz",
+      "integrity": "sha512-ekBKwAp0oKkMULn5zgmHEYLwSJfkfb95AbTtbDkQazNkqYw9PRD/mVyFUR6Ff2IeRyZI0gxy+N2AKBISWydhug==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -4925,6 +5046,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -5077,6 +5214,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5097,6 +5235,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5124,6 +5263,7 @@
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -5393,6 +5533,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build": "tsup",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
     "dev": "tsx src/index.ts"
   },
   "homepage": "https://github.com/dynatrace-oss/dt-evals#readme",

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -41,10 +41,12 @@
     "@google/genai": "^1.0.0",
     "@inquirer/prompts": "^7.10.1",
     "@types/figlet": "^1.7.0",
+    "ajv": "^8.20.0",
     "commander": "^12.0.0",
     "figlet": "^1.11.0",
     "openai": "^4.73.0",
     "picocolors": "^1.1.1",
+    "recheck": "^4.5.0",
     "yaml": "^2.4.0"
   },
   "devDependencies": {

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
 import { join, dirname } from 'node:path';
+import { Ajv } from 'ajv';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import {
   CURRENT_SCHEMA_VERSION,
@@ -210,6 +211,7 @@ export function saveConfig(config: DtEvalConfig, filePath: string): void {
 const DETERMINISTIC_METHODS = ['exact_match', 'regex', 'must_not_match', 'json_schema', 'must_contain', 'must_not_contain'];
 const ALL_METHODS = ['llm_as_judge', ...DETERMINISTIC_METHODS];
 const CANONICAL_SPAN_FIELDS = ['input', 'output', 'context', 'systemInstruction', 'model', 'userPrompt'];
+const METRIC_INPUT_SLOTS = ['input', 'output', 'context', 'expectedOutput'];
 
 type CheckSync = (source: string, flags: string, params?: object) => { status: string };
 let _checkSync: CheckSync | null | undefined;
@@ -246,6 +248,26 @@ function regexSafetyIssue(pattern: string, flags: string): string | null {
     return 'it is vulnerable to catastrophic backtracking (ReDoS); simplify the pattern';
   }
   return 'its safety could not be verified (analysis inconclusive or timed out); simplify the pattern';
+}
+
+/** Validate per-metric routing before the runner can silently fall back. */
+function validateMetricInputs(entry: Record<string, unknown>, i: number, issues: string[]): void {
+  const inputs = entry['inputs'];
+  if (inputs === undefined) return;
+  if (typeof inputs !== 'object' || inputs === null || Array.isArray(inputs)) {
+    issues.push(`metrics.enabled[${i}].inputs must be an object`);
+    return;
+  }
+
+  for (const [slot, field] of Object.entries(inputs)) {
+    if (!METRIC_INPUT_SLOTS.includes(slot)) {
+      issues.push(`metrics.enabled[${i}].inputs.${slot} is not supported`);
+      continue;
+    }
+    if (typeof field !== 'string' || !CANONICAL_SPAN_FIELDS.includes(field)) {
+      issues.push(`metrics.enabled[${i}].inputs.${slot} must route one of: ${CANONICAL_SPAN_FIELDS.join(', ')}`);
+    }
+  }
 }
 
 /** Validate the optional deterministic `method` + `params` on an object metric entry. */
@@ -291,8 +313,17 @@ function validateMethodEntry(entry: Record<string, unknown>, i: number, issues: 
     }
     checkBoolean(params, 'caseSensitive', i, method, issues);
   }
-  if (method === 'json_schema' && (typeof params['schema'] !== 'object' || params['schema'] === null)) {
-    issues.push(`metrics.enabled[${i}].params.schema (object) is required for method "json_schema"`);
+  if (method === 'json_schema') {
+    const schema = params['schema'];
+    if (typeof schema !== 'object' || schema === null) {
+      issues.push(`metrics.enabled[${i}].params.schema (object) is required for method "json_schema"`);
+    } else {
+      try {
+        new Ajv({ allErrors: true, strict: false }).compile(schema);
+      } catch (err) {
+        issues.push(`metrics.enabled[${i}].params.schema is not a valid JSON Schema: ${(err as Error).message}`);
+      }
+    }
   }
 }
 
@@ -368,6 +399,7 @@ export function validateConfig(config: DtEvalConfig): void {
         if (typeof (entry as { id?: unknown }).id !== 'string' || !(entry as { id: string }).id.trim()) {
           issues.push(`metrics.enabled[${i}].id must be a non-empty string`);
         }
+        validateMetricInputs(entry as Record<string, unknown>, i, issues);
         validateMethodEntry(entry as Record<string, unknown>, i, issues);
       } else {
         issues.push(`metrics.enabled[${i}] must be a string or { id, method?, params?, inputs? } object`);

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { createRequire } from 'node:module';
 import { join, dirname } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import {
@@ -206,6 +207,102 @@ export function saveConfig(config: DtEvalConfig, filePath: string): void {
   writeFileSync(filePath, yamlContent, 'utf-8');
 }
 
+const DETERMINISTIC_METHODS = ['exact_match', 'regex', 'must_not_match', 'json_schema', 'must_contain', 'must_not_contain'];
+const ALL_METHODS = ['llm_as_judge', ...DETERMINISTIC_METHODS];
+const CANONICAL_SPAN_FIELDS = ['input', 'output', 'context', 'systemInstruction', 'model', 'userPrompt'];
+
+type CheckSync = (source: string, flags: string, params?: object) => { status: string };
+let _checkSync: CheckSync | null | undefined;
+/** Lazily load recheck's synchronous ReDoS checker; null if unavailable. */
+function loadCheckSync(): CheckSync | null {
+  if (_checkSync === undefined) {
+    try {
+      _checkSync = createRequire(import.meta.url)('recheck').checkSync as CheckSync;
+    } catch {
+      _checkSync = null;
+    }
+  }
+  return _checkSync;
+}
+
+/**
+ * Fail-closed regex safety check, mirroring the lib's run-time guard: a pattern
+ * is accepted only when recheck reports it `safe`. Returns a human-readable
+ * reason to reject, or null when the pattern is safe. When the analyzer cannot
+ * be loaded here, returns null and defers to the lib's run-time guard (which
+ * fails closed with an install message).
+ */
+function regexSafetyIssue(pattern: string, flags: string): string | null {
+  const checkSync = loadCheckSync();
+  if (!checkSync) return null;
+  let status: string;
+  try {
+    status = checkSync(pattern, flags, { checker: 'auto', timeout: 1000 }).status;
+  } catch {
+    return 'its safety could not be verified (analysis failed); simplify the pattern';
+  }
+  if (status === 'safe') return null;
+  if (status === 'vulnerable') {
+    return 'it is vulnerable to catastrophic backtracking (ReDoS); simplify the pattern';
+  }
+  return 'its safety could not be verified (analysis inconclusive or timed out); simplify the pattern';
+}
+
+/** Validate the optional deterministic `method` + `params` on an object metric entry. */
+function validateMethodEntry(entry: Record<string, unknown>, i: number, issues: string[]): void {
+  const method = entry['method'];
+  if (method === undefined) return;
+  if (typeof method !== 'string' || !ALL_METHODS.includes(method)) {
+    issues.push(`metrics.enabled[${i}].method must be one of: ${ALL_METHODS.join(', ')}`);
+    return;
+  }
+  if (!DETERMINISTIC_METHODS.includes(method)) return;
+
+  const params = (entry['params'] ?? {}) as Record<string, unknown>;
+  if (method === 'exact_match') {
+    // The runner marks expectedOutput a required field for exact_match, so a
+    // span-field routing for it must be configured or every span fails at runtime.
+    const expected = (entry['inputs'] as Record<string, unknown> | undefined)?.['expectedOutput'];
+    if (typeof expected !== 'string' || !CANONICAL_SPAN_FIELDS.includes(expected)) {
+      issues.push(`metrics.enabled[${i}] method "exact_match" requires inputs.expectedOutput to route one of: ${CANONICAL_SPAN_FIELDS.join(', ')}`);
+    }
+    checkBoolean(params, 'caseSensitive', i, method, issues);
+    checkBoolean(params, 'trim', i, method, issues);
+  }
+  if (method === 'regex' || method === 'must_not_match') {
+    const pattern = params['pattern'];
+    if (typeof pattern !== 'string' || !pattern) {
+      issues.push(`metrics.enabled[${i}].params.pattern is required for method "${method}"`);
+    } else {
+      const reason = regexSafetyIssue(pattern, typeof params['flags'] === 'string' ? params['flags'] : '');
+      if (reason) issues.push(`metrics.enabled[${i}].params.pattern for method "${method}": ${reason}`);
+    }
+    if (params['flags'] !== undefined && typeof params['flags'] !== 'string') {
+      issues.push(`metrics.enabled[${i}].params.flags must be a string for method "${method}"`);
+    }
+  }
+  if (method === 'must_contain' || method === 'must_not_contain') {
+    const kw = params['keywords'];
+    if (!Array.isArray(kw) || kw.length === 0 || kw.some(k => typeof k !== 'string' || !k)) {
+      issues.push(`metrics.enabled[${i}].params.keywords must be a non-empty string array for method "${method}"`);
+    }
+    if (params['mode'] !== undefined && params['mode'] !== 'any' && params['mode'] !== 'all') {
+      issues.push(`metrics.enabled[${i}].params.mode must be "any" or "all" for method "${method}"`);
+    }
+    checkBoolean(params, 'caseSensitive', i, method, issues);
+  }
+  if (method === 'json_schema' && (typeof params['schema'] !== 'object' || params['schema'] === null)) {
+    issues.push(`metrics.enabled[${i}].params.schema (object) is required for method "json_schema"`);
+  }
+}
+
+/** Push an issue if an optional param is present but not a boolean. */
+function checkBoolean(params: Record<string, unknown>, key: string, i: number, method: string, issues: string[]): void {
+  if (params[key] !== undefined && typeof params[key] !== 'boolean') {
+    issues.push(`metrics.enabled[${i}].params.${key} must be a boolean for method "${method}"`);
+  }
+}
+
 export function validateConfig(config: DtEvalConfig): void {
   const issues: string[] = [];
 
@@ -271,8 +368,9 @@ export function validateConfig(config: DtEvalConfig): void {
         if (typeof (entry as { id?: unknown }).id !== 'string' || !(entry as { id: string }).id.trim()) {
           issues.push(`metrics.enabled[${i}].id must be a non-empty string`);
         }
+        validateMethodEntry(entry as Record<string, unknown>, i, issues);
       } else {
-        issues.push(`metrics.enabled[${i}] must be a string or { id, inputs? } object`);
+        issues.push(`metrics.enabled[${i}] must be a string or { id, method?, params?, inputs? } object`);
       }
     }
   }

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -1,4 +1,6 @@
-export const CURRENT_SCHEMA_VERSION = 2;
+import type { DeterministicParams, EvaluatorMethod } from '@dynatrace-oss/dt-eval-lib';
+
+export const CURRENT_SCHEMA_VERSION = 3;
 
 /** A single Dynatrace tenant endpoint (origin for reads, destination for writes). */
 export interface DynatraceEndpoint {
@@ -100,13 +102,18 @@ export interface MetricInputs {
   input?: CanonicalSpanField;
   output?: CanonicalSpanField;
   context?: CanonicalSpanField;
+  /** Reference value for deterministic methods that compare against it (e.g. exact_match). */
+  expectedOutput?: CanonicalSpanField;
 }
 
 /**
- * A metric entry in `metrics.enabled`. Either a string id (legacy form) or an
- * object with optional per-metric input routing.
+ * A metric entry in `metrics.enabled`. Either a string id (legacy LLM-judge form)
+ * or an object. Object form carries optional per-metric input routing and, for
+ * deterministic evaluators, the `method` + `params`. Omitting `method` ⇒ `llm_as_judge`.
  */
-export type MetricEntry = string | { id: string; inputs?: MetricInputs };
+export type MetricEntry =
+  | string
+  | { id: string; inputs?: MetricInputs; method?: EvaluatorMethod; params?: DeterministicParams };
 
 export interface MetricsConfig {
   enabled: MetricEntry[];
@@ -144,6 +151,16 @@ export function metricId(entry: MetricEntry): string {
 /** Per-metric input routing, or undefined if the entry is a bare string. */
 export function metricInputs(entry: MetricEntry): MetricInputs | undefined {
   return typeof entry === 'string' ? undefined : entry.inputs;
+}
+
+/** Evaluation method for an entry. Defaults to "llm_as_judge" when omitted. */
+export function metricMethod(entry: MetricEntry): EvaluatorMethod {
+  return typeof entry === 'string' ? 'llm_as_judge' : entry.method ?? 'llm_as_judge';
+}
+
+/** Deterministic-method params, or undefined for LLM-judge / bare-string entries. */
+export function metricParams(entry: MetricEntry): DeterministicParams | undefined {
+  return typeof entry === 'string' ? undefined : entry.params;
 }
 
 /** Normalize a single-or-list candidate to a list. */

--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import type { DynatraceClient } from './client.js';
 import type { GenAiSpan, BizeventPayload } from './types.js';
-import type { EvalResult } from '@dynatrace-oss/dt-eval-lib';
+import type { EvalResult, EvaluatorMethod } from '@dynatrace-oss/dt-eval-lib';
 
 declare const __CLIENT_VERSION__: string | undefined;
 const CLIENT_NAME = 'dt-eval-cli';
@@ -40,8 +40,10 @@ export function buildBizeventPayload(
   metricName: string,
   result: EvalResult,
   runId: string,
-  judgeProvider: string,
-  judgeModel: string,
+  method: EvaluatorMethod,
+  /** LLM-judge only — omitted for deterministic methods. */
+  judgeProvider?: string,
+  judgeModel?: string,
   serviceName?: string,
   judgeInputs?: JudgeInputs,
   storeEvaluatedPrompt = false,
@@ -52,16 +54,18 @@ export function buildBizeventPayload(
     'trace_id': span.traceId,
     'timestamp': new Date().toISOString(),
     'gen_ai.evaluation.name': metricName,
-    'gen_ai.evaluation.type': 'ready_made',
+    // Built-in catalog metrics (LLM judge) are ready_made; deterministic
+    // methods are authored by the user in their config, so they are custom.
+    'gen_ai.evaluation.type': method === 'llm_as_judge' ? 'ready_made' : 'custom',
     'gen_ai.evaluation.version': 'v1.0',
     'gen_ai.evaluation.spec_id': metricId,
     'gen_ai.evaluation.scoring_format': scoringFormat(result.score.value),
     'gen_ai.evaluation.score.value': result.score.value,
     'gen_ai.evaluation.score.label': result.score.label,
     'gen_ai.evaluation.explanation': result.explanation.summary,
-    'gen_ai.evaluation.method': 'llm_as_judge',
-    'gen_ai.request.model': judgeModel,
-    'gen_ai.provider.name': judgeProvider,
+    'gen_ai.evaluation.method': method,
+    ...(judgeModel ? { 'gen_ai.request.model': judgeModel } : {}),
+    ...(judgeProvider ? { 'gen_ai.provider.name': judgeProvider } : {}),
     ...(serviceName ? { 'dt.service.name': serviceName } : {}),
     'dt.eval.run_id': runId,
     'gen_ai.eval.client': CLIENT_NAME,
@@ -110,7 +114,7 @@ export class BizeventWriter {
     judgeModel: string,
     serviceName?: string,
   ): Promise<void> {
-    const payload = buildBizeventPayload(span, metricId, metricName, result, runId, judgeProvider, judgeModel, serviceName);
+    const payload = buildBizeventPayload(span, metricId, metricName, result, runId, 'llm_as_judge', judgeProvider, judgeModel, serviceName);
     await this.writeBatch([payload]);
   }
 

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -28,7 +28,7 @@ export interface BizeventPayload {
   'span.end_time'?: string;
   'timestamp'?: string;
   'gen_ai.evaluation.name': string;
-  'gen_ai.evaluation.type': 'ready_made';
+  'gen_ai.evaluation.type': 'ready_made' | 'custom';
   'gen_ai.evaluation.version': string;
   'gen_ai.evaluation.spec_id': string;
   'gen_ai.evaluation.scoring_format': string;
@@ -37,7 +37,7 @@ export interface BizeventPayload {
   'gen_ai.evaluation.explanation': string;
   /** Detailed judge rationale; only present when the evaluator produced one. */
   'gen_ai.evaluation.reasoning'?: string;
-  'gen_ai.evaluation.method': 'llm_as_judge';
+  'gen_ai.evaluation.method': 'llm_as_judge' | 'exact_match' | 'regex' | 'must_not_match' | 'json_schema' | 'must_contain' | 'must_not_contain';
   /** Only present when `storeEvaluatedPrompt` is enabled. */
   'gen_ai.evaluation.input.question'?: string;
   /** Only present when `storeEvaluatedPrompt` is enabled. */

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import { evaluate, getPrompt, type EvalConfig, type EvalInput, type EvalResult } from '@dynatrace-oss/dt-eval-lib';
+import { evaluate, getPrompt, BINARY_SCALE, type EvalConfig, type EvalInput, type EvalResult, type EvaluatorMethod, type DeterministicParams, type PromptDefinition } from '@dynatrace-oss/dt-eval-lib';
 import type { DynatraceClient } from '../dt/client.js';
 import type { DtEvalConfig, MetricEntry, MetricInputs, CanonicalSpanField } from '../config/schema.js';
-import { metricId, metricInputs } from '../config/schema.js';
+import { metricId, metricInputs, metricMethod, metricParams } from '../config/schema.js';
 import type { GenAiSpan, BizeventPayload } from '../dt/types.js';
 import { buildGenAiSpanQuery, parseSpanResults, filterSpansByOperationName } from '../dt/dql.js';
 import { BizeventWriter, buildBizeventPayload } from '../dt/bizevent.js';
@@ -71,6 +71,29 @@ interface EvalTask {
   span: GenAiSpan;
   metric: string;
   inputs?: MetricInputs;
+  method: EvaluatorMethod;
+  params?: DeterministicParams;
+}
+
+/**
+ * Resolve the evaluator definition for a task. LLM-judge metrics come from the
+ * lib catalog; deterministic metrics are synthesized from the entry's method +
+ * params (binary pass/fail scale, output-only required fields except exact_match).
+ */
+function resolvePrompt(task: EvalTask): PromptDefinition {
+  if (task.method === 'llm_as_judge') {
+    return getPrompt(task.metric);
+  }
+  return {
+    id: task.metric,
+    name: task.metric,
+    version: 'v1.0',
+    description: `${task.method} evaluator`,
+    method: task.method,
+    params: task.params,
+    requiredFields: task.method === 'exact_match' ? ['output', 'expectedOutput'] : ['output'],
+    scoring: BINARY_SCALE,
+  };
 }
 
 /**
@@ -94,10 +117,14 @@ function buildEvalInput(span: GenAiSpan, inputs: MetricInputs | undefined): Eval
   if (!inputs) {
     return { input: span.input, output: span.output, context: span.context };
   }
+  const expectedOutput = inputs.expectedOutput
+    ? resolveCanonicalField(span, inputs.expectedOutput)
+    : undefined;
   return {
     input: (inputs.input && resolveCanonicalField(span, inputs.input)) ?? span.input,
     output: (inputs.output && resolveCanonicalField(span, inputs.output)) ?? span.output,
     context: (inputs.context && resolveCanonicalField(span, inputs.context)) ?? span.context,
+    ...(expectedOutput !== undefined ? { expectedOutput } : {}),
   };
 }
 
@@ -105,6 +132,7 @@ interface EvalTaskResult {
   span: GenAiSpan;
   metricId: string;
   metricName: string;
+  method: EvaluatorMethod;
   evalResult: EvalResult;
   /** The exact input the judge was given — may be a routed subset of span fields. */
   evalInput: EvalInput;
@@ -209,7 +237,13 @@ export async function runEvals(
   const runDrift = metricIds.includes(DRIFT_METRIC_ID);
 
   const tasks: EvalTask[] = maskedSpans.flatMap(span =>
-    evalEntries.map(entry => ({ span, metric: metricId(entry), inputs: metricInputs(entry) })),
+    evalEntries.map(entry => ({
+      span,
+      metric: metricId(entry),
+      inputs: metricInputs(entry),
+      method: metricMethod(entry),
+      params: metricParams(entry),
+    })),
   );
   const evaluatorStats = new Map<string, EvaluatorRunStats>();
   for (const entry of evalEntries) {
@@ -275,11 +309,11 @@ export async function runEvals(
       const t0 = Date.now();
       const input: EvalInput = buildEvalInput(task.span, task.inputs);
       try {
-        const prompt = getPrompt(task.metric);
+        const prompt = resolvePrompt(task);
         const evalResult = await evaluate(prompt, input, libConfig);
         evalCount++;
         const elapsed = Date.now() - t0;
-        logger.debug(`eval [${evalCount}/${tasks.length}] ${task.metric} ${judgeProvider}/${judgeModel} trace=${task.span.traceId.slice(0, 8)}… ${elapsed}ms score=${evalResult.score.value}`);
+        logger.debug(`eval [${evalCount}/${tasks.length}] ${task.metric} ${task.method} trace=${task.span.traceId.slice(0, 8)}… ${elapsed}ms score=${evalResult.score.value}`);
         recordEvaluatorOutcome(evaluatorStats.get(task.metric), true, elapsed);
         emit?.({
           phase: 'eval-completed',
@@ -289,7 +323,7 @@ export async function runEvals(
           traceId: task.span.traceId,
           durationMs: elapsed,
         });
-        return { span: task.span, metricId: task.metric, metricName: prompt.name, evalResult, evalInput: input };
+        return { span: task.span, metricId: task.metric, metricName: prompt.name, method: task.method, evalResult, evalInput: input };
       } catch (err) {
         evalCount++;
         evalErrors++;
@@ -348,9 +382,15 @@ export async function runEvals(
   if (!emit) logger.step('Writing bizevents...');
   const storeEvaluatedPrompt = opts.storeEvaluatedPrompt ?? evalConfig.storeEvaluatedPrompt ?? false;
   const writer = new BizeventWriter(writeClient);
-  const payloads: BizeventPayload[] = successResults.map(r =>
-    buildBizeventPayload(r.span, r.metricId, r.metricName, r.evalResult, runId, judgeProvider, judgeModel, evalConfig.scope.service, r.evalInput, storeEvaluatedPrompt),
-  );
+  const payloads: BizeventPayload[] = successResults.map(r => {
+    const isLlm = r.method === 'llm_as_judge';
+    return buildBizeventPayload(
+      r.span, r.metricId, r.metricName, r.evalResult, runId, r.method,
+      isLlm ? judgeProvider : undefined,
+      isLlm ? judgeModel : undefined,
+      evalConfig.scope.service, r.evalInput, storeEvaluatedPrompt,
+    );
+  });
   emit?.({ phase: 'writing', payloads: payloads.length });
 
   const t0Ingest = Date.now();

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -339,6 +339,51 @@ describe('config', () => {
       expect(() => validateConfig(config)).not.toThrow();
     });
 
+    it.each(['input', 'output', 'context', 'expectedOutput'])(
+      'rejects an invalid inputs.%s canonical field',
+      (slot) => {
+        const config = makeValidConfig();
+        config.metrics.enabled = [
+          {
+            id: 'routed',
+            method: 'must_contain',
+            params: { keywords: ['ok'] },
+            inputs: { [slot]: 'outpt' },
+          },
+        ] as never;
+
+        expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+        try {
+          validateConfig(config);
+        } catch (err) {
+          const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+          expect(issues).toContain(
+            `metrics.enabled[0].inputs.${slot} must route one of: input, output, context, systemInstruction, model, userPrompt`,
+          );
+        }
+      },
+    );
+
+    it('rejects unknown input routing slots', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        {
+          id: 'routed',
+          method: 'must_contain',
+          params: { keywords: ['ok'] },
+          inputs: { answer: 'output' },
+        },
+      ] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues).toContain('metrics.enabled[0].inputs.answer is not supported');
+      }
+    });
+
     it('rejects an invalid contains mode (typo silently coerced by the scorer otherwise)', () => {
       const config = makeValidConfig();
       config.metrics.enabled = [
@@ -384,6 +429,27 @@ describe('config', () => {
         const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
         expect(issues).toContain('metrics.enabled[0].params.pattern is required for method "regex"');
         expect(issues).toContain('metrics.enabled[1].params.keywords must be a non-empty string array for method "must_not_contain"');
+      }
+    });
+
+    it('rejects a JSON Schema that AJV cannot compile', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        {
+          id: 'invalid-schema',
+          method: 'json_schema',
+          params: { schema: { type: 'not-a-json-schema-type' } },
+        },
+      ] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues.some(issue =>
+          issue.startsWith('metrics.enabled[0].params.schema is not a valid JSON Schema:'),
+        )).toBe(true);
       }
     });
 

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -280,6 +280,113 @@ describe('config', () => {
       expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
     });
 
+    it('accepts a valid deterministic metric entry', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        { id: 'has-json', method: 'json_schema', params: { schema: { type: 'object' } } },
+        { id: 'has-error', method: 'must_contain', params: { keywords: ['error'], mode: 'any' } },
+        { id: 'no-refusal', method: 'must_not_contain', params: { keywords: ['i cannot help'], mode: 'any' } },
+        { id: 'matches', method: 'regex', params: { pattern: '\\d+' } },
+        { id: 'no-ssn', method: 'must_not_match', params: { pattern: '\\d{3}-\\d{2}-\\d{4}' } },
+      ] as never;
+
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects a ReDoS-vulnerable regex pattern at config time', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        { id: 'evil', method: 'must_not_match', params: { pattern: '^(a+)+$' } },
+      ] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues.some(m => /ReDoS/.test(m))).toBe(true);
+      }
+    });
+
+    it('accepts a safe (linear) regex pattern', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        { id: 'ok', method: 'must_not_match', params: { pattern: '\\d{3}-\\d{2}-\\d{4}' } },
+      ] as never;
+
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('requires inputs.expectedOutput for exact_match', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [{ id: 'em', method: 'exact_match' }] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues.some(m => /exact_match.*inputs\.expectedOutput/.test(m))).toBe(true);
+      }
+    });
+
+    it('accepts exact_match when inputs.expectedOutput routes a canonical field', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        { id: 'em', method: 'exact_match', inputs: { expectedOutput: 'context' } },
+      ] as never;
+
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('rejects an invalid contains mode (typo silently coerced by the scorer otherwise)', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        { id: 'c', method: 'must_contain', params: { keywords: ['x'], mode: 'alll' } },
+      ] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues.some(m => /mode must be "any" or "all"/.test(m))).toBe(true);
+      }
+    });
+
+    it('rejects a non-string regex flags param', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        { id: 'r', method: 'regex', params: { pattern: 'abc', flags: 123 } },
+      ] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+    });
+
+    it('throws for an unknown method', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [{ id: 'x', method: 'bogus' }] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+    });
+
+    it('throws when a deterministic method is missing required params', () => {
+      const config = makeValidConfig();
+      config.metrics.enabled = [
+        { id: 'r', method: 'regex' },
+        { id: 'c', method: 'must_not_contain', params: { keywords: [] } },
+      ] as never;
+
+      expect(() => validateConfig(config)).toThrowError(ConfigValidationError);
+      try {
+        validateConfig(config);
+      } catch (err) {
+        const issues = (err as InstanceType<typeof ConfigValidationError>).issues;
+        expect(issues).toContain('metrics.enabled[0].params.pattern is required for method "regex"');
+        expect(issues).toContain('metrics.enabled[1].params.keywords must be a non-empty string array for method "must_not_contain"');
+      }
+    });
+
     it('allows an empty scope.operationNames list to disable the operation-name filter', () => {
       const config = makeValidConfig({
         scope: {

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -29,7 +29,7 @@ describe('buildBizeventPayload', () => {
   it('produces a payload with the correct schema fields', () => {
     const span = makeSpan();
     const result = makeEvalResult();
-    const payload = buildBizeventPayload(span, 'relevance', 'Relevance', result, 'run-001', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(span, 'relevance', 'Relevance', result, 'run-001', 'llm_as_judge', 'openai', 'gpt-4o');
 
     expect(payload['event.type']).toBe('gen_ai.evaluation.result');
     expect(payload['event.provider']).toBe('dt-eval-cli');
@@ -38,6 +38,7 @@ describe('buildBizeventPayload', () => {
     expect(payload['gen_ai.evaluation.name']).toBe('Relevance');
     expect(payload['gen_ai.evaluation.spec_id']).toBe('relevance');
     expect(payload['gen_ai.evaluation.score.value']).toBe(0.9);
+    expect(payload['gen_ai.evaluation.type']).toBe('ready_made');
     expect(payload['gen_ai.provider.name']).toBe('openai');
     expect(payload['gen_ai.request.model']).toBe('gpt-4o');
     expect(payload['gen_ai.evaluation.input.request_model']).toBe('gpt-4o');
@@ -47,31 +48,31 @@ describe('buildBizeventPayload', () => {
   });
 
   it('sets event.type to "gen_ai.evaluation.result"', () => {
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'anthropic', 'claude');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'llm_as_judge', 'anthropic', 'claude');
     expect(payload['event.type']).toBe('gen_ai.evaluation.result');
   });
 
   it('sets score label to "pass" from eval result', () => {
     const result = makeEvalResult(0.9, 'pass');
-    const payload = buildBizeventPayload(makeSpan(), 'relevance', 'Relevance', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'relevance', 'Relevance', result, 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.score.label']).toBe('pass');
   });
 
   it('sets score label to "fail" from eval result', () => {
     const result = makeEvalResult(0.1, 'fail');
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', result, 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.score.label']).toBe('fail');
   });
 
   it('uses the exact score.value from EvalResult', () => {
     const result = makeEvalResult(0.75, 'pass');
-    const payload = buildBizeventPayload(makeSpan(), 'user-frustration', 'User Frustration', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'user-frustration', 'User Frustration', result, 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.score.value']).toBe(0.75);
   });
 
   it('uses explanation.summary as the explanation string', () => {
     const result = makeEvalResult(1, 'pass', 'No harmful content detected.');
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', result, 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', result, 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
     expect(payload['gen_ai.evaluation.explanation']).toBe('No harmful content detected.');
   });
 
@@ -91,20 +92,34 @@ describe('buildBizeventPayload', () => {
   });
 
   it('includes judge provider and model metadata', () => {
-    const payload = buildBizeventPayload(makeSpan(), 'faithfulness', 'Faithfulness', makeEvalResult(), 'run-1', 'anthropic', 'claude-sonnet-4-6');
+    const payload = buildBizeventPayload(makeSpan(), 'faithfulness', 'Faithfulness', makeEvalResult(), 'run-1', 'llm_as_judge', 'anthropic', 'claude-sonnet-4-6');
     expect(payload['gen_ai.provider.name']).toBe('anthropic');
     expect(payload['gen_ai.request.model']).toBe('claude-sonnet-4-6');
   });
 
+  it('records the deterministic method and omits provider/model when not an LLM judge', () => {
+    const payload = buildBizeventPayload(makeSpan(), 'json-format', 'json-format', makeEvalResult(1, 'pass'), 'run-1', 'json_schema');
+    expect(payload['gen_ai.evaluation.method']).toBe('json_schema');
+    expect(payload['gen_ai.provider.name']).toBeUndefined();
+    expect(payload['gen_ai.request.model']).toBeUndefined();
+  });
+
+  it('marks deterministic evaluations as custom and LLM-judge as ready_made', () => {
+    const det = buildBizeventPayload(makeSpan(), 'no-pii-leak', 'no-pii-leak', makeEvalResult(1, 'pass'), 'run-1', 'must_not_contain');
+    expect(det['gen_ai.evaluation.type']).toBe('custom');
+    const llm = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
+    expect(llm['gen_ai.evaluation.type']).toBe('ready_made');
+  });
+
   it('omits gen_ai.system when span.system is absent', () => {
     const span = makeSpan({ system: undefined });
-    const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
     // gen_ai.system is not part of the dt-ai-ingest schema; only gen_ai.provider.name is used
     expect(payload['gen_ai.provider.name']).toBe('openai');
   });
 
   it('includes a valid ISO timestamp field', () => {
-    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
     expect(payload.timestamp).toBeDefined();
     expect(new Date(payload.timestamp!).toISOString()).toBe(payload.timestamp);
   });
@@ -112,7 +127,7 @@ describe('buildBizeventPayload', () => {
   describe('storeEvaluatedPrompt', () => {
     it('omits the evaluated question/answer/system_prompt by default', () => {
       const span = makeSpan({ systemInstruction: 'be helpful' });
-      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
       expect(payload['gen_ai.evaluation.input.question']).toBeUndefined();
       expect(payload['gen_ai.evaluation.input.answer']).toBeUndefined();
       expect(payload['gen_ai.evaluation.input.system_prompt']).toBeUndefined();
@@ -120,14 +135,14 @@ describe('buildBizeventPayload', () => {
 
     it('omits them when explicitly disabled', () => {
       const span = makeSpan({ systemInstruction: 'be helpful' });
-      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o', undefined, undefined, false);
+      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o', undefined, undefined, false);
       expect(payload['gen_ai.evaluation.input.question']).toBeUndefined();
       expect(payload['gen_ai.evaluation.input.answer']).toBeUndefined();
     });
 
     it('includes them when enabled', () => {
       const span = makeSpan({ systemInstruction: 'be helpful' });
-      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o', undefined, undefined, true);
+      const payload = buildBizeventPayload(span, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o', undefined, undefined, true);
       expect(payload['gen_ai.evaluation.input.question']).toBe(span.input);
       expect(payload['gen_ai.evaluation.input.answer']).toBe(span.output);
       expect(payload['gen_ai.evaluation.input.system_prompt']).toBe('be helpful');
@@ -165,8 +180,8 @@ describe('BizeventWriter', () => {
     const span2 = makeSpan({ traceId: 'trace-2' });
 
     const payloads = [
-      buildBizeventPayload(span1, 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
-      buildBizeventPayload(span2, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'openai', 'gpt-4o'),
+      buildBizeventPayload(span1, 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o'),
+      buildBizeventPayload(span2, 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o'),
     ];
 
     await writer.writeBatch(payloads);
@@ -200,6 +215,7 @@ describe('BizeventWriter', () => {
         'User Frustration',
         makeEvalResult(0, 'fail'),
         'run-1',
+        'llm_as_judge',
         'openai',
         'gpt-4o',
         'my-service',
@@ -219,6 +235,7 @@ describe('BizeventWriter', () => {
         'Faithfulness',
         makeEvalResult(),
         'run-1',
+        'llm_as_judge',
         'openai',
         'gpt-4o',
         undefined,
@@ -236,6 +253,7 @@ describe('BizeventWriter', () => {
         'Relevance',
         makeEvalResult(),
         'run-1',
+        'llm_as_judge',
         'openai',
         'gpt-4o',
         undefined,
@@ -255,6 +273,7 @@ describe('BizeventWriter', () => {
         'User Frustration',
         makeEvalResult(),
         'run-1',
+        'llm_as_judge',
         'openai',
         'gpt-4o',
         undefined,

--- a/dt-eval-cli/tests/runner/deterministic.integration.test.ts
+++ b/dt-eval-cli/tests/runner/deterministic.integration.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DtEvalConfig } from '../../src/config/schema.js';
+
+vi.mock('@dynatrace-oss/dt-eval-lib', async () =>
+  import('../../../dt-eval-lib/src/index.ts'));
+
+describe('deterministic evaluator integration', () => {
+  it('runs exact_match through the real library implementation', async () => {
+    const { runEvals } = await import('../../src/runner/index.js');
+    const dtClient = {
+      executeDql: vi.fn().mockResolvedValue([{
+        'trace.id': 'trace-exact-match',
+        'span.id': 'span-exact-match',
+        'gen_ai.operation.name': 'chat',
+        'gen_ai.input.messages': 'question',
+        'gen_ai.output.messages': 'expected answer',
+        'reference.answer': 'expected answer',
+      }]),
+      ingestBizevents: vi.fn().mockResolvedValue(undefined),
+      ingestMetrics: vi.fn().mockResolvedValue(undefined),
+    };
+    const config: DtEvalConfig = {
+      schemaVersion: 3,
+      dynatrace: { environmentUrl: 'https://example.live.dynatrace.com' },
+      judge: { provider: 'openai' },
+      scope: {
+        since: '1h',
+        spanFields: { context: 'reference.answer' },
+        sampling: { strategy: 'random', percent: 100 },
+      },
+      metrics: {
+        enabled: [{
+          id: 'answer-match',
+          method: 'exact_match',
+          inputs: { expectedOutput: 'context' },
+        }],
+      },
+    };
+
+    const result = await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    expect(result.errors).toBe(0);
+    expect(result.resultsWritten).toBe(1);
+    const [payloads] = dtClient.ingestBizevents.mock.calls[0] as [Record<string, unknown>[]];
+    expect(payloads[0]).toMatchObject({
+      'gen_ai.evaluation.method': 'exact_match',
+      'gen_ai.evaluation.score.value': 1,
+      'gen_ai.evaluation.score.label': 'pass',
+    });
+  });
+});

--- a/dt-eval-cli/tests/runner/index.test.ts
+++ b/dt-eval-cli/tests/runner/index.test.ts
@@ -17,6 +17,7 @@ vi.mock('@dynatrace-oss/dt-eval-lib', () => ({
     requiredFields: ['input', 'output'],
     scoring: { type: 'continuous', range: [0, 1], threshold: 0.7 },
   })),
+  BINARY_SCALE: { type: 'binary', range: [0, 1], threshold: 0.5 },
   DRIFT_METRIC_ID: 'drift',
 }));
 
@@ -520,6 +521,36 @@ describe('runEvals', () => {
     const callArgs = evaluate.mock.calls[0] as unknown[];
     const evalInput = callArgs[1] as { context?: string };
     expect(evalInput.context).toBe('retrieved facts');
+  });
+
+  it('dispatches a deterministic metric via a synthesized definition and tags the bizevent method', async () => {
+    const span = makeSpan({ traceId: 'trace-det' });
+    const dtClient = makeDtClient([span]);
+    const config = makeConfig({
+      metrics: {
+        enabled: [
+          { id: 'json-ok', method: 'json_schema', params: { schema: { type: 'object' } } },
+        ],
+      },
+    });
+
+    await runEvals(
+      dtClient as unknown as import('../../src/dt/client.js').DynatraceClient,
+      config,
+      { since: '1h' },
+    );
+
+    // evaluate() is called with the synthesized deterministic definition (no getPrompt lookup)
+    expect(evaluate).toHaveBeenCalledOnce();
+    const prompt = evaluate.mock.calls[0]![0] as { id: string; method: string };
+    expect(prompt.id).toBe('json-ok');
+    expect(prompt.method).toBe('json_schema');
+
+    // bizevent carries the method and omits judge provider/model
+    const [payloads] = dtClient.ingestBizevents.mock.calls[0] as [Record<string, unknown>[]];
+    expect(payloads[0]!['gen_ai.evaluation.method']).toBe('json_schema');
+    expect(payloads[0]!['gen_ai.provider.name']).toBeUndefined();
+    expect(payloads[0]!['gen_ai.request.model']).toBeUndefined();
   });
 
   it('emits onProgress events for each phase in order', async () => {


### PR DESCRIPTION
## What

Lets the deterministic evaluators from #196 be **authored in `.dt-eval.yaml` and run** in the normal pipeline, with the evaluation surfaced in telemetry. A metric entry gains optional `method` + `params` (omit `method` for LLM-judge); `MetricInputs` gains `expectedOutput` routing; `schemaVersion` → 3. Config is validated at load time, deterministic input is built the same way as for LLM-judge, and bizevents record the real `gen_ai.evaluation.method` — with `gen_ai.evaluation.type` = `custom` for user-authored deterministic metrics vs `ready_made` for built-in LLM-judge, and judge `provider`/`model` written only for LLM metrics.

```yaml
metrics:
  enabled:
    - toxicity                        # llm_as_judge
    - id: valid-json
      method: json_schema
      params: { schema: { type: object, required: [answer] } }
    - id: no-refusal
      method: must_not_contain
      params: { keywords: ["i cannot help", "i'm sorry"], mode: any }
```

## Limitations / out of scope

- **Release ordering:** the CLI consumes `dt-eval-lib` from the registry — bump `@dynatrace-oss/dt-eval-lib` (and the lockfile) after #196 is released.
- Span content is PII-masked before evaluation, so a "no PII" guardrail detects the mask marker (`must_not_contain: ["[REDACTED]"]`) rather than raw values.
- A deterministic entry has only an `id` (no separate display name), so `gen_ai.evaluation.name` equals `gen_ai.evaluation.spec_id`.
- A user-defined *custom LLM-judge* prompt is still tagged `ready_made` (type is derived from method); only deterministic methods are marked `custom`.
- Authoring is YAML-only (no interactive wizard yet).
- `dt-eval-deploy` needs `recheck` added to run regex methods in serverless; without it those methods error rather than run.
