### PR TITLE
feat(dt-eval-cli): add conversation grouping and span selection for trajectory mode (AI-458-3)

### DIFF
--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -80,6 +80,8 @@ export interface ScopeConfig {
   spanFields?: SpanFieldsMap;
   mode?: "span" | "trajectory";
   keepPartTypes?: string[];
+  /** Maximum number of conversations to evaluate. Only used in trajectory mode. */
+  maxConversations?: number;
 }
 
 /**

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -12,6 +12,8 @@ export interface DqlQueryOptions {
   spanFields?: SpanFieldsMap;
   /** GenAI operation names to keep. Empty array disables this filter. */
   operationNames?: string[];
+  mode?: "span" | "trajectory";
+  maxConversations?: number;
 }
 
 export type DqlResult = GenAiSpan[];
@@ -77,9 +79,10 @@ export function filterSpansByOperationName(spans: GenAiSpan[], operationNames?: 
 }
 
 export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
-  const { app, since, limit = 1000, errorsOnly = false, spanFields } = opts;
+  const { app, since, limit = 1000, errorsOnly = false, spanFields, mode, maxConversations = 200 } = opts;
   const operationNames = resolveOperationNames(opts.operationNames);
   const fields = resolveFields(spanFields);
+  const isTrajectory = mode === 'trajectory';
 
   // Use explicit from:/to: timeframe — a filter alone leaves Grail's default
   // ~2h analysis window in effect even when the filter asks for longer.
@@ -138,11 +141,15 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
     ...fields.systemInstruction,
     ...fields.model,
   ]);
+  if (isTrajectory) {
+    fieldSet.add('gen_ai.conversation.id');
+    fieldSet.add('gen_ai.response.finish_reasons');
+  }
   const baseFields = [...fieldSet].join(', ');
 
   lines.push(`| fields ${baseFields}, ${promptFields}`);
-  lines.push('| sort start_time desc');
-  lines.push(`| limit ${limit}`);
+  lines.push(isTrajectory ? '| sort end_time desc' : '| sort start_time desc');
+  lines.push(isTrajectory ? `| limit ${maxConversations * 20}` : `| limit ${limit}`);
 
   return lines.join('\n');
 }
@@ -342,10 +349,48 @@ export function parseSpanResults(
       responseModel: asString(r['gen_ai.response.model']),
       agentName: asString(r['gen_ai.agent.name']),
       isError: statusCode === 'ERROR' || undefined,
+      conversationId: asString(r['gen_ai.conversation.id']),
+      finishReasons: asString(r['gen_ai.response.finish_reasons']),
     });
   }
 
   return spans;
+}
+
+/**
+ * Group spans by conversationId (falling back to traceId), then select one
+ * representative span per group. Prefers spans with a "stop" finish reason;
+ * among ties, picks the latest by endTime (or startTime as fallback).
+ * Returns at most `maxConversations` spans (default 200).
+ */
+export function selectTrajectorySpans(spans: GenAiSpan[], maxConversations = 200): GenAiSpan[] {
+  const groups = new Map<string, GenAiSpan[]>();
+  for (const span of spans) {
+    const key = span.conversationId ?? span.traceId;
+    const group = groups.get(key);
+    if (group) {
+      group.push(span);
+    } else {
+      groups.set(key, [span]);
+    }
+  }
+
+  const selected: GenAiSpan[] = [];
+  for (const group of groups.values()) {
+    const best = group.reduce((a, b) => {
+      const aStop = a.finishReasons?.toLowerCase().includes('stop') ?? false;
+      const bStop = b.finishReasons?.toLowerCase().includes('stop') ?? false;
+      if (aStop !== bStop) return aStop ? a : b;
+      const aTime = a.endTime ?? a.startTime;
+      const bTime = b.endTime ?? b.startTime;
+      if (!aTime) return b;
+      if (!bTime) return a;
+      return aTime >= bTime ? a : b;
+    });
+    selected.push(best);
+    if (selected.length >= maxConversations) break;
+  }
+  return selected;
 }
 
 function asString(value: unknown): string | undefined {

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -22,6 +22,9 @@ export type DqlResult = GenAiSpan[];
 // (gen_ai.prompt.0.content, gen_ai.prompt.1.content, ...)
 const PROMPT_SLOTS = 3;
 
+const TRAJECTORY_SPANS_PER_CONVERSATION = 20;
+const DEFAULT_MAX_CONVERSATIONS = 200;
+
 // Built-in candidate attribute lists per canonical field. User-supplied
 // candidates are prepended to these so the user's choice wins, but the
 // defaults remain as a fallback.
@@ -79,7 +82,7 @@ export function filterSpansByOperationName(spans: GenAiSpan[], operationNames?: 
 }
 
 export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
-  const { app, since, limit = 1000, errorsOnly = false, spanFields, mode, maxConversations = 200 } = opts;
+  const { app, since, limit = 1000, errorsOnly = false, spanFields, mode, maxConversations = DEFAULT_MAX_CONVERSATIONS } = opts;
   const operationNames = resolveOperationNames(opts.operationNames);
   const fields = resolveFields(spanFields);
   const isTrajectory = mode === 'trajectory';
@@ -149,7 +152,7 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
 
   lines.push(`| fields ${baseFields}, ${promptFields}`);
   lines.push(isTrajectory ? '| sort end_time desc' : '| sort start_time desc');
-  lines.push(isTrajectory ? `| limit ${maxConversations * 20}` : `| limit ${limit}`);
+  lines.push(isTrajectory ? `| limit ${maxConversations * TRAJECTORY_SPANS_PER_CONVERSATION}` : `| limit ${limit}`);
 
   return lines.join('\n');
 }
