### PR TITLE
feat: add input model/provider/agent fields to eval bizevent output, ref: NOISSUE

### DIFF
--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -75,6 +75,11 @@ export function buildBizeventPayload(
     payload['gen_ai.response.id'] = span.spanId;
   }
 
+  if (span.requestModel) payload['gen_ai.evaluation.input.request_model'] = span.requestModel;
+  if (span.responseModel) payload['gen_ai.evaluation.input.response_model'] = span.responseModel;
+  if (span.system) payload['gen_ai.evaluation.input.provider'] = span.system;
+  if (span.agentName) payload['gen_ai.evaluation.input.agent'] = span.agentName;
+
   if (storeEvaluatedPrompt) {
     // Record the evaluated question/answer, while keeping system_prompt
     // reserved for the actual system instruction on the traced span.

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -130,6 +130,8 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
     'gen_ai.operation.name',
     'gen_ai.system',
     'gen_ai.provider.name',
+    'gen_ai.response.model',
+    'gen_ai.agent.name',
     ...fields.input,
     ...fields.output,
     ...fields.context,
@@ -307,6 +309,8 @@ export function parseSpanResults(
       system: asString(r['gen_ai.system']) ?? asString(r['gen_ai.provider.name']),
       operationName: asString(r['gen_ai.operation.name']),
       requestModel: pickFirstMatch(r, fields.model)?.value,
+      responseModel: asString(r['gen_ai.response.model']),
+      agentName: asString(r['gen_ai.agent.name']),
       isError: statusCode === 'ERROR' || undefined,
     });
   }

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -10,6 +10,8 @@ export interface GenAiSpan {
   system?: string;            // gen_ai.provider.name (e.g. "openai")
   operationName?: string;     // gen_ai.operation.name (e.g. "chat", "text_completion")
   requestModel?: string;      // gen_ai.request.model
+  responseModel?: string;     // gen_ai.response.model
+  agentName?: string;         // gen_ai.agent.name
   /** Latest user-role content extracted from prompt slots or structured messages.
    * Useful for metrics that should score the user's turn alone. */
   userPrompt?: string;
@@ -40,6 +42,10 @@ export interface BizeventPayload {
   'gen_ai.evaluation.input.answer'?: string;
   /** Only present when `storeEvaluatedPrompt` is enabled. */
   'gen_ai.evaluation.input.system_prompt'?: string;
+  'gen_ai.evaluation.input.request_model'?: string;
+  'gen_ai.evaluation.input.response_model'?: string;
+  'gen_ai.evaluation.input.provider'?: string;
+  'gen_ai.evaluation.input.agent'?: string;
   'gen_ai.request.model'?: string;
   'gen_ai.provider.name'?: string;
   'dt.service.name'?: string;

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -12,6 +12,8 @@ function makeSpan(overrides?: Partial<GenAiSpan>): GenAiSpan {
     output: 'Paris.',
     system: 'openai',
     requestModel: 'gpt-4o',
+    responseModel: 'gpt-5',
+    agentName: 'my-agent',
     ...overrides,
   };
 }
@@ -38,6 +40,10 @@ describe('buildBizeventPayload', () => {
     expect(payload['gen_ai.evaluation.score.value']).toBe(0.9);
     expect(payload['gen_ai.provider.name']).toBe('openai');
     expect(payload['gen_ai.request.model']).toBe('gpt-4o');
+    expect(payload['gen_ai.evaluation.input.request_model']).toBe('gpt-4o');
+    expect(payload['gen_ai.evaluation.input.response_model']).toBe('gpt-5');
+    expect(payload['gen_ai.evaluation.input.provider']).toBe('openai');
+    expect(payload['gen_ai.evaluation.input.agent']).toBe('my-agent');
   });
 
   it('sets event.type to "gen_ai.evaluation.result"', () => {


### PR DESCRIPTION
Adds four optional fields to the eval bizevent payload, read from the evaluated span:

- `gen_ai.evaluation.input.request_model` ← `gen_ai.request.model`
- `gen_ai.evaluation.input.response_model` ← `gen_ai.response.model`
- `gen_ai.evaluation.input.provider` ← `gen_ai.system` ?? `gen_ai.provider.name`
- `gen_ai.evaluation.input.agent` ← `gen_ai.agent.name`