### PR TITLE
docs(dt-eval-cli): add deterministic evaluator examples (AI-454)

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -606,6 +606,68 @@ Drift results are written back as the same event type with `gen_ai.evaluation.ty
 | `toxicity` | Harmful, offensive, or unsafe output | `output` |
 | `user-frustration` | Frustration signals in the user's message | `input` |
 
+### Deterministic evaluators (code checks)
+
+Not every check needs an LLM. Add a `method` to a metric entry in
+`metrics.enabled` to run a fast, reproducible, zero-cost code check instead of
+an LLM judge. Each check scores the span output as pass (`1.0`) or fail
+(`0.0`). Omitting `method` keeps the default LLM-as-judge behavior, so existing
+configs are unaffected.
+
+Available methods: `exact_match`, `regex`, `must_not_match`, `must_contain`,
+`must_not_contain`, and `json_schema`.
+
+**`must_contain` — require an expected keyword to be present**
+
+```yaml
+metrics:
+  enabled:
+    - id: cites-a-source
+      method: must_contain
+      params:
+        keywords: ["source", "reference", "according to"]
+        mode: any          # any = pass if one is present; all = require every keyword
+```
+
+**`must_not_contain` — block forbidden or harmful words**
+
+```yaml
+    - id: no-harmful-words
+      method: must_not_contain
+      params:
+        keywords: ["harmful_word_1", "harmful_word_2", "harmful_word_3"]
+        mode: any          # fail if ANY blocked word appears
+        # matching is case-insensitive by default; set caseSensitive: true to change
+```
+
+**`must_not_match` — fail if the output matches a pattern (e.g. a leaked IP address)**
+
+```yaml
+    - id: no-ip-leaked
+      method: must_not_match
+      params:
+        pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b"
+```
+
+> Use `regex` for the opposite check — pass only when the output **does** match
+> the pattern.
+
+**`json_schema` — require valid, well-structured JSON**
+
+```yaml
+    - id: valid-response-object
+      method: json_schema
+      params:
+        schema:
+          type: object
+          required: [answer]
+```
+
+> **Note:** `json_schema` parses the raw output, so the output must be **bare**
+> JSON — a response wrapped in markdown fences (` ```json … ``` `) will not
+> parse. `json_schema` needs the optional `ajv` dependency, and `regex` /
+> `must_not_match` need the optional `recheck` dependency (for ReDoS safety).
+
 ### Custom evaluators
 
 You can create a custom judge metric with `dt-evals evaluators add`, then


### PR DESCRIPTION
## What

Documents the new deterministic (code-check) evaluators in the CLI README, under a new **Deterministic evaluators (code checks)** subsection in `## Built-in Evaluators`.

General, provider-agnostic examples (no project-specific data):

- `must_contain` — require an expected keyword
- `must_not_contain` — block forbidden/harmful words (placeholder tokens)
- `must_not_match` — fail if the output matches a pattern (e.g. a leaked IP address), with a pointer to `regex` for the inverse
- `json_schema` — require valid, well-structured JSON

Includes a note that `json_schema` needs **bare** JSON (markdown-fenced JSON won't parse) and that `json_schema` / `regex` / `must_not_match` rely on the optional `ajv` / `recheck` dependencies.

## Why

The deterministic evaluators shipped without README coverage. Examples were validated end-to-end against a live tenant before writing them.

## Notes

- Docs-only change; `markdownlint` passes clean.

ref: AI-454

🤖 Generated with [Claude Code](https://claude.com/claude-code)