### PR TITLE
feat(dt-eval-cli): print resolved config path and carry eval name in bizevents (AI-459)

### DIFF
--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { loadConfig, validateConfig } from '../../config/index.js';
+import { loadConfig, validateConfig, getProjectConfigPath } from '../../config/index.js';
 import { resolveEndpoints, metricId } from '../../config/schema.js';
 import { DynatraceClient } from '../../dt/client.js';
 import { runEvals, type RunProgressEvent, type RunResult } from '../../runner/index.js';
@@ -115,6 +115,7 @@ export function createRunCommand(): Command {
       configureLogger({ level: 'debug' });
     }
     const configPath = configArg ?? options.config;
+    const resolvedConfigPath = configPath ?? getProjectConfigPath();
     let config;
     try {
       config = loadConfig(configPath ? { projectFile: configPath } : undefined);
@@ -128,6 +129,8 @@ export function createRunCommand(): Command {
       logger.error('Run "dt-evals configure" to set up your configuration.');
       process.exit(1);
     }
+
+    if (!options.ci) logger.info(`Using config: ${resolvedConfigPath}`);
 
     const { origin, destination } = resolveEndpoints(config.dynatrace);
     const missing: string[] = [];

--- a/dt-eval-cli/src/cli/commands/run.ts
+++ b/dt-eval-cli/src/cli/commands/run.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { loadConfig, validateConfig, getProjectConfigPath } from '../../config/index.js';
+import { loadConfig, validateConfig } from '../../config/index.js';
 import { resolveEndpoints, metricId } from '../../config/schema.js';
 import { DynatraceClient } from '../../dt/client.js';
 import { runEvals, type RunProgressEvent, type RunResult } from '../../runner/index.js';
@@ -115,7 +115,6 @@ export function createRunCommand(): Command {
       configureLogger({ level: 'debug' });
     }
     const configPath = configArg ?? options.config;
-    const resolvedConfigPath = configPath ?? getProjectConfigPath();
     let config;
     try {
       config = loadConfig(configPath ? { projectFile: configPath } : undefined);
@@ -130,7 +129,7 @@ export function createRunCommand(): Command {
       process.exit(1);
     }
 
-    if (!options.ci) logger.info(`Using config: ${resolvedConfigPath}`);
+    if (!options.ci) logger.info(`Using config: ${config.sourcePath ?? 'defaults + environment'}`);
 
     const { origin, destination } = resolveEndpoints(config.dynatrace);
     const missing: string[] = [];

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -31,7 +31,7 @@ function getGlobalConfigPath(): string {
   return join(homedir(), '.dt-eval', 'config.yaml');
 }
 
-export function getProjectConfigPath(): string {
+function getProjectConfigPath(): string {
   return join(process.cwd(), '.dt-eval.yaml');
 }
 
@@ -169,11 +169,16 @@ export function loadConfig(opts?: LoadConfigOptions): DtEvalConfig {
   const globalPath = opts?.globalFile ?? getGlobalConfigPath();
   const projectPath = opts?.projectFile ?? getProjectConfigPath();
 
-  const globalConfig = readYamlFile(globalPath) ?? {};
-  const projectConfig = readYamlFile(projectPath) ?? {};
+  const globalConfig = readYamlFile(globalPath);
+  const projectConfig = readYamlFile(projectPath);
+
+  // Track the source file per layer so project overrides global — the merged
+  // config then carries the path it was effectively loaded from.
+  if (globalConfig) globalConfig.sourcePath = globalPath;
+  if (projectConfig) projectConfig.sourcePath = projectPath;
 
   // Merge: defaults < global < project (migrate legacy field names first)
-  const merged = resolveEffectiveConfig(deepMerge(migrateLegacy(globalConfig) as DtEvalConfig, migrateLegacy(projectConfig) as Partial<DtEvalConfig>));
+  const merged = resolveEffectiveConfig(deepMerge(migrateLegacy(globalConfig ?? {}) as DtEvalConfig, migrateLegacy(projectConfig ?? {}) as Partial<DtEvalConfig>));
 
   // Apply env var overrides (highest precedence)
   return applyEnvVars(merged);
@@ -187,6 +192,7 @@ export function loadConfig(opts?: LoadConfigOptions): DtEvalConfig {
  */
 function stripSecrets(config: DtEvalConfig): DtEvalConfig {
   const clone = JSON.parse(JSON.stringify(config)) as DtEvalConfig;
+  delete clone.sourcePath;
   if (clone.judge) {
     delete clone.judge.apiKey;
     delete clone.judge.secretKey;

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -31,7 +31,7 @@ function getGlobalConfigPath(): string {
   return join(homedir(), '.dt-eval', 'config.yaml');
 }
 
-function getProjectConfigPath(): string {
+export function getProjectConfigPath(): string {
   return join(process.cwd(), '.dt-eval.yaml');
 }
 

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -126,6 +126,8 @@ export interface AlertsConfig {
 
 export interface DtEvalConfig {
   schemaVersion: number;
+  /** Absolute path of the config file this was loaded from. Runtime-only metadata; never persisted. */
+  sourcePath?: string;
   /** Human-readable name for this eval configuration (e.g. "travel-advisor-prod") */
   name?: string;
   dynatrace: DynatraceConfig;

--- a/dt-eval-cli/src/dt/bizevent.ts
+++ b/dt-eval-cli/src/dt/bizevent.ts
@@ -47,6 +47,7 @@ export function buildBizeventPayload(
   serviceName?: string,
   judgeInputs?: JudgeInputs,
   storeEvaluatedPrompt = false,
+  evalName?: string,
 ): BizeventPayload {
   const payload: BizeventPayload = {
     'event.type': 'gen_ai.evaluation.result',
@@ -68,6 +69,7 @@ export function buildBizeventPayload(
     ...(judgeProvider ? { 'gen_ai.provider.name': judgeProvider } : {}),
     ...(serviceName ? { 'dt.service.name': serviceName } : {}),
     'dt.eval.run_id': runId,
+    ...(evalName ? { 'dt.eval.name': evalName } : {}),
     'gen_ai.eval.client': CLIENT_NAME,
     'gen_ai.eval.client.version': CLIENT_VERSION,
     'span.start_time': span.startTime,

--- a/dt-eval-cli/src/dt/types.ts
+++ b/dt-eval-cli/src/dt/types.ts
@@ -52,6 +52,7 @@ export interface BizeventPayload {
   'gen_ai.provider.name'?: string;
   'dt.service.name'?: string;
   'dt.eval.run_id': string;
+  'dt.eval.name'?: string;
   'gen_ai.eval.client': string;
   'gen_ai.eval.client.version': string;
 }

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -388,7 +388,7 @@ export async function runEvals(
       r.span, r.metricId, r.metricName, r.evalResult, runId, r.method,
       isLlm ? judgeProvider : undefined,
       isLlm ? judgeModel : undefined,
-      evalConfig.scope.service, r.evalInput, storeEvaluatedPrompt,
+      evalConfig.scope.service, r.evalInput, storeEvaluatedPrompt, evalConfig.name,
     );
   });
   emit?.({ phase: 'writing', payloads: payloads.length });

--- a/dt-eval-cli/tests/config.test.ts
+++ b/dt-eval-cli/tests/config.test.ts
@@ -142,6 +142,15 @@ describe('config', () => {
 
       const config = loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: join(TEST_DIR, 'nonexistent.yaml') });
       expect(config.dynatrace.environmentUrl).toBe('https://global.dynatrace.com');
+      expect(config.sourcePath).toBe(GLOBAL_CONFIG_PATH);
+    });
+
+    it('sourcePath resolves to the project file when it exists, else the global, else undefined', () => {
+      writeYaml(GLOBAL_CONFIG_PATH, { schemaVersion: 1, dynatrace: { environmentUrl: 'https://global.dynatrace.com' }, judge: { provider: 'openai' } });
+      writeYaml(PROJECT_CONFIG_PATH, { dynatrace: { environmentUrl: 'https://project.dynatrace.com' } });
+
+      expect(loadConfig({ globalFile: GLOBAL_CONFIG_PATH, projectFile: PROJECT_CONFIG_PATH }).sourcePath).toBe(PROJECT_CONFIG_PATH);
+      expect(loadConfig({ globalFile: join(TEST_DIR, 'nope.yaml'), projectFile: join(TEST_DIR, 'nope.yaml') }).sourcePath).toBeUndefined();
     });
   });
 

--- a/dt-eval-cli/tests/dt/bizevent.test.ts
+++ b/dt-eval-cli/tests/dt/bizevent.test.ts
@@ -47,6 +47,13 @@ describe('buildBizeventPayload', () => {
     expect(payload['gen_ai.evaluation.input.agent']).toBe('my-agent');
   });
 
+  it('carries the eval name (config.name) when provided and omits it otherwise', () => {
+    const named = buildBizeventPayload(makeSpan(), 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o', undefined, undefined, false, 'my-eval-config');
+    expect(named['dt.eval.name']).toBe('my-eval-config');
+    const unnamed = buildBizeventPayload(makeSpan(), 'relevance', 'Relevance', makeEvalResult(), 'run-1', 'llm_as_judge', 'openai', 'gpt-4o');
+    expect(unnamed['dt.eval.name']).toBeUndefined();
+  });
+
   it('sets event.type to "gen_ai.evaluation.result"', () => {
     const payload = buildBizeventPayload(makeSpan(), 'toxicity', 'Toxicity', makeEvalResult(), 'run-1', 'llm_as_judge', 'anthropic', 'claude');
     expect(payload['event.type']).toBe('gen_ai.evaluation.result');


### PR DESCRIPTION
## What

Addresses two small pieces of feedback (AI-459):

- **Print the config file used by `dt-evals run`.** The command now resolves and prints the config path it picked up (`Using config: <path>`) before the run starts — suppressed in `--ci` mode.
- **Carry the eval name into bizevents.** Adds a `dt.eval.name` field to the evaluation-result bizevent, populated from the config's `name`, so results can be grouped/filtered by eval configuration.

## Verify

Run against real traces:
\`\`\`dql
fetch bizevents, from: now()-30m
| filter event.type == "gen_ai.evaluation.result"
| summarize count = count(), by: {\`dt.eval.name\`}
\`\`\`

Confirmed end-to-end: all written results carry the config's `name`, and the CLI prints the resolved config path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)