### PR TITLE
chore(dt-eval-cli): reset release-please manifest to 0.2.21-alpha

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
     "dt-eval-lib": "0.0.17-alpha",
-    "dt-eval-cli": "0.2.22-alpha"
+    "dt-eval-cli": "0.2.21-alpha"
 }


### PR DESCRIPTION
## Problem

The pending CLI release PR (#205) regenerated the **entire changelog from project history** and proposed a spurious **0.3.0-alpha** minor bump.

### Root cause

The `node-workspace` release-please plugin bumped `dt-eval-cli` from `0.2.21-alpha` → `0.2.22-alpha` in `.release-please-manifest.json` **as a side effect of the dt-eval-lib 0.0.17-alpha release (#204)**. But because the repo uses `separate-pull-requests: true`, the CLI's own release artifacts (a `v0.2.22-alpha` tag, a `0.2.22-alpha` CHANGELOG entry, a `package.json` bump) were never created — that was meant to happen in a separate CLI release PR that never merged.

Result: the manifest ran **one version ahead of the last real release** (`v0.2.21-alpha`, #203). When release-please then prepared the next CLI release (#205), it read `0.2.22-alpha` as the baseline, failed to find the (non-existent) `v0.2.22-alpha` tag to bound the commit range, and re-swept the whole history — which also re-included the old breaking `rename CLI to dt-evals (#65)` commit, forcing a minor bump under `bump-minor-pre-major`.

## Fix

Reset the manifest's `dt-eval-cli` entry back to the last actually-released version, `0.2.21-alpha`. `dt-eval-lib: 0.0.17-alpha` is left untouched (that release is real and tagged).

Once merged, release-please will recompute only the real delta since `v0.2.21-alpha` and regenerate #205 with a normal, short changelog and a correct patch/minor bump.

## Verification
- Last real CLI tag: `v0.2.21-alpha` ✅
- `v0.2.22-alpha` tag: does not exist ✅
- Single-line, bookkeeping-only change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)