### PR TITLE
refactor(dt-eval-cli)!: rename scope.mode → scope.level with agent-* values

### DIFF
--- a/dt-eval-cli/src/config/defaults.ts
+++ b/dt-eval-cli/src/config/defaults.ts
@@ -39,7 +39,7 @@ export const DEFAULT_CONFIG: Omit<DtEvalConfig, 'dynatrace' | 'judge'> & {
   },
   scope: {
     since: '1h',
-    mode: 'span' as const,
+    level: 'agent-span' as const,
     operationNames: DEFAULT_OPERATION_NAMES,
     sampling: {
       strategy: 'random',

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -394,11 +394,6 @@ export function validateConfig(config: DtEvalConfig): void {
   if (level !== undefined && level !== 'agent-span' && level !== 'agent-session') {
     issues.push(`scope.level must be "agent-span" or "agent-session" (got "${level}")`);
   }
-  // `scope.mode` was renamed to `scope.level` (values: span→agent-span, trajectory→agent-session).
-  // Catch stale configs so the old key doesn't silently fall back to the default level.
-  if ((config.scope as { mode?: unknown } | undefined)?.mode !== undefined) {
-    issues.push('scope.mode has been renamed to scope.level (use "agent-span" or "agent-session")');
-  }
 
   const { strategy } = config.scope?.sampling ?? {};
   if (strategy && !['random', 'latest', 'errors-only'].includes(strategy)) {

--- a/dt-eval-cli/src/config/index.ts
+++ b/dt-eval-cli/src/config/index.ts
@@ -390,9 +390,14 @@ export function validateConfig(config: DtEvalConfig): void {
     }
   }
 
-  const mode = config.scope?.mode as unknown;
-  if (mode !== undefined && mode !== 'span' && mode !== 'trajectory') {
-    issues.push(`scope.mode must be "span" or "trajectory" (got "${mode}")`);
+  const level = config.scope?.level as unknown;
+  if (level !== undefined && level !== 'agent-span' && level !== 'agent-session') {
+    issues.push(`scope.level must be "agent-span" or "agent-session" (got "${level}")`);
+  }
+  // `scope.mode` was renamed to `scope.level` (values: span→agent-span, trajectory→agent-session).
+  // Catch stale configs so the old key doesn't silently fall back to the default level.
+  if ((config.scope as { mode?: unknown } | undefined)?.mode !== undefined) {
+    issues.push('scope.mode has been renamed to scope.level (use "agent-span" or "agent-session")');
   }
 
   const { strategy } = config.scope?.sampling ?? {};

--- a/dt-eval-cli/src/config/schema.ts
+++ b/dt-eval-cli/src/config/schema.ts
@@ -78,14 +78,20 @@ export interface ScopeConfig {
   };
   /** Custom span attribute mapping. Defaults handle OTel + OpenLLMetry. */
   spanFields?: SpanFieldsMap;
-  mode?: "span" | "trajectory";
+  /**
+   * Evaluation granularity.
+   * - `agent-span`: evaluate each span (one LLM call / operation) individually.
+   * - `agent-session`: group spans by conversation (`gen_ai.conversation.id`, falling back
+   *   to trace id) and evaluate one representative span per conversation.
+   */
+  level?: "agent-span" | "agent-session";
   keepPartTypes?: string[];
   /**
-   * Fetch/selection cap for trajectory mode: how many conversation groups to consider before
+   * Fetch/selection cap for `agent-session` level: how many conversation groups to consider before
    * `sampling` is applied (default: random @ 5%). Increase to widen coverage, decrease to cut cost.
    */
   maxConversations?: number;
-  /** Maximum number of messages to keep per trajectory (oldest are dropped). Only used in trajectory mode. */
+  /** Maximum number of messages to keep per conversation (oldest are dropped). Only used at `agent-session` level. */
   maxMessages?: number;
 }
 

--- a/dt-eval-cli/src/dt/dql.ts
+++ b/dt-eval-cli/src/dt/dql.ts
@@ -12,7 +12,7 @@ export interface DqlQueryOptions {
   spanFields?: SpanFieldsMap;
   /** GenAI operation names to keep. Empty array disables this filter. */
   operationNames?: string[];
-  mode?: "span" | "trajectory";
+  level?: "agent-span" | "agent-session";
   maxConversations?: number;
 }
 
@@ -83,10 +83,10 @@ export function filterSpansByOperationName(spans: GenAiSpan[], operationNames?: 
 }
 
 export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
-  const { app, since, limit = 1000, errorsOnly = false, spanFields, mode, maxConversations = DEFAULT_MAX_CONVERSATIONS } = opts;
+  const { app, since, limit = 1000, errorsOnly = false, spanFields, level, maxConversations = DEFAULT_MAX_CONVERSATIONS } = opts;
   const operationNames = resolveOperationNames(opts.operationNames);
   const fields = resolveFields(spanFields);
-  const isTrajectory = mode === 'trajectory';
+  const isTrajectory = level === 'agent-session';
 
   // Use explicit from:/to: timeframe — a filter alone leaves Grail's default
   // ~2h analysis window in effect even when the filter asks for longer.
@@ -160,7 +160,7 @@ export function buildGenAiSpanQuery(opts: DqlQueryOptions): string {
 
 export interface ParseSpanOptions {
   spanFields?: SpanFieldsMap;
-  mode?: "span" | "trajectory";
+  level?: "agent-span" | "agent-session";
   keepPartTypes?: string[];
   maxMessages?: number;
 }
@@ -316,7 +316,7 @@ export function parseSpanResults(
       systemInstruction ??= inputRoles.system;
       userPrompt ??= inputRoles.user;
       if (inputMatch?.key === DEFAULT_INPUT_FIELDS[0]) {
-        if (options.mode === 'trajectory' && input) {
+        if (options.level === 'agent-session' && input) {
           const filtered = extractFullHistory(input, options.keepPartTypes, options.maxMessages);
           if (filtered && filtered !== '[]') input = filtered;
         } else if (inputRoles.user) {

--- a/dt-eval-cli/src/runner/index.ts
+++ b/dt-eval-cli/src/runner/index.ts
@@ -191,7 +191,7 @@ export async function runEvals(
     errorsOnly: evalConfig.scope.sampling?.strategy === 'errors-only',
     spanFields: evalConfig.scope.spanFields,
     operationNames: evalConfig.scope.operationNames,
-    mode: evalConfig.scope.mode,
+    level: evalConfig.scope.level,
     maxConversations: evalConfig.scope.maxConversations,
   });
   logger.debug(`DQL query:\n${query}`);
@@ -202,12 +202,12 @@ export async function runEvals(
   logger.timing('DQL fetch', dqlMs, { rawRecords: (rawRecords as unknown[]).length });
 
   const t0Parse = Date.now();
-  const parsedSpans = parseSpanResults(rawRecords, { spanFields: evalConfig.scope.spanFields, mode: evalConfig.scope.mode, keepPartTypes: evalConfig.scope.keepPartTypes, maxMessages: evalConfig.scope.maxMessages });
+  const parsedSpans = parseSpanResults(rawRecords, { spanFields: evalConfig.scope.spanFields, level: evalConfig.scope.level, keepPartTypes: evalConfig.scope.keepPartTypes, maxMessages: evalConfig.scope.maxMessages });
   // Safety net: re-apply the operation-name keep-list at the parser layer so a DQL
   // change or unexpected extra records can't leak non-keep-listed operation spans
   // into evaluation.
   const filteredSpans = filterSpansByOperationName(parsedSpans, evalConfig.scope.operationNames);
-  const allSpans = evalConfig.scope.mode === 'trajectory'
+  const allSpans = evalConfig.scope.level === 'agent-session'
     ? selectTrajectorySpans(filteredSpans, evalConfig.scope.maxConversations)
     : filteredSpans;
   logger.timing('Parse spans', Date.now() - t0Parse, {


### PR DESCRIPTION
## What

Renames the evaluation-granularity config key `scope.mode` → `scope.level` and its values for clearer, more accurate naming:

| Old (`scope.mode`) | New (`scope.level`) | Meaning |
|--------------------|---------------------|---------|
| `span`             | `agent-span`        | Evaluate each span (one LLM call / operation) individually — **the default** |
| `trajectory`       | `agent-session`     | Group spans by conversation (`gen_ai.conversation.id`, falling back to trace id) and evaluate one representative span per conversation |

## Why

- `mode` is generic; `level` communicates that the setting controls evaluation **granularity**.
- `agent-span` / `agent-session` read as product-level concepts and are self-documenting about what gets grouped.

## Config example

```yaml
scope:
  since: 24h
  level: agent-session   # was: mode: trajectory
```

If `scope.level` is omitted it defaults to `agent-span`.

## Files
- `src/config/schema.ts`, `defaults.ts`, `index.ts`
- `src/dt/dql.ts`, `src/runner/index.ts`

## Testing
- `tsc --noEmit` clean; unit tests pass.
- Built locally and validated end-to-end against a live tenant with an `agent-session` config: 4 spans → 4 conversation groups × 6 metrics = 24 results written to Dynatrace, all metrics passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)