### PR TITLE
feat(dt-eval-cli): preserve full message history in trajectory mode (AI-458-2)

### DIFF
--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -79,6 +79,7 @@ export interface ScopeConfig {
   /** Custom span attribute mapping. Defaults handle OTel + OpenLLMetry. */
   spanFields?: SpanFieldsMap;
   mode?: "span" | "trajectory";
+  keepPartTypes?: string[];
 }
 
 /**

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -149,6 +149,8 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
 
 export interface ParseSpanOptions {
   spanFields?: SpanFieldsMap;
+  mode?: "span" | "trajectory";
+  keepPartTypes?: string[];
 }
 
 /**
@@ -227,6 +229,29 @@ function extractRolesFromJsonMessages(value: string | undefined):
   return out;
 }
 
+const DEFAULT_KEEP_PART_TYPES = ["text", "tool_call", "tool_call_response"];
+
+function extractFullHistory(raw: string, keepPartTypes?: string[]): string | null {
+  try {
+    const messages = JSON.parse(raw);
+    if (!Array.isArray(messages)) return null;
+    const keep = new Set(keepPartTypes ?? DEFAULT_KEEP_PART_TYPES);
+    const filtered = messages
+      .map((msg: { role: string; parts?: Array<{ type?: string; content?: unknown; text?: unknown }>; content?: unknown }) => {
+        if (!Array.isArray(msg.parts)) return msg;
+        const parts = msg.parts.filter((p) => !p.type || keep.has(p.type));
+        return { ...msg, parts };
+      })
+      .filter((msg) => {
+        if (!Array.isArray(msg.parts)) return true;
+        return msg.parts.length > 0;
+      });
+    return JSON.stringify(filtered);
+  } catch {
+    return null;
+  }
+}
+
 export function parseSpanResults(
   records: unknown[],
   options: ParseSpanOptions = {},
@@ -277,8 +302,13 @@ export function parseSpanResults(
     if (inputRoles) {
       systemInstruction ??= inputRoles.system;
       userPrompt ??= inputRoles.user;
-      if (inputMatch?.key === DEFAULT_INPUT_FIELDS[0] && inputRoles.user) {
-        input = inputRoles.user;
+      if (inputMatch?.key === DEFAULT_INPUT_FIELDS[0]) {
+        if (options.mode === 'trajectory' && input) {
+          const filtered = extractFullHistory(input, options.keepPartTypes);
+          if (filtered) input = filtered;
+        } else if (inputRoles.user) {
+          input = inputRoles.user;
+        }
       }
     }
 

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -229,7 +229,7 @@ function extractRolesFromJsonMessages(value: string | undefined):
   return out;
 }
 
-const DEFAULT_KEEP_PART_TYPES = ["text", "tool_call", "tool_call_response"];
+const DEFAULT_KEEP_PART_TYPES = ['text', 'tool_call', 'tool_call_response'];
 
 function extractFullHistory(raw: string, keepPartTypes?: string[]): string | null {
   try {
@@ -305,7 +305,7 @@ export function parseSpanResults(
       if (inputMatch?.key === DEFAULT_INPUT_FIELDS[0]) {
         if (options.mode === 'trajectory' && input) {
           const filtered = extractFullHistory(input, options.keepPartTypes);
-          if (filtered) input = filtered;
+          if (filtered && filtered !== '[]') input = filtered;
         } else if (inputRoles.user) {
           input = inputRoles.user;
         }

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -200,7 +200,7 @@ export async function runEvals(
   logger.timing('DQL fetch', dqlMs, { rawRecords: (rawRecords as unknown[]).length });
 
   const t0Parse = Date.now();
-  const parsedSpans = parseSpanResults(rawRecords, { spanFields: evalConfig.scope.spanFields });
+  const parsedSpans = parseSpanResults(rawRecords, { spanFields: evalConfig.scope.spanFields, mode: evalConfig.scope.mode, keepPartTypes: evalConfig.scope.keepPartTypes });
   // Safety net: re-apply the operation-name keep-list at the parser layer so a DQL
   // change or unexpected extra records can't leak non-keep-listed operation spans
   // into evaluation.


### PR DESCRIPTION
## Summary
- Adds `keepPartTypes` to `ScopeConfig` to control which message part types are retained in trajectory mode
- Adds `mode` and `keepPartTypes` to `ParseSpanOptions` and threads them through to `parseSpanResults`
- Adds `extractFullHistory` helper that filters message parts by type (defaults: `text`, `tool_call`, `tool_call_response`) and returns compact JSON
- In trajectory mode, `input` is set to the filtered full message history instead of just the latest user turn; span mode behavior is unchanged

## Test plan
- [ ] Verify span mode still extracts only the user turn from `gen_ai.input.messages` (no regression)
- [ ] Verify trajectory mode preserves full message history with default part types
- [ ] Verify `keepPartTypes` config filters out unwanted part types (e.g. reasoning parts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)