### PR TITLE
docs(dt-eval-cli): split README into docs/ and add evaluation guides (AI-465)

### DIFF
--- a/dt-eval-cli/.gitignore
+++ b/dt-eval-cli/.gitignore
@@ -14,3 +14,5 @@ dist/
 # Project-specific eval configs (contain credentials — use example.dt-eval.yaml as a template)
 *.dt-eval.yaml
 !example.dt-eval.yaml
+# Committed, placeholder-only example configs
+!examples/*.dt-eval.yaml

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -20,7 +20,7 @@ npx @dynatrace-oss/dt-evals validate
 npx @dynatrace-oss/dt-evals run --since 1h --sample 10 --concurrency 10
 ```
 
-> 🎮 **See it live before installing** — [**open the dt-evals playground dashboard**](http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8) on our public Dynatrace tenant. Real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, click-through to the originating trace.
+> 🎮 **See it live before installing** — [**open the dt-evals playground dashboard**](https://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8) on our public Dynatrace tenant. Real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, click-through to the originating trace.
 
 ## Why Teams Use It
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -41,12 +41,12 @@ npx @dynatrace-oss/dt-evals run --since 1h --sample 10 --concurrency 10
 
 ## What It Does
 
-- **14 built-in judge metrics** plus **deterministic code checks** for safety, grounding, relevance, quality, and structure
-- **Single-turn (span) and multi-turn (trajectory) evaluation** — see [Evaluations](docs/evaluations.md)
-- **Statistical drift detection** against a 7-day baseline of prior scores
-- **Flexible sampling** with random percentage, latest `N`, or `errors-only`
-- **PII masking before judge calls** for emails, phone numbers, credit cards, and SSNs
-- **OpenAI, Anthropic, Azure OpenAI, Google Gemini (Vertex AI), and Bedrock support** with optional custom base URLs
+- **14 built-in judge metrics** plus **deterministic code checks** for safety, grounding, relevance, quality, and structure — see [Evaluation types](docs/evaluations.md#evaluation-types)
+- **Single-turn (span) and multi-turn (trajectory) evaluation** — see [Evaluation scope](docs/evaluations.md#evaluation-scope)
+- **Statistical drift detection** against a 7-day baseline of prior scores — see [Drift detection](docs/evaluations.md#drift-detection)
+- **Flexible sampling** with random percentage, latest `N`, or `errors-only` — see [Scope](docs/configuration.md#scope)
+- **PII masking before judge calls** for emails, phone numbers, credit cards, and SSNs — see [PII handling](docs/configuration.md#pii-handling)
+- **OpenAI, Anthropic, Azure OpenAI, Google Gemini Enterprise Platform (Vertex AI), and Bedrock support** with optional custom base URLs — see [Environment variables](docs/configuration.md#environment-variables)
 - **CI-friendly runs** with JSON output and non-zero exit codes on threshold breaches
 - **Local run history and scheduled runs** stored locally
 - **TypeScript API** for running the evaluator catalog directly in code
@@ -63,11 +63,13 @@ sample traces -> mask sensitive data -> score with judge or code check -> write 
                                              query in DQL, dashboard, alert, export
 ```
 
+For a step-by-step breakdown of the run pipeline, see [How a run works](docs/evaluations.md#how-a-run-works).
+
 ## Requirements
 
 - Node.js `>=20`
 - A Dynatrace environment with GenAI spans or OpenTelemetry-style `gen_ai.*` fields
-- Credentials for your judge provider (OpenAI, Anthropic, Azure OpenAI, Google Gemini/Vertex AI, or Bedrock)
+- Credentials for your judge provider (OpenAI, Anthropic, Azure OpenAI, Google Gemini Enterprise Platform (Vertex AI), or Bedrock)
 
 ## Install
 
@@ -104,6 +106,8 @@ dt-evals configure \
   --output .dt-eval.yaml
 ```
 
+For every config option see [Configuration](docs/configuration.md), or start from a ready-to-run file in [`examples/`](examples/).
+
 ### 2. Validate the setup
 
 ```bash
@@ -127,6 +131,8 @@ dt-evals run --since 6h --metric relevance --ci
 ```
 
 Tune `--concurrency` (or `judge.concurrency` in your config) to control how many judge calls run in parallel. Default is 5.
+
+To score whole conversations instead of single turns, set `scope.mode: trajectory` — see [Evaluation scope](docs/evaluations.md#evaluation-scope) and [`examples/trajectory.dt-eval.yaml`](examples/trajectory.dt-eval.yaml). For deterministic checks, see [`examples/code-evals.dt-eval.yaml`](examples/code-evals.dt-eval.yaml).
 
 ## Documentation
 
@@ -167,7 +173,7 @@ Global flags:
 --debug                    Per-step timing logs
 ```
 
-Run records are stored in `~/.dt-eval/runs.json`; schedules in `~/.dt-eval/schedules.json`.
+Flags override values from the config file; for the full set of config keys see [Configuration](docs/configuration.md). Run records are stored in `~/.dt-eval/runs.json`; schedules in `~/.dt-eval/schedules.json`.
 
 ## TypeScript Library
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -5,20 +5,14 @@
 [![npm version](https://img.shields.io/npm/v/@dynatrace-oss/dt-evals/alpha?style=flat-square&label=npm&color=cb3837)](https://www.npmjs.com/package/@dynatrace-oss/dt-evals)
 [![npm downloads](https://img.shields.io/npm/dm/@dynatrace-oss/dt-evals?style=flat-square&color=cb3837)](https://www.npmjs.com/package/@dynatrace-oss/dt-evals)
 [![Build](https://github.com/dynatrace-oss/dt-evals/actions/workflows/ci-cli.yml/badge.svg?branch=main)](https://github.com/dynatrace-oss/dt-evals/actions/workflows/ci-cli.yml)
-[![License](https://img.shields.io/badge/license-Apache_2.0-blue?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/badge/license-Apache_2.0-blue?style=flat-square)](../LICENSE)
 [![Node](https://img.shields.io/node/v/@dynatrace-oss/dt-evals/alpha?style=flat-square)](package.json)
 
 ![dt-evals welcome](../assets/dt-evals-welcome.gif)
 
 `dt-evals` is for teams shipping chat, RAG, copilots, and agent workflows who want evals to run on real traffic, not just curated test sets.
 
-Today, the CLI uses Dynatrace as both the trace source and the evaluation result store. It pulls gen_ai.* spans from your live environment, masks sensitive data in memory, scores real production interactions with an LLM judge, detects score drift over time, and writes structured evaluation results back to Dynatrace as business events.
-
-That means when a score drops or an outlier appears, you do not just see that quality regressed, you can trace it back through the full AI execution path: prompts, retrieval context, model calls, tool usage, latency, failures, and service dependencies.
-
-In practice, this gives AI engineers a closed loop for evaluation, observability, alerting, anomaly detection, and remediation on the same production telemetry they already use to operate their systems.
-
-The repository also includes `dt-eval-lib`, a reusable TypeScript evaluation engine for running the same judge-based metrics directly in code, using either the built-in evaluator catalog or your own custom prompt definitions. It also fits cleanly into broader evaluation workflows and observability stacks such as Ragas, MLflow, or Langfuse when you want to orchestrate or track evals in those systems alongside this library.
+The CLI uses Dynatrace as both the trace source and the evaluation result store. It pulls `gen_ai.*` spans from your live environment, masks sensitive data in memory, scores real production interactions with an LLM judge or deterministic code checks, detects score drift over time, and writes structured results back to Dynatrace as business events. When a score drops, you can trace it back through the full AI execution path: prompts, retrieval context, model calls, tool usage, latency, and failures.
 
 ```bash
 npx @dynatrace-oss/dt-evals configure
@@ -26,20 +20,16 @@ npx @dynatrace-oss/dt-evals validate
 npx @dynatrace-oss/dt-evals run --since 1h --sample 10 --concurrency 10
 ```
 
-Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many judge calls run in parallel — bump it for faster runs, drop it if the provider rate-limits you. Default is 5.
-
 > 🎮 **See it live before installing** — [**open the dt-evals playground dashboard**](http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8) on our public Dynatrace tenant. Real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, click-through to the originating trace.
 
 ## Why Teams Use It
 
 - Run evals on real production traces, not static test sets
 - Keep eval results in Dynatrace with traces, logs, metrics, dashboards, and alerts
-- Catch common LLM and agent failure modes with built-in judge metrics
+- Catch common LLM and agent failure modes with built-in judge and code metrics
 - Detect regressions, drift, and outlier score changes early
 - Go from low score to root cause with end-to-end AI observability
-- Correlate failures with prompts, retrieval, tool calls, latency, and dependencies
-- Reuse the same evaluator catalog in CI, app code, and local workflows with dt-eval-lib
-- Trigger alerts and optional remediation from the same evaluation pipeline
+- Reuse the same evaluator catalog in CI, app code, and local workflows with `dt-eval-lib`
 
 ## Packages
 
@@ -51,16 +41,14 @@ Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many j
 
 ## What It Does
 
-- **14 built-in judge metrics** for safety, grounding, relevance, quality, and retrieval quality
-- **Statistical drift detection** against a 7 day baseline of prior evaluation scores
+- **14 built-in judge metrics** plus **deterministic code checks** for safety, grounding, relevance, quality, and structure
+- **Single-turn (span) and multi-turn (trajectory) evaluation** — see [Evaluations](docs/evaluations.md)
+- **Statistical drift detection** against a 7-day baseline of prior scores
 - **Flexible sampling** with random percentage, latest `N`, or `errors-only`
 - **PII masking before judge calls** for emails, phone numbers, credit cards, and SSNs
-- **Evaluated prompt/response excluded from bizevents by default** — opt in with `storeEvaluatedPrompt` (see [Configuration](#configuration))
-- **OpenAI, Anthropic, Azure OpenAI, Google Gemini Enterprise Platform (Vertex AI), and Bedrock support** with optional custom base URLs for gateways and proxies
-- **CI friendly runs** with JSON output and non-zero exit codes on threshold breaches
-- **Local run history** with list, inspect, and export flows
-- **Scheduled runs** stored locally and triggerable on demand
-- **Evaluator inspection and testing** from the CLI
+- **OpenAI, Anthropic, Azure OpenAI, Google Gemini (Vertex AI), and Bedrock support** with optional custom base URLs
+- **CI-friendly runs** with JSON output and non-zero exit codes on threshold breaches
+- **Local run history and scheduled runs** stored locally
 - **TypeScript API** for running the evaluator catalog directly in code
 
 ## How It Works
@@ -69,19 +57,17 @@ Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many j
 Dynatrace spans (gen_ai.*)
         |
         v
-sample traces -> mask sensitive data -> score with LLM judge -> write business events
-                                                                    |
-                                                                    v
+sample traces -> mask sensitive data -> score with judge or code check -> write business events
+                                                                              |
+                                                                              v
                                              query in DQL, dashboard, alert, export
 ```
-
-The current CLI path is Dynatrace specific. The product positioning is broader: continuous evals for AI-native engineering teams, using your live LLM traffic as the source of truth.
 
 ## Requirements
 
 - Node.js `>=20`
 - A Dynatrace environment with GenAI spans or OpenTelemetry-style `gen_ai.*` fields
-- Credentials for your judge provider (OpenAI, Anthropic, Azure OpenAI, Google Gemini Enterprise Platform (Vertex AI), or Bedrock)
+- Credentials for your judge provider (OpenAI, Anthropic, Azure OpenAI, Google Gemini/Vertex AI, or Bedrock)
 
 ## Install
 
@@ -101,13 +87,11 @@ The CLI also auto-loads a local `.env` file from the current working directory.
 
 ### 1. Create config
 
-Interactive setup:
-
 ```bash
-dt-evals configure
+dt-evals configure                 # interactive
 ```
 
-Non-interactive setup:
+Or non-interactively:
 
 ```bash
 dt-evals configure \
@@ -126,115 +110,29 @@ dt-evals configure \
 dt-evals validate
 ```
 
-This checks:
-
-- config schema
-- Dynatrace connectivity
-- judge provider reachability
-- evaluator catalog availability
+Checks the config schema, Dynatrace connectivity, judge provider reachability, and evaluator catalog availability.
 
 ### 3. Run evals on recent traces
 
 ```bash
-dt-evals run --since 1h --sample 10 --concurrency 5
+dt-evals run --since 1h --sample 10 --concurrency 5   # full run
+dt-evals run --since 6h --metric faithfulness         # one evaluator
+dt-evals run --since 1h --sample 5 --dry-run          # preview, no judge calls or writes
 ```
 
-Run only one evaluator:
-
-```bash
-dt-evals run --since 6h --metric faithfulness
-```
-
-Preview the work without calling the judge or writing results:
-
-```bash
-dt-evals run --since 1h --sample 5 --dry-run
-```
-
-## CLI Workflows
-
-### Production eval run
-
-```bash
-dt-evals run \
-  --since 2h \
-  --sample 20 \
-  --concurrency 8 \
-  --debug
-```
-
-### CI gate on quality regressions
+Gate CI on quality regressions (exit `1` on a threshold breach):
 
 ```bash
 dt-evals run --since 6h --metric relevance --ci
 ```
 
-- exit code `0`: no threshold breaches
-- exit code `1`: one or more threshold breaches
+Tune `--concurrency` (or `judge.concurrency` in your config) to control how many judge calls run in parallel. Default is 5.
 
-Example GitHub Actions step:
+## Documentation
 
-```yaml
-- name: Run LLM eval gate
-  run: npx @dynatrace-oss/dt-evals run --since 6h --metric faithfulness --ci
-  env:
-    DT_ENV_URL: ${{ secrets.DT_ENV_URL }}
-    DT_API_TOKEN: ${{ secrets.DT_API_TOKEN }}
-    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-```
-
-### Run drift detection only
-
-```bash
-dt-evals run --metric drift --since 24h
-```
-
-This uses prior evaluation results already written to Dynatrace and compares the recent window against a 7 day baseline.
-
-### Inspect available evaluators
-
-```bash
-dt-evals evaluators list
-dt-evals evaluators show faithfulness
-dt-evals evaluators test relevance
-```
-
-Create or remove a custom evaluator:
-
-```bash
-dt-evals evaluators add
-dt-evals evaluators delete my-custom-eval
-```
-
-### Manage run history
-
-```bash
-dt-evals runs list --limit 20
-dt-evals runs show run-2026-04-10T12-00-00-ab12cd34
-dt-evals runs export --format csv --output runs.csv
-```
-
-Run records are stored locally in `~/.dt-eval/runs.json`.
-
-### Schedule recurring runs
-
-```bash
-dt-evals schedule add --name hourly-rag --cron "0 * * * *" --since 1h --sample 10
-dt-evals schedule list
-dt-evals schedule run <schedule-id>
-dt-evals schedule disable <schedule-id>
-dt-evals schedule enable <schedule-id>
-dt-evals schedule delete <schedule-id>
-```
-
-Schedules are stored locally in `~/.dt-eval/schedules.json`.
-
-### Check current status
-
-```bash
-dt-evals status
-dt-evals configure --show
-```
+- **[Evaluations](docs/evaluations.md)** — span (single-turn) vs trajectory (multi-turn), LLM-as-judge vs code checks, the built-in catalog, custom evaluators, and drift
+- **[Configuration](docs/configuration.md)** — full config reference, sampling, cross-tenant, token scopes, span-field mapping, results, and DQL
+- **[Example configs](examples/)** — [`trajectory.dt-eval.yaml`](examples/trajectory.dt-eval.yaml), [`code-evals.dt-eval.yaml`](examples/code-evals.dt-eval.yaml), and the full [`example.dt-eval.yaml`](example.dt-eval.yaml)
 
 ## Commands
 
@@ -258,500 +156,22 @@ Global flags:
 `run` flags:
 
 ```text
---config <path>        Path to config file
---since <duration>     Trace lookback window, for example 1h or 24h
---sample <percent>     Percentage of traces to evaluate
---metric <name>        Run only one evaluator
---dry-run              Do not call the judge or write results
---ci                   JSON result output and exit 1 on threshold breach
---concurrency <n>      Parallel judge calls (overrides judge.concurrency in the config; default 5)
---store-evaluated-prompt   Include the evaluated prompt/response in bizevents (overrides storeEvaluatedPrompt in the config; default: false)
---debug                Per-step timing logs
+--config <path>            Path to config file
+--since <duration>         Trace lookback window, for example 1h or 24h
+--sample <percent>         Percentage of traces to evaluate
+--metric <name>            Run only one evaluator
+--dry-run                  Do not call the judge or write results
+--ci                       JSON result output and exit 1 on threshold breach
+--concurrency <n>          Parallel judge calls (overrides judge.concurrency; default 5)
+--store-evaluated-prompt   Include the evaluated prompt/response in bizevents (default: false)
+--debug                    Per-step timing logs
 ```
 
-## Configuration
-
-Config is resolved in this order:
-
-| Priority | Source |
-|----------|--------|
-| 1 | Environment variables |
-| 2 | Project config, usually `.dt-eval.yaml` |
-| 3 | Global config, `~/.dt-eval/config.yaml` |
-| 4 | Built-in defaults |
-
-### Example config
-
-```yaml
-schemaVersion: 3
-name: travel-assistant-prod
-
-dynatrace:
-  environmentUrl: https://your-env.live.dynatrace.com
-  dtctlContext: my-prod-context
-
-judge:
-  provider: openai
-  model: gpt-4.1
-  timeout: 30000
-  maxRetries: 2
-  concurrency: 5
-
-scope:
-  service: travel-assistant
-  since: 1h
-  operationNames: [chat, text_completion, generate_content]
-  sampling:
-    strategy: random
-    percent: 10
-
-metrics:
-  enabled:
-    - faithfulness
-    - hallucination
-    - relevance
-    - answer-completeness
-    - id: valid-json
-      method: json_schema
-      params:
-        schema:
-          type: object
-          required: [answer]
-    - id: no-refusal
-      method: must_not_contain
-      params:
-        keywords: ["i cannot help", "i'm sorry"]
-        mode: any
-    - drift
-
-alerts:
-  thresholds:
-    faithfulness: 0.7
-    relevance: 0.7
-    answer-completeness: 0.8
-
-storeEvaluatedPrompt: false
-```
-
-String entries and object entries without `method` use the configured
-LLM-as-judge provider. Deterministic entries set `method` to `exact_match`,
-`regex`, `must_not_match`, `json_schema`, `must_contain`, or
-`must_not_contain`. `exact_match` also requires an `inputs.expectedOutput`
-route to a canonical span field:
-
-```yaml
-metrics:
-  enabled:
-    - id: exact-answer
-      method: exact_match
-      params:
-        caseSensitive: false
-        trim: true
-      inputs:
-        expectedOutput: context
-```
-
-By default, the runner keeps only chat/text-generation spans:
-`chat`, `text_completion`, and `generate_content`. Configure
-`scope.operationNames` to narrow or extend that keep-list, for example
-`operationNames: [chat]`. Set it to `[]` only if you intentionally want to
-disable the operation-name filter.
-
-Sampling strategies:
-
-| Strategy | Example |
-|----------|---------|
-| Random percentage | `strategy: random`, `percent: 10` |
-| Most recent traces | `strategy: latest`, `count: 200` |
-| Error traces only | `strategy: errors-only` |
-
-### Cross-tenant configuration
-
-`dynatrace.environmentUrl` / `dynatrace.apiToken` describe a single tenant
-that handles both reads and writes. To split them — fetch GenAI spans from
-one tenant and write evaluation bizevents to another — use `origin` (read)
-and `destination` (write):
-
-```yaml
-dynatrace:
-  origin:
-    environmentUrl: https://prod.live.dynatrace.com
-  destination:
-    environmentUrl: https://eval-results.dev.apps.dynatracelabs.com
-```
-
-Top-level `environmentUrl` / `apiToken` (if present) act as fallbacks — if
-either side omits a field, the top-level value is used. So a single-tenant
-config is just the cross-tenant form with both sides empty.
-
-The `validate` command probes each side separately, including a real
-`fetch spans | limit 1` against the origin to catch missing
-`storage:spans:read` scope before a run is attempted.
-
-### Required token scopes
-
-| Scope | Required for |
-|---|---|
-| `storage:spans:read` | Reading GenAI spans (origin) |
-| `storage:buckets:read` | Grail prerequisite — without this, DQL returns empty results silently |
-| `storage:bizevents:read` | Drift detection baseline (reads past eval bizevents) |
-| `storage:events:write` | Writing evaluation results as bizevents (destination) |
-| `storage:metrics:write` | Writing evaluation metrics *(optional)* |
-| `storage:logs:read` | `dt-evals validate` connectivity probe |
-
-For `dt-evals alerts apply` (Dynatrace Workflows), grant these additionally on the dtctl OAuth client:
-
-| Scope | Required for |
-|---|---|
-| `automation:workflows:read` | `list`, `diff`, idempotent `apply` |
-| `automation:workflows:write` | `apply`, `delete` |
-| `automation:workflows:run` | Manual execution from the UI *(optional)* |
-
-### Custom span field mapping
-
-By default, the CLI reads OTel GenAI semconv (`gen_ai.input.messages`,
-`gen_ai.output.messages`, …). It also probes a
-small set of legacy fallback attributes (`gen_ai.prompt.N.*`,
-`gen_ai.completion.0.content`) for compatibility with older emitters. If
-your spans expose the LLM I/O under different attribute names — for
-example OpenInference (`llm.input_messages`, `llm.output_messages`,
-`llm.model_name`) — point the CLI at them via `scope.spanFields`. See the
-[`dynatrace-ai-agent-instrumentation-examples`](https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples)
-for end-to-end instrumentation examples.
-Each entry accepts a single attribute or a list of candidates; the first
-non-null value wins, with the built-in defaults appended as fallback.
-
-**Example 1 — explicit legacy output mapping**:
-
-```yaml
-scope:
-  service: pydantic-ai-music-agent
-  spanFields:
-    output: `gen_ai.completion.0.content
-```
-
-The default output mapping uses `gen_ai.output.messages`. `spanFields` lets
-you opt into legacy or emitter-specific attributes explicitly.
-
-**Example 2 — OTel spans not following the GenAI SemConv (OpenInference):**
-
-```yaml
-scope:
-  service: my-openinference-service
-  since: 30m
-  spanFields:
-    input: [llm.input_messages, input.value]
-    output: [llm.output_messages, output.value]
-    model: llm.model_name
-```
-
-OpenInference usually stores chat turns in `llm.input_messages` /
-`llm.output_messages` and plain-text payloads in `input.value` /
-`output.value`, so listing both keeps the mapping resilient across
-instrumentations.
-
-### Per-metric input routing
-
-Metric entries in `metrics.enabled` accept either a string id (the legacy
-form) or an object with `inputs` that overrides which canonical span field
-feeds each evaluator input slot. This is useful when a metric should score
-only part of the conversation — e.g. `user-frustration` evaluates the user's
-turn in isolation, not the joined transcript:
-
-```yaml
-metrics:
-  enabled:
-    - faithfulness                                  # plain string form
-    - id: user-frustration
-      inputs:
-        input: userPrompt
-    - id: hallucination
-      inputs:
-        context: context
-```
-
-Available canonical fields: `input`, `output`, `context`,
-`systemInstruction`, `model`, `userPrompt` (latest user-role prompt slot, extracted from
-`gen_ai.prompt.N.role == "user"`). `context` has no built-in default span
-attribute — if a span does not provide it, evaluator context is omitted unless
-you explicitly route `inputs.context` elsewhere.
-
-### Full example
-
-A complete `.dt-eval.yaml` combining everything — schema bump, custom
-span field mapping, per-metric input routing, sampling, alerts:
-
-```yaml
-schemaVersion: 3
-name: travel-assistant-prod
-
-dynatrace:
-  environmentUrl: https://your-env.live.dynatrace.com
-  # apiToken loaded from DT_API_TOKEN env var
-
-judge:
-  provider: azure-openai
-  model: gpt-4.1-mini
-  # apiKey, baseUrl, apiVersion loaded from AZURE_OPENAI_* env vars
-
-scope:
-  service: travel-assistant
-  since: 1h
-  operationNames: [chat, text_completion, generate_content]
-  sampling:
-    strategy: latest
-    count: 50
-  spanFields:
-    context: span.context
-    # input, systemInstruction, model use built-in defaults
-
-metrics:
-  enabled:
-    - faithfulness
-    - relevance
-    - hallucination
-    - answer-completeness
-    - id: user-frustration
-      inputs:
-        input: userPrompt
-    - id: no-refusal
-      method: must_not_contain
-      params:
-        keywords: ["i cannot help", "i'm sorry"]
-        mode: any
-
-alerts:
-  thresholds:
-    faithfulness: 0.7
-    relevance: 0.7
-    answer-completeness: 0.8
-    user-frustration: 1
-```
-
-Useful environment variables:
-
-```bash
-DT_ENV_URL=https://your-env.live.dynatrace.com
-DT_API_TOKEN=dt0c01.xxxxx
-DT_DTCTL_CONTEXT=my-prod-context
-
-# Cross-tenant overrides (optional — when set, these win over the top-level pair)
-DT_ORIGIN_ENV_URL=https://prod.live.dynatrace.com
-DT_ORIGIN_API_TOKEN=dt0s16.xxxxx
-DT_DESTINATION_ENV_URL=https://eval-results.dev.apps.dynatracelabs.com
-DT_DESTINATION_API_TOKEN=dt0s16.yyyyy
-
-JUDGE_PROVIDER=openai
-JUDGE_MODEL=gpt-4.1
-
-OPENAI_API_KEY=sk-...
-OPENAI_BASE_URL=https://your-gateway.example.com/v1
-
-ANTHROPIC_API_KEY=sk-ant-...
-ANTHROPIC_BASE_URL=https://your-proxy.example.com
-
-# Google Gemini Enterprise Platform (Vertex AI)
-GOOGLE_API_KEY=...
-# Or authenticate via Workload Identity / Application Default Credentials instead of an API key.
-# Set the target project and region (or judge.project / judge.location in config):
-GOOGLE_CLOUD_PROJECT=my-gcp-project
-GOOGLE_CLOUD_LOCATION=global
-```
-
-## Results in Dynatrace
-
-Evaluation results are written as business events with `event.type == "gen_ai.evaluation.result"`.
-
-Important fields include:
-
-| Field | Meaning |
-|-------|---------|
-| `gen_ai.evaluation.name` | Evaluator name, for example `faithfulness` |
-| `gen_ai.evaluation.score.value` | Numeric score |
-| `gen_ai.evaluation.score.label` | `pass` or `fail` |
-| `gen_ai.evaluation.score.explanation` | Short summary from the judge |
-| `dt.eval.run_id` | Evaluation run identifier |
-| `trace_id` | Source trace ID |
-| `dt.service.name` | Service filter when configured |
-
-Example DQL:
-
-```dql
-fetch bizevents
-| filter event.type == "gen_ai.evaluation.result"
-| summarize avg_score = avg(gen_ai.evaluation.score.value), by: { gen_ai.evaluation.name }
-| sort avg_score asc
-```
-
-Drift results are written back as the same event type with `gen_ai.evaluation.type == "drift"`.
-
-## Built-in Evaluators
-
-`dt-evals` ships with 14 built-in LLM judge evaluators, plus drift detection as a separate statistical metric.
-
-| Evaluator | Measures | Fields used |
-|-----------|----------|-------------|
-| `answer-completeness` | Whether all parts of the request were answered | `input`, `output` |
-| `bias` | Harmful bias or unfair framing | `input`, `output` |
-| `conciseness` | Whether the answer avoids filler and unnecessary padding | `input`, `output` |
-| `context-relevance` | Retrieval quality for supplied context | `input` |
-| `factual-accuracy` | Accuracy using world knowledge | `input`, `output` |
-| `faithfulness` | Whether the answer is grounded in provided context | `input`, `output` |
-| `fluency` | Grammar, clarity, and natural language quality | `input`, `output` |
-| `hallucination` | Unsupported or fabricated claims | `input`, `output` |
-| `pii-leakage` | Personally identifiable information in the answer | `input`, `output` |
-| `prompt-injection` | Prompt injection attempts in the input | `input` |
-| `relevance` | Whether the answer addresses the user request | `input`, `output` |
-| `summarization-quality` | Summary faithfulness, coverage, and conciseness | `input`, `output` |
-| `toxicity` | Harmful, offensive, or unsafe output | `output` |
-| `user-frustration` | Frustration signals in the user's message | `input` |
-
-### Deterministic evaluators (code checks)
-
-Not every check needs an LLM. Add a `method` to a metric entry in
-`metrics.enabled` to run a fast, reproducible, zero-cost code check instead of
-an LLM judge. Each check scores the span output as pass (`1.0`) or fail
-(`0.0`). Omitting `method` keeps the default LLM-as-judge behavior, so existing
-configs are unaffected.
-
-Available methods: `exact_match`, `regex`, `must_not_match`, `must_contain`,
-`must_not_contain`, and `json_schema`.
-
-**`must_contain` — require an expected keyword to be present**
-
-```yaml
-metrics:
-  enabled:
-    - id: cites-a-source
-      method: must_contain
-      params:
-        keywords: ["source", "reference", "according to"]
-        mode: any          # any = pass if one is present; all = require every keyword
-```
-
-**`must_not_contain` — block forbidden or harmful words**
-
-```yaml
-    - id: no-harmful-words
-      method: must_not_contain
-      params:
-        keywords: ["harmful_word_1", "harmful_word_2", "harmful_word_3"]
-        mode: any          # fail if ANY blocked word appears
-        # matching is case-insensitive by default; set caseSensitive: true to change
-```
-
-**`must_not_match` — fail if the output matches a pattern (e.g. a leaked IP address)**
-
-```yaml
-    - id: no-ip-leaked
-      method: must_not_match
-      params:
-        pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b"
-```
-
-> Use `regex` for the opposite check — pass only when the output **does** match
-> the pattern.
-
-**`json_schema` — require valid, well-structured JSON**
-
-```yaml
-    - id: valid-response-object
-      method: json_schema
-      params:
-        schema:
-          type: object
-          required: [answer]
-```
-
-> **Note:** `json_schema` parses the raw output, so the output must be **bare**
-> JSON — a response wrapped in markdown fences (` ```json … ``` `) will not
-> parse. `json_schema` needs the optional `ajv` dependency, and `regex` /
-> `must_not_match` need the optional `recheck` dependency (for ReDoS safety).
-
-### Custom evaluators
-
-You can create a custom judge metric with `dt-evals evaluators add`, then
-enable it in `metrics.enabled` like any built-in evaluator.
-
-**Example custom evaluator definition** (created by the interactive wizard
-and stored locally):
-
-```json
-{
-  "id": "answer-style",
-  "version": "1",
-  "name": "Answer Style",
-  "description": "Checks whether the answer is concise, direct, and well structured.",
-  "prompt": "Evaluate the answer style for this request. User request: {{input}} Answer: {{output}} Return a continuous score from 0.0 to 1.0.",
-  "requiredFields": ["input", "output"],
-  "scoring": {
-    "type": "continuous",
-    "range": [0, 1],
-    "threshold": 0.7
-  }
-}
-```
-
-Enable it in your eval config:
-
-```yaml
-metrics:
-  enabled:
-    - faithfulness
-    - answer-style
-```
-
-Useful commands:
-
-```bash
-dt-evals evaluators add
-dt-evals evaluators list
-dt-evals evaluators show answer-style
-dt-evals evaluators test answer-style
-```
-
-### Drift detection
-
-`drift` compares current score distributions against a 7 day baseline of prior evaluation events.
-
-Use it when you care about regressions that show up gradually, not just single-run threshold breaches.
+Run records are stored in `~/.dt-eval/runs.json`; schedules in `~/.dt-eval/schedules.json`.
 
 ## TypeScript Library
 
-The repository also includes [`dt-eval-lib`](../dt-eval-lib/README.md) — a standalone TypeScript package for running the same judge-based metrics directly in code, tests, and CI pipelines without the CLI. It supports all six providers and the full built-in evaluator catalog.
-
-## PII Handling
-
-For CLI trace evaluation runs, the following are masked in memory before content is sent to an external judge model:
-
-- email addresses
-- phone numbers
-- credit card numbers
-- social security numbers
-
-The original values are not sent to the judge by the CLI path.
-
-## Data Expectations
-
-The CLI reads OTel GenAI semconv fields by default:
-
-| Canonical field | Default attributes read |
-|----------------|------------------------|
-| `input` | `gen_ai.input.messages` |
-| `output` | `gen_ai.output.messages` |
-| `model` | `gen_ai.request.model` |
-| `systemInstruction` | `gen_ai.system_instruction` |
-
-This makes the CLI a good fit for apps instrumented with OpenTelemetry
-GenAI conventions. For other tracing schemas — including OpenInference —
-use `scope.spanFields` to map their attributes to the canonical fields
-above. OpenInference commonly uses attributes such as
-`llm.input_messages`, `llm.output_messages`, `input.value`,
-`output.value`, and `llm.model_name`. A small set of legacy fallback attributes
-(`gen_ai.prompt.<n>.content/role`, `gen_ai.completion.0.content`) is also
-probed for compatibility with older emitters. See
-[`dynatrace-ai-agent-instrumentation-examples`](https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples)
-for example instrumentations.
+The repository also includes [`dt-eval-lib`](../dt-eval-lib/README.md) — a standalone TypeScript package for running the same judge-based metrics directly in code, tests, and CI pipelines without the CLI. It supports all providers and the full built-in evaluator catalog.
 
 ## Local Development
 
@@ -778,10 +198,8 @@ npm test
 
 ## Contributing
 
-Issues and pull requests are welcome.
-
-If you want to work on a larger change, open an issue first so the direction is clear before implementation starts.
+Issues and pull requests are welcome. For a larger change, open an issue first so the direction is clear before implementation starts.
 
 ## License
 
-[Apache 2.0](LICENSE)
+[Apache 2.0](../LICENSE)

--- a/dt-eval-cli/docs/configuration.md
+++ b/dt-eval-cli/docs/configuration.md
@@ -1,0 +1,287 @@
+# Configuration
+
+Full configuration reference for `dt-evals`. For evaluation concepts (span vs
+trajectory, LLM judge vs code checks) see [Evaluations](evaluations.md).
+
+Config is resolved in this order:
+
+| Priority | Source |
+|----------|--------|
+| 1 | Environment variables |
+| 2 | Project config, usually `.dt-eval.yaml` |
+| 3 | Global config, `~/.dt-eval/config.yaml` |
+| 4 | Built-in defaults |
+
+## Example config
+
+```yaml
+schemaVersion: 3
+name: travel-assistant-prod
+
+dynatrace:
+  environmentUrl: https://your-env.live.dynatrace.com
+  dtctlContext: my-prod-context
+
+judge:
+  provider: openai
+  model: gpt-4.1
+  timeout: 30000
+  maxRetries: 2
+  concurrency: 5
+
+scope:
+  service: travel-assistant
+  since: 1h
+  operationNames: [chat, text_completion, generate_content]
+  sampling:
+    strategy: random
+    percent: 10
+
+metrics:
+  enabled:
+    - faithfulness
+    - hallucination
+    - relevance
+    - answer-completeness
+    - id: valid-json
+      method: json_schema
+      params:
+        schema:
+          type: object
+          required: [answer]
+    - drift
+
+alerts:
+  thresholds:
+    faithfulness: 0.7
+    relevance: 0.7
+    answer-completeness: 0.8
+
+storeEvaluatedPrompt: false
+```
+
+## Scope
+
+`scope` selects which spans to evaluate.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `service` | — | `service.name` filter |
+| `since` | `1h` | Look-back window, e.g. `1h`, `24h` |
+| `operationNames` | `[chat, text_completion, generate_content]` | GenAI operations to keep; `[]` disables the filter |
+| `sampling` | random @ 5% | See below |
+| `mode` | `span` | `span` (single-turn) or `trajectory` (multi-turn) — see [Evaluations](evaluations.md#evaluation-scope) |
+| `maxConversations` | `200` | Trajectory only: conversation groups to consider before sampling |
+| `maxMessages` | `50` | Trajectory only: max messages kept per conversation (oldest dropped) |
+| `keepPartTypes` | `[text, tool_call, tool_call_response]` | Trajectory only: message part types to keep |
+
+By default the runner keeps only chat/text-generation spans (`chat`,
+`text_completion`, `generate_content`). Set `scope.operationNames` to narrow or
+extend that keep-list; set it to `[]` only to disable the filter entirely.
+
+Sampling strategies:
+
+| Strategy | Example |
+|----------|---------|
+| Random percentage | `strategy: random`, `percent: 10` |
+| Most recent traces | `strategy: latest`, `count: 200` |
+| Error traces only | `strategy: errors-only` |
+
+## Cross-tenant configuration
+
+`dynatrace.environmentUrl` / `dynatrace.apiToken` describe a single tenant that
+handles both reads and writes. To split them — fetch GenAI spans from one tenant
+and write evaluation bizevents to another — use `origin` (read) and
+`destination` (write):
+
+```yaml
+dynatrace:
+  origin:
+    environmentUrl: https://prod.live.dynatrace.com
+  destination:
+    environmentUrl: https://eval-results.dev.apps.dynatracelabs.com
+```
+
+Top-level `environmentUrl` / `apiToken` act as fallbacks — if either side omits
+a field, the top-level value is used. A single-tenant config is just the
+cross-tenant form with both sides empty.
+
+The `validate` command probes each side separately, including a real
+`fetch spans | limit 1` against the origin to catch a missing
+`storage:spans:read` scope before a run is attempted.
+
+## Required token scopes
+
+| Scope | Required for |
+|---|---|
+| `storage:spans:read` | Reading GenAI spans (origin) |
+| `storage:buckets:read` | Grail prerequisite — without this, DQL returns empty results silently |
+| `storage:bizevents:read` | Drift detection baseline (reads past eval bizevents) |
+| `storage:events:write` | Writing evaluation results as bizevents (destination) |
+| `storage:metrics:write` | Writing evaluation metrics *(optional)* |
+| `storage:logs:read` | `dt-evals validate` connectivity probe |
+
+For `dt-evals alerts apply` (Dynatrace Workflows), grant these additionally on
+the dtctl OAuth client:
+
+| Scope | Required for |
+|---|---|
+| `automation:workflows:read` | `list`, `diff`, idempotent `apply` |
+| `automation:workflows:write` | `apply`, `delete` |
+| `automation:workflows:run` | Manual execution from the UI *(optional)* |
+
+## Custom span field mapping
+
+By default, the CLI reads OTel GenAI semconv (`gen_ai.input.messages`,
+`gen_ai.output.messages`, …). It also probes a small set of legacy fallback
+attributes (`gen_ai.prompt.N.*`, `gen_ai.completion.0.content`) for
+compatibility with older emitters. If your spans expose the LLM I/O under
+different attribute names — for example OpenInference (`llm.input_messages`,
+`llm.output_messages`, `llm.model_name`) — point the CLI at them via
+`scope.spanFields`. See the
+[`dynatrace-ai-agent-instrumentation-examples`](https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples)
+for end-to-end instrumentation examples.
+
+Each entry accepts a single attribute or a list of candidates; the first
+non-null value wins, with the built-in defaults appended as fallback.
+
+**Example 1 — explicit legacy output mapping:**
+
+```yaml
+scope:
+  service: pydantic-ai-music-agent
+  spanFields:
+    output: gen_ai.completion.0.content
+```
+
+The default output mapping uses `gen_ai.output.messages`. `spanFields` lets you
+opt into legacy or emitter-specific attributes explicitly.
+
+**Example 2 — OTel spans not following the GenAI SemConv (OpenInference):**
+
+```yaml
+scope:
+  service: my-openinference-service
+  since: 30m
+  spanFields:
+    input: [llm.input_messages, input.value]
+    output: [llm.output_messages, output.value]
+    model: llm.model_name
+```
+
+OpenInference usually stores chat turns in `llm.input_messages` /
+`llm.output_messages` and plain-text payloads in `input.value` / `output.value`,
+so listing both keeps the mapping resilient across instrumentations.
+
+## Per-metric input routing
+
+Metric entries in `metrics.enabled` accept either a string id (the legacy form)
+or an object with `inputs` that overrides which canonical span field feeds each
+evaluator input slot. This is useful when a metric should score only part of the
+conversation — e.g. `user-frustration` evaluates the user's turn in isolation,
+not the joined transcript:
+
+```yaml
+metrics:
+  enabled:
+    - faithfulness                                  # plain string form
+    - id: user-frustration
+      inputs:
+        input: userPrompt
+    - id: hallucination
+      inputs:
+        context: context
+```
+
+Available canonical fields: `input`, `output`, `context`, `systemInstruction`,
+`model`, `userPrompt` (latest user-role prompt slot, extracted from
+`gen_ai.prompt.N.role == "user"`). `context` has no built-in default span
+attribute — if a span does not provide it, evaluator context is omitted unless
+you explicitly route `inputs.context` elsewhere.
+
+## Environment variables
+
+```bash
+DT_ENV_URL=https://your-env.live.dynatrace.com
+DT_API_TOKEN=dt0c01.xxxxx
+DT_DTCTL_CONTEXT=my-prod-context
+
+# Cross-tenant overrides (optional — when set, these win over the top-level pair)
+DT_ORIGIN_ENV_URL=https://prod.live.dynatrace.com
+DT_ORIGIN_API_TOKEN=dt0s16.xxxxx
+DT_DESTINATION_ENV_URL=https://eval-results.dev.apps.dynatracelabs.com
+DT_DESTINATION_API_TOKEN=dt0s16.yyyyy
+
+JUDGE_PROVIDER=openai
+JUDGE_MODEL=gpt-4.1
+
+OPENAI_API_KEY=sk-...
+OPENAI_BASE_URL=https://your-gateway.example.com/v1
+
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_BASE_URL=https://your-proxy.example.com
+
+# Google Gemini Enterprise Platform (Vertex AI)
+GOOGLE_API_KEY=...
+# Or authenticate via Workload Identity / Application Default Credentials instead of an API key.
+# Set the target project and region (or judge.project / judge.location in config):
+GOOGLE_CLOUD_PROJECT=my-gcp-project
+GOOGLE_CLOUD_LOCATION=global
+```
+
+## Results in Dynatrace
+
+Evaluation results are written as business events with
+`event.type == "gen_ai.evaluation.result"`.
+
+| Field | Meaning |
+|-------|---------|
+| `gen_ai.evaluation.name` | Evaluator name, for example `faithfulness` |
+| `gen_ai.evaluation.score.value` | Numeric score |
+| `gen_ai.evaluation.score.label` | `pass` or `fail` |
+| `gen_ai.evaluation.score.explanation` | Short summary from the judge |
+| `dt.eval.run_id` | Evaluation run identifier |
+| `trace_id` | Source trace ID |
+| `dt.service.name` | Service filter when configured |
+
+Example DQL:
+
+```dql
+fetch bizevents
+| filter event.type == "gen_ai.evaluation.result"
+| summarize avg_score = avg(gen_ai.evaluation.score.value), by: { gen_ai.evaluation.name }
+| sort avg_score asc
+```
+
+Drift results are written back as the same event type with
+`gen_ai.evaluation.type == "drift"`.
+
+## PII handling
+
+For CLI trace evaluation runs, the following are masked in memory before content
+is sent to an external judge model:
+
+- email addresses
+- phone numbers
+- credit card numbers
+- social security numbers
+
+The original values are not sent to the judge by the CLI path.
+
+## Data expectations
+
+The CLI reads OTel GenAI semconv fields by default:
+
+| Canonical field | Default attributes read |
+|----------------|------------------------|
+| `input` | `gen_ai.input.messages` |
+| `output` | `gen_ai.output.messages` |
+| `model` | `gen_ai.request.model` |
+| `systemInstruction` | `gen_ai.system_instruction` |
+
+This makes the CLI a good fit for apps instrumented with OpenTelemetry GenAI
+conventions. For other tracing schemas — including OpenInference — use
+`scope.spanFields` to map their attributes to the canonical fields above. A
+small set of legacy fallback attributes (`gen_ai.prompt.<n>.content/role`,
+`gen_ai.completion.0.content`) is also probed for compatibility with older
+emitters.

--- a/dt-eval-cli/docs/configuration.md
+++ b/dt-eval-cli/docs/configuration.md
@@ -88,6 +88,17 @@ Sampling strategies:
 | Most recent traces | `strategy: latest`, `count: 200` |
 | Error traces only | `strategy: errors-only` |
 
+Notes on how sampling is applied (defaults to `random` at 5%):
+
+- `random` shuffles the fetched spans and keeps `floor(percent / 100 × count)` of
+  them, so a low `percent` over a small window can round down to **zero** — raise
+  `percent` or widen `since` if a run evaluates nothing. `percent: 100` keeps all.
+- `latest` keeps the newest `count` spans (all of them when `count` is unset).
+- `errors-only` returns every error span and ignores `percent` / `count`.
+- In [trajectory mode](evaluations.md#evaluation-scope), sampling runs *after*
+  conversations are grouped, so it samples whole conversations (one representative
+  span each) drawn from at most `maxConversations`.
+
 ## Cross-tenant configuration
 
 `dynatrace.environmentUrl` / `dynatrace.apiToken` describe a single tenant that

--- a/dt-eval-cli/docs/configuration.md
+++ b/dt-eval-cli/docs/configuration.md
@@ -1,7 +1,8 @@
 # Configuration
 
-Full configuration reference for `dt-evals`. For evaluation concepts (span vs
-trajectory, LLM judge vs code checks) see [Evaluations](evaluations.md).
+Full configuration reference for `dt-evals`. For evaluation concepts and the
+types of supported evals (code evals or LLM-as-judge), see
+[Evaluations](evaluations.md).
 
 Config is resolved in this order:
 
@@ -174,6 +175,9 @@ OpenInference usually stores chat turns in `llm.input_messages` /
 so listing both keeps the mapping resilient across instrumentations.
 
 ## Per-metric input routing
+
+`dt-evals` ships multiple built-in metrics, or you can define your own — see
+[Evaluations](evaluations.md#evaluation-types) for the catalog and details.
 
 Metric entries in `metrics.enabled` accept either a string id (the legacy form)
 or an object with `inputs` that overrides which canonical span field feeds each

--- a/dt-eval-cli/docs/evaluations.md
+++ b/dt-eval-cli/docs/evaluations.md
@@ -187,8 +187,16 @@ scores the span output as pass (`1.0`) or fail (`0.0`).
 **Use it for** objective, structural checks — valid JSON, required keywords,
 forbidden phrases, exact/regex matches — where the answer is unambiguous.
 
-Available methods: `exact_match`, `regex`, `must_not_match`, `must_contain`,
-`must_not_contain`, `json_schema`.
+Available methods:
+
+| Method | How it works | Suggested use |
+|--------|--------------|---------------|
+| `exact_match` | Passes when the output equals an expected value (routed via `inputs.expectedOutput`); `caseSensitive` / `trim` options | Check a fixed, canonical answer |
+| `must_contain` | Passes when the output contains the keyword(s) — `mode: any` (one) or `all` (every) | Require a citation, disclaimer, or required token |
+| `must_not_contain` | Fails when the output contains a forbidden keyword (`mode: any` / `all`) | Block refusals, confidential markers, or banned terms |
+| `regex` | Passes when the output matches the `pattern` | Enforce a required format (ID, date, currency) |
+| `must_not_match` | Fails when the output matches the `pattern` | Catch leaked patterns (IPs, emails, secrets) |
+| `json_schema` | Passes when the output is bare JSON matching the `schema` | Validate structured or tool output |
 
 ```yaml
 metrics:

--- a/dt-eval-cli/docs/evaluations.md
+++ b/dt-eval-cli/docs/evaluations.md
@@ -1,0 +1,202 @@
+# Evaluations
+
+An evaluation in `dt-evals` is defined along two independent axes:
+
+- **Scope** — *how much* is scored: a single turn (`span`) or a whole
+  conversation (`trajectory`).
+- **Type** — *what computes the score*: an LLM-as-judge or a deterministic
+  code check.
+
+The axes compose: an LLM judge or a code check can each run in span or
+trajectory mode.
+
+---
+
+## Evaluation scope
+
+Set with `scope.mode` (default `span`).
+
+### Span — single-turn
+
+Scores one span: a single user turn and the model's reply. In span mode the
+input is collapsed to the latest user message.
+
+**Use it for** per-response quality: relevance, safety, grounding/faithfulness,
+retrieval (RAG) quality, PII leakage, prompt injection.
+
+```yaml
+scope:
+  mode: span   # default — can be omitted
+  since: 1h
+```
+
+### Trajectory — multi-turn (agentic)
+
+Scores a whole conversation. Spans are grouped by `gen_ai.conversation.id`
+(falling back to `trace.id` when absent); one representative span is picked per
+conversation (preferring one whose `finish_reason` is `stop`, else the latest),
+and its full `gen_ai.input.messages` history is evaluated as a single
+trajectory.
+
+**Use it for** conversation-level outcomes: goal/task completion, coherence
+across turns, knowledge retention, and frustration that builds over a session.
+
+```yaml
+scope:
+  mode: trajectory
+  since: 24h
+  maxConversations: 200                          # groups to consider before sampling (default 200)
+  maxMessages: 50                                # messages kept per conversation (default 50)
+  keepPartTypes: [text, tool_call, tool_call_response]
+```
+
+See [`examples/trajectory.dt-eval.yaml`](../examples/trajectory.dt-eval.yaml)
+for a complete config.
+
+#### Limitations and assumptions
+
+- **Full history must be inlined in the span.** Trajectory mode assumes the
+  representative span's `gen_ai.input.messages` carries the full conversation.
+  This holds for stateless APIs that re-send history on each call, but **breaks
+  for stateful APIs** (e.g. the OpenAI Responses API with `previous_response_id`)
+  that keep history server-side.
+- **Grouping degrades without `gen_ai.conversation.id`** — each trace becomes
+  its own "conversation".
+- **`maxConversations` is best-effort**, in first-seen order — not a strict
+  most-recent-N guarantee.
+- **Full-history extraction only applies to the default `gen_ai.input.messages`
+  attribute.** Custom `scope.spanFields.input` mappings are not expanded into
+  history.
+- **Truncation is message-count based** (`maxMessages`), not token based.
+- **Config-driven only** — there is no trajectory CLI flag; set `scope.mode`.
+
+---
+
+## Evaluation types
+
+Set per metric in `metrics.enabled`. Omitting `method` selects the LLM-as-judge
+default; adding a `method` selects a deterministic code check.
+
+### LLM-as-judge
+
+A judge model scores the span against a prompt. Use it for **subjective or
+nuanced quality where there is no ground truth** — relevance, faithfulness,
+tone, completeness.
+
+`dt-evals` ships 14 built-in judge evaluators:
+
+| Evaluator | Measures | Fields used |
+|-----------|----------|-------------|
+| `answer-completeness` | Whether all parts of the request were answered | `input`, `output` |
+| `bias` | Harmful bias or unfair framing | `input`, `output` |
+| `conciseness` | Whether the answer avoids filler and unnecessary padding | `input`, `output` |
+| `context-relevance` | Retrieval quality for supplied context | `input` |
+| `factual-accuracy` | Accuracy using world knowledge | `input`, `output` |
+| `faithfulness` | Whether the answer is grounded in provided context | `input`, `output` |
+| `fluency` | Grammar, clarity, and natural language quality | `input`, `output` |
+| `hallucination` | Unsupported or fabricated claims | `input`, `output` |
+| `pii-leakage` | Personally identifiable information in the answer | `input`, `output` |
+| `prompt-injection` | Prompt injection attempts in the input | `input` |
+| `relevance` | Whether the answer addresses the user request | `input`, `output` |
+| `summarization-quality` | Summary faithfulness, coverage, and conciseness | `input`, `output` |
+| `toxicity` | Harmful, offensive, or unsafe output | `output` |
+| `user-frustration` | Frustration signals in the user's message | `input` |
+
+#### Custom evaluators
+
+Create a custom judge metric with `dt-evals evaluators add`, then enable it in
+`metrics.enabled` like any built-in. Definitions are stored locally:
+
+```json
+{
+  "id": "answer-style",
+  "version": "1",
+  "name": "Answer Style",
+  "description": "Checks whether the answer is concise, direct, and well structured.",
+  "prompt": "Evaluate the answer style for this request. User request: {{input}} Answer: {{output}} Return a continuous score from 0.0 to 1.0.",
+  "requiredFields": ["input", "output"],
+  "scoring": { "type": "continuous", "range": [0, 1], "threshold": 0.7 }
+}
+```
+
+```bash
+dt-evals evaluators add
+dt-evals evaluators list
+dt-evals evaluators show answer-style
+dt-evals evaluators test answer-style
+```
+
+### Code (deterministic) evals
+
+Not every check needs an LLM. Add a `method` to a metric entry to run a fast,
+reproducible, **zero-cost** code check instead of a judge call. Each check
+scores the span output as pass (`1.0`) or fail (`0.0`).
+
+**Use it for** objective, structural checks — valid JSON, required keywords,
+forbidden phrases, exact/regex matches — where the answer is unambiguous.
+
+Available methods: `exact_match`, `regex`, `must_not_match`, `must_contain`,
+`must_not_contain`, `json_schema`.
+
+```yaml
+metrics:
+  enabled:
+    - id: cites-a-source
+      method: must_contain
+      params:
+        keywords: ["source", "reference", "according to"]
+        mode: any          # any = pass if one present; all = require every keyword
+
+    - id: no-harmful-words
+      method: must_not_contain
+      params:
+        keywords: ["harmful_word_1", "harmful_word_2"]
+        mode: any          # fail if ANY blocked word appears (case-insensitive by default)
+
+    - id: no-ip-leaked
+      method: must_not_match
+      params:
+        pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b"
+
+    - id: valid-response-object
+      method: json_schema
+      params:
+        schema:
+          type: object
+          required: [answer]
+
+    - id: exact-answer
+      method: exact_match
+      params:
+        caseSensitive: false
+        trim: true
+      inputs:
+        expectedOutput: context   # route the expected value to a canonical span field
+```
+
+Use `regex` for the opposite of `must_not_match` — pass only when the output
+**does** match the pattern.
+
+See [`examples/code-evals.dt-eval.yaml`](../examples/code-evals.dt-eval.yaml)
+for a complete config.
+
+#### Limitations and assumptions
+
+- **`json_schema` parses raw output**, so the output must be **bare** JSON — a
+  response wrapped in markdown fences (` ```json … ``` `) will not parse.
+- **Optional dependencies:** `json_schema` needs `ajv`; `regex` /
+  `must_not_match` need `recheck` (for ReDoS safety).
+
+---
+
+## Drift detection
+
+`drift` is a statistical metric (no LLM call) that compares current score
+distributions against a 7-day baseline of prior evaluation events. Use it for
+regressions that show up gradually rather than as single-run threshold breaches.
+
+```yaml
+metrics:
+  enabled:
+    - drift
+```

--- a/dt-eval-cli/docs/evaluations.md
+++ b/dt-eval-cli/docs/evaluations.md
@@ -1,5 +1,22 @@
 # Evaluations
 
+## How a run works
+
+```text
+fetch gen_ai.* spans  →  sample  →  mask PII  →  evaluate  →  write bizevents
+    (scope.service,      (scope.    (in memory)  (judge or    (gen_ai.evaluation.result
+     scope.since)         sampling)               code check)   in Dynatrace)
+```
+
+1. **Fetch** — query `gen_ai.*` spans from Dynatrace for the configured service and window.
+2. **Sample** — reduce to the traces (or conversations, in trajectory mode) to score.
+3. **Mask PII** — redact sensitive values in memory before content leaves the process.
+4. **Evaluate** — run each enabled metric as an LLM-as-judge or a deterministic code check.
+5. **Write bizevents** — write results back to Dynatrace as `gen_ai.evaluation.result`
+   business events. If `drift` is enabled, it runs afterward against the historical baseline.
+
+## Two axes
+
 An evaluation in `dt-evals` is defined along two independent axes:
 
 - **Scope** — *how much* is scored: a single turn (`span`) or a whole

--- a/dt-eval-cli/docs/evaluations.md
+++ b/dt-eval-cli/docs/evaluations.md
@@ -102,6 +102,10 @@ scope:
   keepPartTypes: [text]
 ```
 
+> **Sampling** here applies to conversations, not individual spans: `scope.sampling`
+> selects a share of the grouped conversations (each represented by one span), drawn
+> from at most `maxConversations`. See [Configuration](configuration.md#scope).
+
 See [`examples/trajectory.dt-eval.yaml`](../examples/trajectory.dt-eval.yaml)
 for a complete config.
 

--- a/dt-eval-cli/docs/evaluations.md
+++ b/dt-eval-cli/docs/evaluations.md
@@ -15,6 +15,10 @@ fetch gen_ai.* spans  →  sample  →  mask PII  →  evaluate  →  write bize
 5. **Write bizevents** — write results back to Dynatrace as `gen_ai.evaluation.result`
    business events. If `drift` is enabled, it runs afterward against the historical baseline.
 
+> **Trajectory mode** adds steps between *fetch* and *sample*: spans are grouped into
+> conversations and one representative span (with truncated history) is selected per
+> conversation. See [Evaluation scope](#evaluation-scope) below.
+
 ## Two axes
 
 An evaluation in `dt-evals` is defined along two independent axes:

--- a/dt-eval-cli/docs/evaluations.md
+++ b/dt-eval-cli/docs/evaluations.md
@@ -53,22 +53,53 @@ scope:
 
 ### Trajectory — multi-turn (agentic)
 
-Scores a whole conversation. Spans are grouped by `gen_ai.conversation.id`
-(falling back to `trace.id` when absent); one representative span is picked per
-conversation (preferring one whose `finish_reason` is `stop`, else the latest),
-and its full `gen_ai.input.messages` history is evaluated as a single
-trajectory.
+Scores a whole conversation as one unit — the mode for agentic and multi-turn
+assistants, where quality is a property of the entire session rather than any
+single reply. It is **opt-in**: `scope.mode` defaults to `span`, so set
+`mode: trajectory` to enable it.
 
 **Use it for** conversation-level outcomes: goal/task completion, coherence
 across turns, knowledge retention, and frustration that builds over a session.
+
+**How it works**
+
+1. **Fetch** — the query additionally pulls `gen_ai.conversation.id` and
+   `gen_ai.response.finish_reasons`, ordered by most recent.
+2. **Group** — spans are grouped into conversations by `gen_ai.conversation.id`
+   (falling back to `trace.id` when the attribute is absent).
+3. **Select** — one representative span is picked per conversation: the span whose
+   `finish_reason` is `stop` (the completed turn), or the latest span otherwise.
+4. **Rebuild history** — the representative span's `gen_ai.input.messages` (a JSON
+   array of role-tagged messages) is treated as the full transcript. Each
+   message's `parts` are filtered to `keepPartTypes`, messages left empty are
+   dropped, and if the transcript exceeds `maxMessages` only the most recent
+   `maxMessages` are kept.
+5. The trajectory is then sampled, masked, and evaluated like any other input,
+   and written back as a `gen_ai.evaluation.result` bizevent.
 
 ```yaml
 scope:
   mode: trajectory
   since: 24h
-  maxConversations: 200                          # groups to consider before sampling (default 200)
-  maxMessages: 50                                # messages kept per conversation (default 50)
-  keepPartTypes: [text, tool_call, tool_call_response]
+  maxConversations: 200                                 # groups to consider before sampling (default 200)
+  maxMessages: 50                                       # messages kept per conversation (default 50)
+  keepPartTypes: [text, tool_call, tool_call_response]  # message parts to keep (default)
+```
+
+**What you can tune**
+
+| Key | Default | What it controls |
+|-----|---------|------------------|
+| `maxConversations` | `200` | How many conversation groups to consider before sampling. Raise for wider coverage, lower to cut cost. |
+| `maxMessages` | `50` | Max messages kept per trajectory; the oldest are dropped first. Lower it to keep judges within a smaller context. |
+| `keepPartTypes` | `[text, tool_call, tool_call_response]` | Which message part types survive into the transcript. |
+
+For example, to score only the natural-language turns and drop tool traffic:
+
+```yaml
+scope:
+  mode: trajectory
+  keepPartTypes: [text]
 ```
 
 See [`examples/trajectory.dt-eval.yaml`](../examples/trajectory.dt-eval.yaml)

--- a/dt-eval-cli/docs/evaluations.md
+++ b/dt-eval-cli/docs/evaluations.md
@@ -61,7 +61,7 @@ single reply. It is **opt-in**: `scope.mode` defaults to `span`, so set
 **Use it for** conversation-level outcomes: goal/task completion, coherence
 across turns, knowledge retention, and frustration that builds over a session.
 
-**How it works**
+#### How it works
 
 1. **Fetch** — the query additionally pulls `gen_ai.conversation.id` and
    `gen_ai.response.finish_reasons`, ordered by most recent.
@@ -86,7 +86,7 @@ scope:
   keepPartTypes: [text, tool_call, tool_call_response]  # message parts to keep (default)
 ```
 
-**What you can tune**
+#### What you can tune
 
 | Key | Default | What it controls |
 |-----|---------|------------------|
@@ -240,7 +240,7 @@ Use `regex` for the opposite of `must_not_match` — pass only when the output
 See [`examples/code-evals.dt-eval.yaml`](../examples/code-evals.dt-eval.yaml)
 for a complete config.
 
-#### Limitations and assumptions
+#### Limitations
 
 - **`json_schema` parses raw output**, so the output must be **bare** JSON — a
   response wrapped in markdown fences (` ```json … ``` `) will not parse.

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -14,9 +14,9 @@ dynatrace:
   # Your Dynatrace environment URL (SaaS or Managed).
   environmentUrl: https://<your-env-id>.apps.dynatracelabs.com
 
-  # API token with the following scopes: bizevents.ingest, storage.read
-  # Tip: use the DYNATRACE_API_TOKEN env var instead of hardcoding the token.
-  apiToken: dt0c01.REPLACE_ME
+  # API token — loaded from the DT_API_TOKEN env var (or a local .env file).
+  # Needs span/bizevent read scopes and an events write scope; see docs/configuration.md.
+  # apiToken: dt0c01.REPLACE_ME
 
   # (Optional) dtctl context name to use OAuth for DQL queries instead of the
   # API token. Requires dtctl to be installed and authenticated.
@@ -26,12 +26,11 @@ dynatrace:
 # Judge (LLM-as-a-judge) provider
 # ---------------------------------------------------------------------------
 judge:
-  # Supported providers: openai, anthropic
+  # Supported providers: openai, anthropic, azure-openai, gemini, vertex, bedrock
   provider: openai
 
-  # API key for the judge provider.
-  # Tip: use OPENAI_API_KEY / ANTHROPIC_API_KEY env vars instead.
-  apiKey: sk-REPLACE_ME
+  # API key — loaded from the provider env var, e.g. OPENAI_API_KEY / ANTHROPIC_API_KEY.
+  # apiKey: sk-REPLACE_ME
 
   # (Optional) Override the model. Defaults: openai → gpt-4o, anthropic → claude-sonnet-4-6
   model: gpt-5.3
@@ -81,7 +80,6 @@ metrics:
     - pii-leakage           # Personally identifiable information in output
     - relevance             # Response answers the user's question
     - factual-accuracy      # Factual correctness vs. provided context
-    - coherence             # Logical flow and readability
     - context-relevance     # Retrieved context relevant to the question
     - answer-completeness   # All aspects of the question addressed
     - prompt-injection      # Adversarial prompt injection attempts
@@ -117,7 +115,6 @@ alerts:
     pii-leakage: 0        # fail if any PII leakage detected
     prompt-injection: 0   # fail if any injection detected
     relevance: 0.6        # fail if average relevance drops below 0.6
-    coherence: 3          # fail if average coherence drops below 3 (out of 5)
     answer-completeness: 0.7
     conciseness: 0.6
     faithfulness: 0.7

--- a/dt-eval-cli/example.dt-eval.yaml
+++ b/dt-eval-cli/example.dt-eval.yaml
@@ -33,7 +33,7 @@ judge:
   # apiKey: sk-REPLACE_ME
 
   # (Optional) Override the model. Defaults: openai → gpt-4o, anthropic → claude-sonnet-4-6
-  model: gpt-5.3
+  model: gpt-4.1
 
   # (Optional) Custom base URL — useful for Azure OpenAI or local proxies.
   # baseUrl: https://my-azure-resource.openai.azure.com/

--- a/dt-eval-cli/examples/code-evals.dt-eval.yaml
+++ b/dt-eval-cli/examples/code-evals.dt-eval.yaml
@@ -57,14 +57,16 @@ metrics:
       params:
         pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b"
 
-    # exact_match — compare output against a canonical span field.
+    # exact_match — compare the span output to another span field, routed via
+    # inputs.expectedOutput. It compares against a span field, not a literal
+    # string, so the routed field must carry the expected value.
     - id: exact-answer
       method: exact_match
       params:
         caseSensitive: false
         trim: true
       inputs:
-        expectedOutput: context
+        expectedOutput: context   # canonical span field holding the expected value
 
 alerts:
   thresholds:

--- a/dt-eval-cli/examples/code-evals.dt-eval.yaml
+++ b/dt-eval-cli/examples/code-evals.dt-eval.yaml
@@ -43,11 +43,12 @@ metrics:
         keywords: ["source", "reference", "according to"]
         mode: any            # any = pass if one present; all = require every keyword
 
-    # must_not_contain — block forbidden phrases (case-insensitive by default).
-    - id: no-refusal
+    # must_not_contain — block internal/confidential markers leaking into the
+    # answer (case-insensitive by default).
+    - id: no-confidential-disclosure
       method: must_not_contain
       params:
-        keywords: ["i cannot help", "i'm sorry"]
+        keywords: ["confidential", "internal use only", "do not distribute"]
         mode: any
 
     # must_not_match — fail if the output matches a pattern (e.g. a leaked IP).

--- a/dt-eval-cli/examples/code-evals.dt-eval.yaml
+++ b/dt-eval-cli/examples/code-evals.dt-eval.yaml
@@ -9,12 +9,12 @@ name: my-ai-service-prod
 
 dynatrace:
   environmentUrl: https://<your-env-id>.apps.dynatracelabs.com
-  apiToken: dt0c01.REPLACE_ME   # tip: use DT_API_TOKEN env var instead
+  # apiToken is loaded from the DT_API_TOKEN env var (or a local .env file).
 
 judge:
   provider: openai
-  apiKey: sk-REPLACE_ME         # tip: use OPENAI_API_KEY env var instead
   model: gpt-4.1
+  # apiKey is loaded from the provider env var, e.g. OPENAI_API_KEY.
 
 scope:
   service: my-ai-service-prod

--- a/dt-eval-cli/examples/code-evals.dt-eval.yaml
+++ b/dt-eval-cli/examples/code-evals.dt-eval.yaml
@@ -1,0 +1,70 @@
+# Code (deterministic) evaluation example
+# Deterministic checks run in-process — fast, reproducible, zero-cost, no judge call.
+# They coexist with LLM-as-judge metrics in the same run.
+# Run: dt-evals run --config examples/code-evals.dt-eval.yaml
+# See: docs/evaluations.md#evaluation-types
+
+schemaVersion: 3
+name: my-ai-service-prod
+
+dynatrace:
+  environmentUrl: https://<your-env-id>.apps.dynatracelabs.com
+  apiToken: dt0c01.REPLACE_ME   # tip: use DT_API_TOKEN env var instead
+
+judge:
+  provider: openai
+  apiKey: sk-REPLACE_ME         # tip: use OPENAI_API_KEY env var instead
+  model: gpt-4.1
+
+scope:
+  service: my-ai-service-prod
+  since: 1h
+  sampling:
+    strategy: random
+    percent: 10
+
+metrics:
+  enabled:
+    # LLM-as-judge metric — subjective quality, no ground truth.
+    - relevance
+
+    # json_schema — output must be bare, valid JSON matching the schema.
+    - id: valid-json
+      method: json_schema
+      params:
+        schema:
+          type: object
+          required: [answer]
+
+    # must_contain — require an expected keyword to be present.
+    - id: cites-a-source
+      method: must_contain
+      params:
+        keywords: ["source", "reference", "according to"]
+        mode: any            # any = pass if one present; all = require every keyword
+
+    # must_not_contain — block forbidden phrases (case-insensitive by default).
+    - id: no-refusal
+      method: must_not_contain
+      params:
+        keywords: ["i cannot help", "i'm sorry"]
+        mode: any
+
+    # must_not_match — fail if the output matches a pattern (e.g. a leaked IP).
+    - id: no-ip-leaked
+      method: must_not_match
+      params:
+        pattern: "\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b"
+
+    # exact_match — compare output against a canonical span field.
+    - id: exact-answer
+      method: exact_match
+      params:
+        caseSensitive: false
+        trim: true
+      inputs:
+        expectedOutput: context
+
+alerts:
+  thresholds:
+    relevance: 0.6

--- a/dt-eval-cli/examples/trajectory.dt-eval.yaml
+++ b/dt-eval-cli/examples/trajectory.dt-eval.yaml
@@ -1,0 +1,51 @@
+# Trajectory (multi-turn) evaluation example
+# Scores a whole conversation instead of a single span/turn.
+# Run: dt-evals run --config examples/trajectory.dt-eval.yaml
+# See: docs/evaluations.md#evaluation-scope
+
+schemaVersion: 3
+name: my-agent-prod
+
+dynatrace:
+  environmentUrl: https://<your-env-id>.apps.dynatracelabs.com
+  apiToken: dt0c01.REPLACE_ME   # tip: use DT_API_TOKEN env var instead
+
+judge:
+  provider: openai
+  apiKey: sk-REPLACE_ME         # tip: use OPENAI_API_KEY env var instead
+  model: gpt-4.1
+
+scope:
+  service: my-agent-prod
+  since: 24h
+
+  # Enable multi-turn evaluation. Spans are grouped by gen_ai.conversation.id
+  # (falling back to trace.id), one representative span is picked per conversation,
+  # and its full gen_ai.input.messages history is scored as one trajectory.
+  mode: trajectory
+
+  # How many conversation groups to consider before `sampling` is applied (default: 200).
+  maxConversations: 200
+
+  # Max messages kept per trajectory; oldest are dropped (default: 50).
+  maxMessages: 50
+
+  # Message part types to keep from the history (default shown below).
+  keepPartTypes: [text, tool_call, tool_call_response]
+
+  sampling:
+    strategy: random
+    percent: 10
+
+metrics:
+  # Conversation-level judges are the natural fit for trajectories.
+  enabled:
+    - answer-completeness   # were all parts of the user's goal addressed
+    - faithfulness          # stayed grounded across the conversation
+    - user-frustration      # frustration signals building over turns
+
+alerts:
+  thresholds:
+    answer-completeness: 0.7
+    faithfulness: 0.7
+    user-frustration: 1

--- a/dt-eval-cli/examples/trajectory.dt-eval.yaml
+++ b/dt-eval-cli/examples/trajectory.dt-eval.yaml
@@ -8,12 +8,12 @@ name: my-agent-prod
 
 dynatrace:
   environmentUrl: https://<your-env-id>.apps.dynatracelabs.com
-  apiToken: dt0c01.REPLACE_ME   # tip: use DT_API_TOKEN env var instead
+  # apiToken is loaded from the DT_API_TOKEN env var (or a local .env file).
 
 judge:
   provider: openai
-  apiKey: sk-REPLACE_ME         # tip: use OPENAI_API_KEY env var instead
   model: gpt-4.1
+  # apiKey is loaded from the provider env var, e.g. OPENAI_API_KEY.
 
 scope:
   service: my-agent-prod


### PR DESCRIPTION
## What

Refactors the `dt-eval-cli` README (788 lines) into a minimal landing page and moves the deep-dive reference into a new `dt-eval-cli/docs/` folder, adding coverage for features that were previously undocumented.

## Changes

- **`README.md`** → trimmed to a landing page (what/why, install, quick start, commands) with a **Documentation** section linking out.
- **`docs/configuration.md`** → full config reference (sampling, cross-tenant, token scopes, span-field mapping, results/DQL, PII) **plus the previously undocumented trajectory scope keys** (`mode`, `maxConversations`, `maxMessages`, `keepPartTypes`).
- **`docs/evaluations.md`** → single evals guide along two axes:
  - **Scope** — span (single-turn) vs trajectory (multi-turn/agentic), with when-to-use and limitations.
  - **Type** — LLM-as-judge vs code (deterministic) checks, with when-to-use and limitations.
  - Built-in catalog, custom evaluators, drift.
- **`examples/trajectory.dt-eval.yaml`** and **`examples/code-evals.dt-eval.yaml`** → runnable, annotated starters linked from the docs (`.gitignore` updated to track them).

Docs-only; no code changes.

## Verification

- Both example configs pass `dt-evals validate` (`✓ Config schema valid`).
- All relative links and anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)