### PR TITLE
feat(dt-eval-cli): add trajectory mode flag to ScopeConfig (AI-458-1)

### DIFF
--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -78,6 +78,7 @@ export interface ScopeConfig {
   };
   /** Custom span attribute mapping. Defaults handle OTel + OpenLLMetry. */
   spanFields?: SpanFieldsMap;
+  mode?: "span" | "trajectory";
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds \`mode?: "span" | "trajectory"\` optional field to \`ScopeConfig\` (defaults to \`"span"\`, preserving existing behaviour)
- Enables future tickets to branch on mode for agentic trajectory-level evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)