@@ -363,7 +366,7 @@ export function parseSpanResults(
  * among ties, picks the latest by endTime (or startTime as fallback).
  * Returns at most `maxConversations` spans (default 200).
  */
-export function selectTrajectorySpans(spans: GenAiSpan[], maxConversations = 200): GenAiSpan[] {
+export function selectTrajectorySpans(spans: GenAiSpan[], maxConversations = DEFAULT_MAX_CONVERSATIONS): GenAiSpan[] {
   const groups = new Map<string, GenAiSpan[]>();
   for (const span of spans) {
     const key = span.conversationId ?? span.traceId;
@@ -388,6 +391,7 @@ export function selectTrajectorySpans(spans: GenAiSpan[], maxConversations = 200
       return aTime >= bTime ? a : b;
     });
     selected.push(best);
+    // groups are in first-seen order; cap is best-effort, not strictly most-recent-N
     if (selected.length >= maxConversations) break;
   }
   return selected;

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -16,6 +16,8 @@ export interface GenAiSpan {
    * Useful for metrics that should score the user's turn alone. */
   userPrompt?: string;
   isError?: boolean;
+  conversationId?: string;   // gen_ai.conversation.id
+  finishReasons?: string;    // gen_ai.response.finish_reasons (raw string from DQL)
 }
 
 export interface BizeventPayload {

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -4,7 +4,7 @@ import type { DynatraceClient } from '../dt/client.js';
 import type { DtEvalConfig, MetricEntry, MetricInputs, CanonicalSpanField } from '../config/schema.js';
 import { metricId, metricInputs, metricMethod, metricParams } from '../config/schema.js';
 import type { GenAiSpan, BizeventPayload } from '../dt/types.js';
-import { buildGenAiSpanQuery, parseSpanResults, filterSpansByOperationName } from '../dt/dql.js';
+import { buildGenAiSpanQuery, parseSpanResults, filterSpansByOperationName, selectTrajectorySpans } from '../dt/dql.js';
 import { BizeventWriter, buildBizeventPayload } from '../dt/bizevent.js';
 import { DRIFT_METRIC_ID, runDriftDetection, buildDriftBizevents } from './drift.js';
 import { applySampling } from './sampler.js';
@@ -191,6 +191,8 @@ export async function runEvals(
     errorsOnly: evalConfig.scope.sampling?.strategy === 'errors-only',
     spanFields: evalConfig.scope.spanFields,
     operationNames: evalConfig.scope.operationNames,
+    mode: evalConfig.scope.mode,
+    maxConversations: evalConfig.scope.maxConversations,
   });
   logger.debug(`DQL query:\n${query}`);
 
@@ -204,7 +206,10 @@ export async function runEvals(
   // Safety net: re-apply the operation-name keep-list at the parser layer so a DQL
   // change or unexpected extra records can't leak non-keep-listed operation spans
   // into evaluation.
-  const allSpans = filterSpansByOperationName(parsedSpans, evalConfig.scope.operationNames);
+  const filteredSpans = filterSpansByOperationName(parsedSpans, evalConfig.scope.operationNames);
+  const allSpans = evalConfig.scope.mode === 'trajectory'
+    ? selectTrajectorySpans(filteredSpans, evalConfig.scope.maxConversations)
+    : filteredSpans;
   logger.timing('Parse spans', Date.now() - t0Parse, {
     spans: allSpans.length,
     dropped: parsedSpans.length - allSpans.length,


### PR DESCRIPTION
## Summary
- Adds `maxConversations` to `ScopeConfig` (trajectory mode only)
- Extends `DqlQueryOptions` with `mode` and `maxConversations`; trajectory mode fetches `gen_ai.conversation.id` + `gen_ai.response.finish_reasons`, sorts by `end_time desc`, and uses a `maxConversations * 20` limit
- Adds `conversationId` and `finishReasons` to `GenAiSpan` and populates them in `parseSpanResults`
- Adds exported `selectTrajectorySpans`: groups by `conversationId` (fallback: `traceId`), picks the best span per group (prefers `stop` finish reason, then latest `endTime`/`startTime`), caps at `maxConversations`
- Runner wires `mode`/`maxConversations` into `buildGenAiSpanQuery` and calls `selectTrajectorySpans` after operation-name filtering in trajectory mode; span mode flow is unchanged

## Test plan
- [ ] Trajectory mode DQL query includes `gen_ai.conversation.id`, `gen_ai.response.finish_reasons`, sorts by `end_time desc`, and limits to `maxConversations * 20`
- [ ] Span mode DQL query is unchanged
- [ ] `selectTrajectorySpans` groups correctly by `conversationId` when present, `traceId` otherwise
- [ ] `stop` finish-reason preference and latest-time tiebreaker work as specified
- [ ] `maxConversations` cap enforced (default 200)
- [ ] Span mode runner path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)