### PR TITLE
fix(dt-eval-cli): update playground dashboard link (AI-230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ End-to-end LLM evaluation toolkit for Dynatrace AI Observability.
 ![dt-evals welcome](assets/dt-evals-welcome.gif)
 
 > 🎮 **Try it without installing anything** — explore a live `dt-evals` dashboard on our public playground tenant:
-> [**Open the dt-evals playground dashboard →**](http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8)
+> [**Open the dt-evals playground dashboard →**](https://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/dynatrace.genai.observability.aiobservability)
 >
 > Shows real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, and click-through to the originating trace.
 

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -28,7 +28,7 @@ npx @dynatrace-oss/dt-evals run --since 1h --sample 10 --concurrency 10
 
 Tune `--concurrency` (or `judge.concurrency` in your yaml) to control how many judge calls run in parallel — bump it for faster runs, drop it if the provider rate-limits you. Default is 5.
 
-> 🎮 **See it live before installing** — [**open the dt-evals playground dashboard**](http://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/monaco-2cf9a79b-8b32-3244-aed1-e9d8c6e3e6a8) on our public Dynatrace tenant. Real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, click-through to the originating trace.
+> 🎮 **See it live before installing** — [**open the dt-evals playground dashboard**](https://wkf10640.apps.dynatrace.com/ui/apps/dynatrace.dashboards/dashboard/dynatrace.genai.observability.aiobservability) on our public Dynatrace tenant. Real evaluation runs against production GenAI traces — scores per metric, drift over time, threshold breaches, click-through to the originating trace.
 
 ## Why Teams Use It
 


### PR DESCRIPTION
Replace broken http dashboard URL with the correct https playground link.