### PR TITLE
docs(dt-eval-cli): add demo video link to README

### DIFF
--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -10,6 +10,9 @@
 
 ![dt-evals welcome](../assets/dt-evals-welcome.gif)
 
+> 📺 **See it in action:** [How to Run LLM Evaluations with dt-evals](https://www.youtube.com/watch?v=64WwV4K287g) —
+> a hands-on walkthrough of pulling production traces, scoring them with an LLM judge, and reading the results back in Dynatrace.
+
 `dt-evals` is for teams shipping chat, RAG, copilots, and agent workflows who want evals to run on real traffic, not just curated test sets.
 
 Today, the CLI uses Dynatrace as both the trace source and the evaluation result store. It pulls gen_ai.* spans from your live environment, masks sensitive data in memory, scores real production interactions with an LLM judge, detects score drift over time, and writes structured evaluation results back to Dynatrace as business events.

--- a/dt-eval-cli/README.md
+++ b/dt-eval-cli/README.md
@@ -8,10 +8,9 @@
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue?style=flat-square)](LICENSE)
 [![Node](https://img.shields.io/node/v/@dynatrace-oss/dt-evals/alpha?style=flat-square)](package.json)
 
-![dt-evals welcome](../assets/dt-evals-welcome.gif)
-
-> 📺 **See it in action:** [How to Run LLM Evaluations with dt-evals](https://www.youtube.com/watch?v=64WwV4K287g) —
-> a hands-on walkthrough of pulling production traces, scoring them with an LLM judge, and reading the results back in Dynatrace.
+> [![Watch the video](../assets/dt-evals-welcome.gif)](https://www.youtube.com/watch?v=64WwV4K287g)
+>
+> 📺 **See it in action:** [How to Run LLM Evaluations with dt-evals](https://www.youtube.com/watch?v=64WwV4K287g) — a hands-on walkthrough of pulling production traces, scoring them with an LLM judge, and reading the results back in Dynatrace.
 
 `dt-evals` is for teams shipping chat, RAG, copilots, and agent workflows who want evals to run on real traffic, not just curated test sets.
 


### PR DESCRIPTION
## What

Adds a link to the Dynatrace video **[How to Run LLM Evaluations with dt-evals │ AI Observability](https://www.youtube.com/watch?v=64WwV4K287g)** in the README, as a callout in the hero section right under the welcome GIF.

## Preview

> 📺 **See it in action:** [How to Run LLM Evaluations with dt-evals](https://www.youtube.com/watch?v=64WwV4K287g) —
> a hands-on walkthrough of pulling production traces, scoring them with an LLM judge, and reading the results back in Dynatrace.

## Why

Gives newcomers a fast, visual way to understand the end-to-end flow before diving into Quick Start. Placed high for visibility; complements (doesn't replace) the existing GIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)