### PR TITLE
feat(dt-eval-cli): emit judge reasoning as a separate bizevent field

### DIFF
--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -70,6 +70,9 @@ export function buildBizeventPayload(
     'span.end_time': span.endTime,
   };
 
+  // Detailed judge rationale, kept separate from the concise explanation (summary).
+  if (result.explanation.reasoning) payload['gen_ai.evaluation.reasoning'] = result.explanation.reasoning;
+
   if (span.spanId) {
     payload['span_id'] = span.spanId;
     payload['gen_ai.response.id'] = span.spanId;

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -35,6 +35,8 @@ export interface BizeventPayload {
   'gen_ai.evaluation.score.value': number;
   'gen_ai.evaluation.score.label': 'pass' | 'fail';
   'gen_ai.evaluation.explanation': string;
+  /** Detailed judge rationale; only present when the evaluator produced one. */
+  'gen_ai.evaluation.reasoning'?: string;
   'gen_ai.evaluation.method': 'llm_as_judge';
   /** Only present when `storeEvaluatedPrompt` is enabled. */
   'gen_ai.evaluation.input.question'?: string;

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -75,6 +75,21 @@ describe('buildBizeventPayload', () => {
     expect(payload['gen_ai.evaluation.explanation']).toBe('No harmful content detected.');
   });
 
+  it('includes explanation.reasoning as a separate field when present', () => {
+    const result: EvalResult = {
+      score: { value: 1, label: 'pass' },
+      explanation: { summary: 'Supported.', reasoning: 'Every atomic fact is entailed by the source.' },
+    };
+    const payload = buildBizeventPayload(makeSpan(), 'faithfulness', 'Faithfulness', result, 'run-1', 'openai', 'gpt-4o');
+    expect(payload['gen_ai.evaluation.explanation']).toBe('Supported.');
+    expect(payload['gen_ai.evaluation.reasoning']).toBe('Every atomic fact is entailed by the source.');
+  });
+
+  it('omits the reasoning field when the evaluator produced none', () => {
+    const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'openai', 'gpt-4o');
+    expect(payload).not.toHaveProperty('gen_ai.evaluation.reasoning');
+  });
+
   it('includes judge provider and model metadata', () => {
     const payload = buildBizeventPayload(makeSpan(), 'faithfulness', 'Faithfulness', makeEvalResult(), 'run-1', 'anthropic', 'claude-sonnet-4-6');
     expect(payload['gen_ai.provider.name']).toBe('anthropic');


### PR DESCRIPTION
## What

The LLM judge returns two explanation parts — a short `summary` and a more detailed `reasoning` (up to ~3 sentences). Only `summary` was being ingested, as `gen_ai.evaluation.explanation`; the `reasoning` never left the CLI.

This adds a distinct **`gen_ai.evaluation.reasoning`** bizevent attribute carrying the full rationale, kept separate from the concise `explanation` so both stay independently queryable in Grail.

- `gen_ai.evaluation.explanation` — unchanged, still the short summary.
- `gen_ai.evaluation.reasoning` — new, the detailed rationale. Omitted entirely when the evaluator produced none.

## Out of scope / notes

- Additive and backward compatible: no existing field changes shape, and the new field is optional.
- Applies to any evaluator that populates `explanation.reasoning` (today, the LLM judge).