### PR TITLE
feat(dt-eval-cli): surface scope level and code evals in the configure wizard

### DIFF
--- a/dt-eval-cli/package-lock.json
+++ b/dt-eval-cli/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.32.0",
         "@aws-sdk/client-bedrock-runtime": "^3.0.0",
-        "@dynatrace-oss/dt-eval-lib": "^0.0.15-alpha",
+        "@dynatrace-oss/dt-eval-lib": "^0.0.19-alpha",
         "@google/genai": "^1.0.0",
         "@inquirer/prompts": "^7.10.1",
         "@types/figlet": "^1.7.0",
@@ -789,9 +789,9 @@
       }
     },
     "node_modules/@dynatrace-oss/dt-eval-lib": {
-      "version": "0.0.15-alpha",
-      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.15-alpha.tgz",
-      "integrity": "sha512-ow5qBNwWlrvi26/bOGiCyJGZ+mYAhWOy07OZzr6H9n44t+h9lsVK2l4rkaoWT1eW3D8P0j+z8NQE5JKxDJPcwg==",
+      "version": "0.0.19-alpha",
+      "resolved": "https://registry.npmjs.org/@dynatrace-oss/dt-eval-lib/-/dt-eval-lib-0.0.19-alpha.tgz",
+      "integrity": "sha512-KoUoSsM/uJPify0U7AoX3Zm2EM+S4J1F3WstE/cRD14grzj1EAsdbMOdHx84M7HDVvw/Y2iUmoklMkXFtEgalQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -800,7 +800,9 @@
         "@anthropic-ai/sdk": "^0.32.0",
         "@aws-sdk/client-bedrock-runtime": "^3.0.0",
         "@google/genai": "^1.0.0",
-        "openai": "^4.73.0"
+        "ajv": "^8.0.0",
+        "openai": "^4.73.0",
+        "recheck": "^4.0.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
@@ -812,7 +814,13 @@
         "@google/genai": {
           "optional": true
         },
+        "ajv": {
+          "optional": true
+        },
         "openai": {
+          "optional": true
+        },
+        "recheck": {
           "optional": true
         }
       }
@@ -3081,6 +3089,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4707,6 +4716,7 @@
       "resolved": "https://registry.npmjs.org/recheck/-/recheck-4.5.0.tgz",
       "integrity": "sha512-kPnbOV6Zfx9a25AZ++28fI1q78L/UVRQmmuazwVRPfiiqpMs+WbOU69Shx820XgfKWfak0JH75PUvZMFtRGSsw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "synckit": "0.9.2"
       },

--- a/dt-eval-cli/package.json
+++ b/dt-eval-cli/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.32.0",
     "@aws-sdk/client-bedrock-runtime": "^3.0.0",
-    "@dynatrace-oss/dt-eval-lib": "^0.0.15-alpha",
+    "@dynatrace-oss/dt-eval-lib": "^0.0.19-alpha",
     "@google/genai": "^1.0.0",
     "@inquirer/prompts": "^7.10.1",
     "@types/figlet": "^1.7.0",

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -3,7 +3,7 @@ import { spawnSync } from 'node:child_process';
 import { join, basename } from 'node:path';
 import { loadConfig, saveConfig, validateConfig } from '../../config/index.js';
 import { updateEnvFile } from '../../config/env-file.js';
-import type { DtEvalConfig } from '../../config/schema.js';
+import type { DtEvalConfig, MetricEntry } from '../../config/schema.js';
 import { metricId } from '../../config/schema.js';
 import { DEFAULT_JUDGE_MODELS, suggestModelForProvider } from '../../config/defaults.js';
 import { stringify as stringifyYaml } from 'yaml';
@@ -167,6 +167,22 @@ async function testServiceSpans(
   } catch {
     return null;
   }
+}
+
+/**
+ * Append a runnable starter deterministic check when the user opts in. The entry
+ * is a valid `must_contain` metric with a placeholder keyword so the config runs
+ * as-is; the user edits the id/method/params (see README "Deterministic
+ * evaluators"). No-op when not requested.
+ */
+export function buildEnabledMetrics(base: MetricEntry[], addCodeCheck: boolean): MetricEntry[] {
+  if (!addCodeCheck) return base;
+  const stub: MetricEntry = {
+    id: 'example-keyword-check',
+    method: 'must_contain',
+    params: { keywords: ['REPLACE_ME'], mode: 'any' },
+  };
+  return [...base, stub];
 }
 
 export function createConfigureCommand(): Command {
@@ -393,6 +409,16 @@ export function createConfigureCommand(): Command {
         ],
       });
 
+      // ── Deterministic / code-based checks ────────────────
+      // Deterministic evals (exact match, regex, keyword, JSON schema) are
+      // authored per-check with method-specific params, so instead of a full
+      // form we drop in one runnable starter entry the user can edit — see the
+      // README "Deterministic evaluators" section.
+      const addCodeCheck = await confirm({
+        message: 'Add a starter code-based check? (deterministic: exact match / regex / keyword / JSON schema — edit it after, see README)',
+        default: false,
+      });
+
       // ── Scope level ────────────────────────────────────────
       const level = await select<'agent-span' | 'agent-session'>({
         message: 'Scope level — what should each evaluation run over?',
@@ -457,7 +483,10 @@ export function createConfigureCommand(): Command {
           },
         },
         metrics: {
-          enabled: selectedMetrics.length > 0 ? selectedMetrics : enabledMetricIds,
+          enabled: buildEnabledMetrics(
+            selectedMetrics.length > 0 ? selectedMetrics : enabledMetricIds,
+            addCodeCheck,
+          ),
         },
         alerts: existing.alerts,
       };
@@ -473,6 +502,9 @@ export function createConfigureCommand(): Command {
         saveConfig(updated, outputPath);
         logger.success(`Config saved to ${outputPath}`);
         persistSecretsToEnv(updated, (msg) => logger.info(msg));
+        if (addCodeCheck) {
+          logger.info(`Added a starter code-based check "example-keyword-check" — edit its keywords/method in ${basename(outputPath)} (see README "Deterministic evaluators")`);
+        }
       } catch (err) {
         logger.error(`Failed to save config: ${(err as Error).message}`);
         process.exit(1);

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -180,10 +180,10 @@ export type CodeCheckMethod =
   | 'json_schema';
 
 /** Concrete object-form metric entry (deterministic checks are always object-form). */
-type CodeEvalEntry = Extract<MetricEntry, { id: string }>;
+export type CodeEvalEntry = Extract<MetricEntry, { id: string }>;
 
 /** Sentinel the sub-menu returns when the user is done adding code evals. */
-const CODE_EVAL_DONE = '__done__' as const;
+export const CODE_EVAL_DONE = '__done__' as const;
 
 /** Main-menu choices: one per deterministic method. */
 const CODE_CHECK_METHOD_CHOICES: Array<{ name: string; value: CodeCheckMethod }> = [
@@ -204,7 +204,7 @@ function uniqueCodeEvalId(base: string, existing: CodeEvalEntry[]): string {
 }
 
 /** Collect the mandatory (and a couple of common optional) params for one method. */
-async function collectCodeEvalParams(
+export async function collectCodeEvalParams(
   method: CodeCheckMethod,
   inq: typeof import('@inquirer/prompts'),
 ): Promise<DeterministicParams> {
@@ -235,7 +235,7 @@ async function collectCodeEvalParams(
       });
       const caseSensitive = await confirm({ message: '    Case-sensitive?', default: true });
       const trim = await confirm({ message: '    Trim whitespace before comparing?', default: true });
-      return { expectedOutput, caseSensitive, trim } as DeterministicParams;
+      return { expectedOutput, caseSensitive, trim };
     }
     case 'regex':
     case 'must_not_match': {
@@ -271,7 +271,7 @@ async function collectCodeEvalParams(
  * Returns `null` when the user leaves the id blank, which the menu treats as
  * "go back" (discard this check and return to the method list).
  */
-async function authorCodeEval(
+export async function authorCodeEval(
   method: CodeCheckMethod,
   inq: typeof import('@inquirer/prompts'),
   existing: CodeEvalEntry[],
@@ -551,6 +551,33 @@ export function createConfigureCommand(): Command {
 
       const resolvedApiKey = resolveConfiguredApiKey(existing.judge, provider, apiKey);
 
+      // ── Scope: level, sampling, time window ──────────────
+      // Scope shapes what every evaluator runs over, so it comes before the
+      // evaluator pickers. `level` sits next to `sampling` since both control
+      // which/how many spans are drawn.
+      const level = await select<'agent-span' | 'agent-session'>({
+        message: 'Scope level — what should each evaluation run over?',
+        choices: [
+          { name: 'agent-span  (evaluate individual agent spans)', value: 'agent-span' },
+          { name: 'agent-session  (evaluate at session level using conversation id, trace id as fallback)', value: 'agent-session' },
+        ],
+        default: existing.scope?.level ?? 'agent-span',
+      });
+
+      const sampleStr = await input({
+        message: 'Sampling — % of traces to evaluate per run  (range: 1–100, default 5 recommended to control costs)',
+        default: String(existing.scope?.sampling?.percent ?? 5),
+        validate: (v) => {
+          const n = parseInt(v, 10);
+          return (n >= 1 && n <= 100) ? true : 'Enter a number between 1 and 100';
+        },
+      });
+
+      const since = await input({
+        message: 'Default time window',
+        default: existing.scope?.since ?? '1h',
+      });
+
       // ── Evaluators ───────────────────────────────────────
       const enabledMetricIds = (existing.metrics?.enabled ?? allMetricIds).map(metricId);
       const selectedMetrics = await checkbox({
@@ -565,31 +592,6 @@ export function createConfigureCommand(): Command {
       // Looping sub-flow: pick a method, fill in its mandatory fields, return to
       // the menu to add more or finish. Runs as pure functions (no LLM).
       const codeEvals = await collectCodeEvals(inquirer);
-
-      // ── Scope level ────────────────────────────────────────
-      const level = await select<'agent-span' | 'agent-session'>({
-        message: 'Scope level — what should each evaluation run over?',
-        choices: [
-          { name: 'agent-span  (evaluate individual agent spans)', value: 'agent-span' },
-          { name: 'agent-session  (evaluate at session level using conversation id, trace id as fallback)', value: 'agent-session' },
-        ],
-        default: existing.scope?.level ?? 'agent-span',
-      });
-
-      // ── Sampling ─────────────────────────────────────────
-      const sampleStr = await input({
-        message: 'Sampling — % of traces to evaluate per run  (range: 1–100, default 5 recommended to control costs)',
-        default: String(existing.scope?.sampling?.percent ?? 5),
-        validate: (v) => {
-          const n = parseInt(v, 10);
-          return (n >= 1 && n <= 100) ? true : 'Enter a number between 1 and 100';
-        },
-      });
-
-      const since = await input({
-        message: 'Default time window',
-        default: existing.scope?.since ?? '1h',
-      });
 
       const updated: DtEvalConfig = {
         schemaVersion: existing.schemaVersion ?? 1,

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -170,7 +170,7 @@ async function testServiceSpans(
   }
 }
 
-/** Deterministic ("code-based") evaluator methods the wizard can scaffold. */
+/** Deterministic ("code-based") evaluator methods the wizard can author. */
 export type CodeCheckMethod =
   | 'exact_match'
   | 'regex'
@@ -179,34 +179,162 @@ export type CodeCheckMethod =
   | 'must_not_contain'
   | 'json_schema';
 
-/**
- * Runnable placeholder entries for each deterministic method. Params use a
- * `REPLACE_ME` sentinel so the config is valid and runs as-is; the user edits
- * id/params afterwards (see README "Deterministic evaluators").
- */
-const CODE_CHECK_STUBS: Record<CodeCheckMethod, Extract<MetricEntry, { id: string }>> = {
-  exact_match:      { id: 'example-exact-match',      method: 'exact_match',      params: { expectedOutput: 'REPLACE_ME' } as DeterministicParams },
-  regex:            { id: 'example-regex',            method: 'regex',            params: { pattern: 'REPLACE_ME' } },
-  must_not_match:   { id: 'example-must-not-match',   method: 'must_not_match',   params: { pattern: 'REPLACE_ME' } },
-  must_contain:     { id: 'example-must-contain',     method: 'must_contain',     params: { keywords: ['REPLACE_ME'], mode: 'any' } },
-  must_not_contain: { id: 'example-must-not-contain', method: 'must_not_contain', params: { keywords: ['REPLACE_ME'], mode: 'any' } },
-  json_schema:      { id: 'example-json-schema',      method: 'json_schema',      params: { schema: { type: 'object' } } },
-};
+/** Concrete object-form metric entry (deterministic checks are always object-form). */
+type CodeEvalEntry = Extract<MetricEntry, { id: string }>;
 
-/** Checkbox choices for the deterministic starter checks (nothing selected by default). */
-const CODE_CHECK_CHOICES: Array<{ name: string; value: CodeCheckMethod }> = [
-  { name: 'must_contain       (output includes a keyword)',        value: 'must_contain' },
+/** Sentinel the sub-menu returns when the user is done adding code evals. */
+const CODE_EVAL_DONE = '__done__' as const;
+
+/** Main-menu choices: one per deterministic method. */
+const CODE_CHECK_METHOD_CHOICES: Array<{ name: string; value: CodeCheckMethod }> = [
+  { name: 'must_contain       (output includes a keyword)',            value: 'must_contain' },
   { name: 'must_not_contain   (output excludes a keyword / blocklist)', value: 'must_not_contain' },
-  { name: 'exact_match        (output equals an expected string)',  value: 'exact_match' },
-  { name: 'regex              (output matches a pattern)',          value: 'regex' },
-  { name: 'must_not_match     (output does not match a pattern)',   value: 'must_not_match' },
-  { name: 'json_schema        (output is valid JSON for a schema)', value: 'json_schema' },
+  { name: 'exact_match        (output equals an expected string)',     value: 'exact_match' },
+  { name: 'regex              (output matches a pattern)',             value: 'regex' },
+  { name: 'must_not_match     (output does not match a pattern)',      value: 'must_not_match' },
+  { name: 'json_schema        (output is valid JSON for a schema)',    value: 'json_schema' },
 ];
 
-/** Append a placeholder entry for each selected deterministic method. No-op when none selected. */
-export function buildEnabledMetrics(base: MetricEntry[], codeCheckMethods: CodeCheckMethod[]): MetricEntry[] {
-  if (codeCheckMethods.length === 0) return base;
-  return [...base, ...codeCheckMethods.map((m) => CODE_CHECK_STUBS[m])];
+/** Suffix a base id with -2, -3, … until it is unique among already-added entries. */
+function uniqueCodeEvalId(base: string, existing: CodeEvalEntry[]): string {
+  if (!existing.some((e) => e.id === base)) return base;
+  let n = 2;
+  while (existing.some((e) => e.id === `${base}-${n}`)) n++;
+  return `${base}-${n}`;
+}
+
+/** Collect the mandatory (and a couple of common optional) params for one method. */
+async function collectCodeEvalParams(
+  method: CodeCheckMethod,
+  inq: typeof import('@inquirer/prompts'),
+): Promise<DeterministicParams> {
+  const { input, select, confirm } = inq;
+  switch (method) {
+    case 'must_contain':
+    case 'must_not_contain': {
+      const raw = await input({
+        message: '    Keywords (comma-separated)',
+        validate: (v) => (v.split(',').some((s) => s.trim()) ? true : 'Enter at least one keyword'),
+      });
+      const keywords = raw.split(',').map((s) => s.trim()).filter(Boolean);
+      const mode = await select<'any' | 'all'>({
+        message: '    Match mode',
+        choices: [
+          { name: 'any  (constraint holds for ≥1 keyword)', value: 'any' },
+          { name: 'all  (constraint holds for every keyword)', value: 'all' },
+        ],
+        default: 'any',
+      });
+      const caseSensitive = await confirm({ message: '    Case-sensitive?', default: false });
+      return { keywords, mode, caseSensitive };
+    }
+    case 'exact_match': {
+      const expectedOutput = await input({
+        message: '    Expected output (exact string)',
+        validate: (v) => (v.length > 0 ? true : 'Expected output is required'),
+      });
+      const caseSensitive = await confirm({ message: '    Case-sensitive?', default: true });
+      const trim = await confirm({ message: '    Trim whitespace before comparing?', default: true });
+      return { expectedOutput, caseSensitive, trim } as DeterministicParams;
+    }
+    case 'regex':
+    case 'must_not_match': {
+      const pattern = await input({
+        message: '    Regex pattern',
+        validate: (v) => (v.trim().length > 0 ? true : 'Pattern is required'),
+      });
+      const flags = await input({ message: '    Regex flags (optional, e.g. i, m, s)', default: '' });
+      return flags.trim() ? { pattern, flags: flags.trim() } : { pattern };
+    }
+    case 'json_schema': {
+      const raw = await input({
+        message: '    JSON schema (a JSON object)',
+        default: '{"type":"object"}',
+        validate: (v) => {
+          try {
+            const parsed = JSON.parse(v);
+            return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+              ? true
+              : 'Must be a JSON object';
+          } catch {
+            return 'Invalid JSON';
+          }
+        },
+      });
+      return { schema: JSON.parse(raw) };
+    }
+  }
+}
+
+/**
+ * Author a single deterministic check: id → mandatory params → field to check.
+ * Returns `null` when the user leaves the id blank, which the menu treats as
+ * "go back" (discard this check and return to the method list).
+ */
+async function authorCodeEval(
+  method: CodeCheckMethod,
+  inq: typeof import('@inquirer/prompts'),
+  existing: CodeEvalEntry[],
+): Promise<CodeEvalEntry | null> {
+  const { input, select } = inq;
+  const defaultId = uniqueCodeEvalId(`${method.replace(/_/g, '-')}-check`, existing);
+  const id = await input({
+    message: `    Name / id for this ${method} check  (leave blank to go back)`,
+    default: defaultId,
+    validate: (v) => {
+      const t = v.trim();
+      if (!t) return true; // blank ⇒ back
+      return existing.some((e) => e.id === t) ? 'An entry with this id already exists' : true;
+    },
+  });
+  if (!id.trim()) return null;
+
+  const params = await collectCodeEvalParams(method, inq);
+
+  const target = await select<'output' | 'input' | 'context'>({
+    message: '    Which span field should this check run against?',
+    choices: [
+      { name: 'output   (model response — default)', value: 'output' },
+      { name: 'input    (user / request text)', value: 'input' },
+      { name: 'context  (retrieved context)', value: 'context' },
+    ],
+    default: 'output',
+  });
+
+  const entry: CodeEvalEntry = { id: id.trim(), method, params };
+  if (target !== 'output') entry.inputs = { output: target };
+  return entry;
+}
+
+/**
+ * Interactive sub-flow: a looping menu where the user picks a deterministic
+ * method, fills in its fields, and returns to the menu to add more or finish.
+ * Returns the authored entries (empty when the user skips).
+ */
+export async function collectCodeEvals(
+  inq: typeof import('@inquirer/prompts'),
+): Promise<CodeEvalEntry[]> {
+  const { select } = inq;
+  const added: CodeEvalEntry[] = [];
+  for (;;) {
+    const choice = await select<CodeCheckMethod | typeof CODE_EVAL_DONE>({
+      message:
+        added.length > 0
+          ? `Code evals (deterministic evals) — ${added.length} added; add another or finish`
+          : 'Code evals (deterministic evals) — pure-function checks, no LLM (optional)',
+      choices: [
+        ...CODE_CHECK_METHOD_CHOICES,
+        {
+          name: added.length > 0 ? '✓ Done adding code evals' : '↵ Skip — no code evals',
+          value: CODE_EVAL_DONE,
+        },
+      ],
+    });
+    if (choice === CODE_EVAL_DONE) break;
+    const entry = await authorCodeEval(choice, inq, added);
+    if (entry) added.push(entry); // null ⇒ user went back; loop shows the menu again
+  }
+  return added;
 }
 
 export function createConfigureCommand(): Command {
@@ -426,22 +554,17 @@ export function createConfigureCommand(): Command {
       // ── Evaluators ───────────────────────────────────────
       const enabledMetricIds = (existing.metrics?.enabled ?? allMetricIds).map(metricId);
       const selectedMetrics = await checkbox({
-        message: `Evaluators to run  (${allMetricIds.length - 1} built-in + drift detection)`,
+        message: `LLM-as-judge evaluators  (${allMetricIds.length - 1} built-in + drift detection)`,
         choices: [
           ...availablePrompts.map(p => ({ name: p.id, value: p.id, checked: enabledMetricIds.includes(p.id) })),
           { name: `${DRIFT_METRIC_ID}  (population-level, compares score distributions vs 7d baseline)`, value: DRIFT_METRIC_ID, checked: enabledMetricIds.includes(DRIFT_METRIC_ID) },
         ],
       });
 
-      // ── Deterministic / code-based checks ────────────────
-      // Deterministic evals are authored per-check with method-specific params.
-      // Rather than a full form, offer a checkbox that scaffolds a runnable
-      // placeholder entry per selected method for the user to edit afterwards
-      // (see README "Deterministic evaluators"). Nothing is selected by default.
-      const codeCheckMethods = await checkbox<CodeCheckMethod>({
-        message: 'Add placeholders for code-based (deterministic) evals  (optional — pick any; edit params after, see README)',
-        choices: CODE_CHECK_CHOICES,
-      });
+      // ── Code evals (deterministic evals) ─────────────────
+      // Looping sub-flow: pick a method, fill in its mandatory fields, return to
+      // the menu to add more or finish. Runs as pure functions (no LLM).
+      const codeEvals = await collectCodeEvals(inquirer);
 
       // ── Scope level ────────────────────────────────────────
       const level = await select<'agent-span' | 'agent-session'>({
@@ -507,10 +630,10 @@ export function createConfigureCommand(): Command {
           },
         },
         metrics: {
-          enabled: buildEnabledMetrics(
-            selectedMetrics.length > 0 ? selectedMetrics : enabledMetricIds,
-            codeCheckMethods,
-          ),
+          enabled: [
+            ...(selectedMetrics.length > 0 ? selectedMetrics : enabledMetricIds),
+            ...codeEvals,
+          ],
         },
         alerts: existing.alerts,
       };
@@ -526,9 +649,9 @@ export function createConfigureCommand(): Command {
         saveConfig(updated, outputPath);
         logger.success(`Config saved to ${outputPath}`);
         persistSecretsToEnv(updated, (msg) => logger.info(msg));
-        if (codeCheckMethods.length > 0) {
-          const ids = codeCheckMethods.map((m) => CODE_CHECK_STUBS[m].id).join(', ');
-          logger.info(`Added placeholder code-based ${codeCheckMethods.length === 1 ? 'check' : 'checks'} (${ids}) — replace the REPLACE_ME params in ${basename(outputPath)} (see README "Deterministic evaluators")`);
+        if (codeEvals.length > 0) {
+          const ids = codeEvals.map((e) => e.id).join(', ');
+          logger.info(`Added ${codeEvals.length} code eval${codeEvals.length === 1 ? '' : 's'} (${ids})`);
         }
       } catch (err) {
         logger.error(`Failed to save config: ${(err as Error).message}`);

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -11,6 +11,7 @@ import { redactSecrets } from '../../ui/format.js';
 import { logger } from '../../logger/index.js';
 import { printBanner } from '../../ui/banner.js';
 import { listPrompts, DRIFT_METRIC_ID } from '@dynatrace-oss/dt-eval-lib';
+import type { DeterministicParams } from '@dynatrace-oss/dt-eval-lib';
 import { DynatraceClient } from '../../dt/client.js';
 
 // Per-million-token pricing [input, output] in USD
@@ -169,20 +170,43 @@ async function testServiceSpans(
   }
 }
 
+/** Deterministic ("code-based") evaluator methods the wizard can scaffold. */
+export type CodeCheckMethod =
+  | 'exact_match'
+  | 'regex'
+  | 'must_not_match'
+  | 'must_contain'
+  | 'must_not_contain'
+  | 'json_schema';
+
 /**
- * Append a runnable starter deterministic check when the user opts in. The entry
- * is a valid `must_contain` metric with a placeholder keyword so the config runs
- * as-is; the user edits the id/method/params (see README "Deterministic
- * evaluators"). No-op when not requested.
+ * Runnable placeholder entries for each deterministic method. Params use a
+ * `REPLACE_ME` sentinel so the config is valid and runs as-is; the user edits
+ * id/params afterwards (see README "Deterministic evaluators").
  */
-export function buildEnabledMetrics(base: MetricEntry[], addCodeCheck: boolean): MetricEntry[] {
-  if (!addCodeCheck) return base;
-  const stub: MetricEntry = {
-    id: 'example-keyword-check',
-    method: 'must_contain',
-    params: { keywords: ['REPLACE_ME'], mode: 'any' },
-  };
-  return [...base, stub];
+const CODE_CHECK_STUBS: Record<CodeCheckMethod, Extract<MetricEntry, { id: string }>> = {
+  exact_match:      { id: 'example-exact-match',      method: 'exact_match',      params: { expectedOutput: 'REPLACE_ME' } as DeterministicParams },
+  regex:            { id: 'example-regex',            method: 'regex',            params: { pattern: 'REPLACE_ME' } },
+  must_not_match:   { id: 'example-must-not-match',   method: 'must_not_match',   params: { pattern: 'REPLACE_ME' } },
+  must_contain:     { id: 'example-must-contain',     method: 'must_contain',     params: { keywords: ['REPLACE_ME'], mode: 'any' } },
+  must_not_contain: { id: 'example-must-not-contain', method: 'must_not_contain', params: { keywords: ['REPLACE_ME'], mode: 'any' } },
+  json_schema:      { id: 'example-json-schema',      method: 'json_schema',      params: { schema: { type: 'object' } } },
+};
+
+/** Checkbox choices for the deterministic starter checks (nothing selected by default). */
+const CODE_CHECK_CHOICES: Array<{ name: string; value: CodeCheckMethod }> = [
+  { name: 'must_contain       (output includes a keyword)',        value: 'must_contain' },
+  { name: 'must_not_contain   (output excludes a keyword / blocklist)', value: 'must_not_contain' },
+  { name: 'exact_match        (output equals an expected string)',  value: 'exact_match' },
+  { name: 'regex              (output matches a pattern)',          value: 'regex' },
+  { name: 'must_not_match     (output does not match a pattern)',   value: 'must_not_match' },
+  { name: 'json_schema        (output is valid JSON for a schema)', value: 'json_schema' },
+];
+
+/** Append a placeholder entry for each selected deterministic method. No-op when none selected. */
+export function buildEnabledMetrics(base: MetricEntry[], codeCheckMethods: CodeCheckMethod[]): MetricEntry[] {
+  if (codeCheckMethods.length === 0) return base;
+  return [...base, ...codeCheckMethods.map((m) => CODE_CHECK_STUBS[m])];
 }
 
 export function createConfigureCommand(): Command {
@@ -410,13 +434,13 @@ export function createConfigureCommand(): Command {
       });
 
       // ── Deterministic / code-based checks ────────────────
-      // Deterministic evals (exact match, regex, keyword, JSON schema) are
-      // authored per-check with method-specific params, so instead of a full
-      // form we drop in one runnable starter entry the user can edit — see the
-      // README "Deterministic evaluators" section.
-      const addCodeCheck = await confirm({
-        message: 'Add a starter code-based check? (deterministic: exact match / regex / keyword / JSON schema — edit it after, see README)',
-        default: false,
+      // Deterministic evals are authored per-check with method-specific params.
+      // Rather than a full form, offer a checkbox that scaffolds a runnable
+      // placeholder entry per selected method for the user to edit afterwards
+      // (see README "Deterministic evaluators"). Nothing is selected by default.
+      const codeCheckMethods = await checkbox<CodeCheckMethod>({
+        message: 'Add placeholders for code-based (deterministic) evals  (optional — pick any; edit params after, see README)',
+        choices: CODE_CHECK_CHOICES,
       });
 
       // ── Scope level ────────────────────────────────────────
@@ -485,7 +509,7 @@ export function createConfigureCommand(): Command {
         metrics: {
           enabled: buildEnabledMetrics(
             selectedMetrics.length > 0 ? selectedMetrics : enabledMetricIds,
-            addCodeCheck,
+            codeCheckMethods,
           ),
         },
         alerts: existing.alerts,
@@ -502,8 +526,9 @@ export function createConfigureCommand(): Command {
         saveConfig(updated, outputPath);
         logger.success(`Config saved to ${outputPath}`);
         persistSecretsToEnv(updated, (msg) => logger.info(msg));
-        if (addCodeCheck) {
-          logger.info(`Added a starter code-based check "example-keyword-check" — edit its keywords/method in ${basename(outputPath)} (see README "Deterministic evaluators")`);
+        if (codeCheckMethods.length > 0) {
+          const ids = codeCheckMethods.map((m) => CODE_CHECK_STUBS[m].id).join(', ');
+          logger.info(`Added placeholder code-based ${codeCheckMethods.length === 1 ? 'check' : 'checks'} (${ids}) — replace the REPLACE_ME params in ${basename(outputPath)} (see README "Deterministic evaluators")`);
         }
       } catch (err) {
         logger.error(`Failed to save config: ${(err as Error).message}`);

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -393,6 +393,16 @@ export function createConfigureCommand(): Command {
         ],
       });
 
+      // ── Scope level ────────────────────────────────────────
+      const level = await select<'agent-span' | 'agent-session'>({
+        message: 'Scope level — what should each evaluation run over?',
+        choices: [
+          { name: 'agent-span  (evaluate individual agent spans)', value: 'agent-span' },
+          { name: 'agent-session  (evaluate at session level using conversation id, trace id as fallback)', value: 'agent-session' },
+        ],
+        default: existing.scope?.level ?? 'agent-span',
+      });
+
       // ── Sampling ─────────────────────────────────────────
       const sampleStr = await input({
         message: 'Sampling — % of traces to evaluate per run  (range: 1–100, default 5 recommended to control costs)',
@@ -401,16 +411,6 @@ export function createConfigureCommand(): Command {
           const n = parseInt(v, 10);
           return (n >= 1 && n <= 100) ? true : 'Enter a number between 1 and 100';
         },
-      });
-
-      // ── Scope level ────────────────────────────────────────
-      const level = await select<'agent-span' | 'agent-session'>({
-        message: 'Scope level — what should each evaluation run over?',
-        choices: [
-          { name: 'agent-span  (evaluate individual agent spans)', value: 'agent-span' },
-          { name: 'agent-session  (group spans into conversations/sessions)', value: 'agent-session' },
-        ],
-        default: existing.scope?.level ?? 'agent-span',
       });
 
       const since = await input({

--- a/dt-eval-cli/src/cli/commands/configure.ts
+++ b/dt-eval-cli/src/cli/commands/configure.ts
@@ -403,6 +403,16 @@ export function createConfigureCommand(): Command {
         },
       });
 
+      // ── Scope level ────────────────────────────────────────
+      const level = await select<'agent-span' | 'agent-session'>({
+        message: 'Scope level — what should each evaluation run over?',
+        choices: [
+          { name: 'agent-span  (evaluate individual agent spans)', value: 'agent-span' },
+          { name: 'agent-session  (group spans into conversations/sessions)', value: 'agent-session' },
+        ],
+        default: existing.scope?.level ?? 'agent-span',
+      });
+
       const since = await input({
         message: 'Default time window',
         default: existing.scope?.since ?? '1h',
@@ -440,6 +450,7 @@ export function createConfigureCommand(): Command {
         scope: {
           service: serviceName.trim(),
           since,
+          level,
           sampling: {
             strategy: 'random',
             percent: parseInt(sampleStr, 10),

--- a/dt-eval-cli/tests/cli/commands/configure-code-evals.test.ts
+++ b/dt-eval-cli/tests/cli/commands/configure-code-evals.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import {
+  collectCodeEvalParams,
+  authorCodeEval,
+  collectCodeEvals,
+  CODE_EVAL_DONE,
+  type CodeCheckMethod,
+  type CodeEvalEntry,
+} from '../../../src/cli/commands/configure.js';
+
+// The interactive helpers take an injected `@inquirer/prompts`-shaped object so
+// they can be driven without a TTY. `scriptedInq` replays a fixed queue of
+// answers across the input/select/confirm prompts, in call order. When a
+// prompt has a `validate` fn, the mock runs it and — like the real inquirer —
+// skips (re-prompts) on failure, recording the rejection for assertions.
+
+interface Rejection {
+  message: string;
+  value: string | boolean;
+  reason: string | boolean;
+}
+
+function scriptedInq(script: Array<string | boolean>): {
+  inq: typeof import('@inquirer/prompts');
+  rejections: Rejection[];
+  remaining: () => number;
+} {
+  const queue = [...script];
+  const rejections: Rejection[] = [];
+
+  const take = (cfg: { message?: string; validate?: (v: string) => true | string }) => {
+    for (;;) {
+      if (queue.length === 0) {
+        throw new Error(`scriptedInq: no answer left for prompt "${cfg.message}"`);
+      }
+      const value = queue.shift() as string | boolean;
+      if (cfg.validate) {
+        const result = cfg.validate(String(value));
+        if (result !== true) {
+          rejections.push({ message: cfg.message ?? '', value, reason: result });
+          continue; // real inquirer re-prompts; pull the next scripted answer
+        }
+      }
+      return value;
+    }
+  };
+
+  const inq = {
+    input: async (cfg: never) => take(cfg) as string,
+    select: async (cfg: never) => take(cfg),
+    confirm: async (cfg: never) => take(cfg) as boolean,
+  } as unknown as typeof import('@inquirer/prompts');
+
+  return { inq, rejections, remaining: () => queue.length };
+}
+
+describe('collectCodeEvalParams', () => {
+  it('must_contain: splits/trims keywords and captures mode + caseSensitive', async () => {
+    const { inq } = scriptedInq([' song, music , track ', 'all', true]);
+    const params = await collectCodeEvalParams('must_contain', inq);
+    expect(params).toEqual({ keywords: ['song', 'music', 'track'], mode: 'all', caseSensitive: true });
+  });
+
+  it('must_not_contain: same param shape (direction is applied by the engine)', async () => {
+    const { inq } = scriptedInq(['spam,ads', 'any', false]);
+    const params = await collectCodeEvalParams('must_not_contain', inq);
+    expect(params).toEqual({ keywords: ['spam', 'ads'], mode: 'any', caseSensitive: false });
+  });
+
+  it('must_contain: rejects an all-blank keyword list, then accepts a valid one', async () => {
+    const { inq, rejections } = scriptedInq(['   ,  ,', 'real-keyword', 'any', false]);
+    const params = await collectCodeEvalParams('must_contain', inq);
+    expect(params).toEqual({ keywords: ['real-keyword'], mode: 'any', caseSensitive: false });
+    expect(rejections).toHaveLength(1);
+    expect(rejections[0]?.reason).toMatch(/at least one keyword/i);
+  });
+
+  it('exact_match: captures expectedOutput + caseSensitive + trim', async () => {
+    const { inq } = scriptedInq(['the answer', false, true]);
+    const params = await collectCodeEvalParams('exact_match', inq);
+    expect(params).toEqual({ expectedOutput: 'the answer', caseSensitive: false, trim: true });
+  });
+
+  it('exact_match: rejects empty expected output', async () => {
+    const { inq, rejections } = scriptedInq(['', 'now-non-empty', true, true]);
+    const params = await collectCodeEvalParams('exact_match', inq);
+    expect(params).toEqual({ expectedOutput: 'now-non-empty', caseSensitive: true, trim: true });
+    expect(rejections[0]?.reason).toMatch(/required/i);
+  });
+
+  it('regex: includes flags only when non-empty', async () => {
+    const withFlags = scriptedInq(['[A-Z]{3,}', 'i']);
+    expect(await collectCodeEvalParams('regex', withFlags.inq)).toEqual({ pattern: '[A-Z]{3,}', flags: 'i' });
+
+    const noFlags = scriptedInq(['[A-Z]{3,}', '   ']);
+    expect(await collectCodeEvalParams('regex', noFlags.inq)).toEqual({ pattern: '[A-Z]{3,}' });
+  });
+
+  it('must_not_match: shares the regex param shape', async () => {
+    const { inq } = scriptedInq(['\\d{3}-\\d{4}', '']);
+    expect(await collectCodeEvalParams('must_not_match', inq)).toEqual({ pattern: '\\d{3}-\\d{4}' });
+  });
+
+  it('json_schema: parses the entered JSON object', async () => {
+    const { inq } = scriptedInq(['{"type":"object","required":["id"]}']);
+    expect(await collectCodeEvalParams('json_schema', inq)).toEqual({
+      schema: { type: 'object', required: ['id'] },
+    });
+  });
+
+  it('json_schema: rejects invalid JSON and non-object JSON', async () => {
+    const { inq, rejections } = scriptedInq(['not json', '[1,2,3]', '{"type":"object"}']);
+    const params = await collectCodeEvalParams('json_schema', inq);
+    expect(params).toEqual({ schema: { type: 'object' } });
+    expect(rejections).toHaveLength(2); // invalid JSON, then a JSON array
+  });
+});
+
+describe('authorCodeEval', () => {
+  it('builds a full entry and omits inputs when target is output (default)', async () => {
+    const { inq } = scriptedInq(['keyword-check', 'hello', 'any', false, 'output']);
+    const entry = await authorCodeEval('must_contain', inq, []);
+    expect(entry).toEqual({
+      id: 'keyword-check',
+      method: 'must_contain',
+      params: { keywords: ['hello'], mode: 'any', caseSensitive: false },
+    });
+    expect(entry?.inputs).toBeUndefined();
+  });
+
+  it('routes a non-output target via inputs.output', async () => {
+    const { inq } = scriptedInq(['pii-check', '\\d{3}', '', 'input']);
+    const entry = await authorCodeEval('must_not_match', inq, []);
+    expect(entry).toEqual({
+      id: 'pii-check',
+      method: 'must_not_match',
+      params: { pattern: '\\d{3}' },
+      inputs: { output: 'input' },
+    });
+  });
+
+  it('returns null (go back) when the id is left blank — no further prompts consumed', async () => {
+    const { inq, remaining } = scriptedInq(['', 'unused-1', 'unused-2']);
+    const entry = await authorCodeEval('exact_match', inq, []);
+    expect(entry).toBeNull();
+    expect(remaining()).toBe(2); // params/target prompts were never reached
+  });
+
+  it('rejects a duplicate id, then accepts a fresh one', async () => {
+    const existing: CodeEvalEntry[] = [{ id: 'taken', method: 'regex', params: { pattern: 'x' } }];
+    const { inq, rejections } = scriptedInq(['taken', 'fresh', '{"type":"object"}', 'output']);
+    const entry = await authorCodeEval('json_schema', inq, existing);
+    expect(entry?.id).toBe('fresh');
+    expect(rejections[0]?.reason).toMatch(/already exists/i);
+  });
+
+  it('trims the entered id', async () => {
+    const { inq } = scriptedInq(['  spaced-id  ', 'k', 'any', false, 'output']);
+    const entry = await authorCodeEval('must_contain', inq, []);
+    expect(entry?.id).toBe('spaced-id');
+  });
+});
+
+describe('collectCodeEvals', () => {
+  it('returns [] when the user skips immediately', async () => {
+    const { inq } = scriptedInq([CODE_EVAL_DONE]);
+    expect(await collectCodeEvals(inq)).toEqual([]);
+  });
+
+  it('collects multiple entries across methods until done', async () => {
+    const { inq } = scriptedInq([
+      // 1st: must_contain
+      'must_contain', 'has-music', 'song,track', 'any', false, 'output',
+      // 2nd: regex on input
+      'regex', 'looks-like-code', '[a-z]+', '', 'input',
+      // finish
+      CODE_EVAL_DONE,
+    ]);
+    const evals = await collectCodeEvals(inq);
+    expect(evals).toHaveLength(2);
+    expect(evals[0]).toEqual({
+      id: 'has-music',
+      method: 'must_contain',
+      params: { keywords: ['song', 'track'], mode: 'any', caseSensitive: false },
+    });
+    expect(evals[1]).toEqual({
+      id: 'looks-like-code',
+      method: 'regex',
+      params: { pattern: '[a-z]+' },
+      inputs: { output: 'input' },
+    });
+  });
+
+  it('a blank id mid-flow discards that check and returns to the menu (back)', async () => {
+    const { inq } = scriptedInq([
+      'exact_match', '', // start authoring, then go back (blank id)
+      'must_contain', 'kept', 'yes', 'any', false, 'output', // author a real one
+      CODE_EVAL_DONE,
+    ]);
+    const evals = await collectCodeEvals(inq);
+    expect(evals).toHaveLength(1);
+    expect(evals[0]?.id).toBe('kept');
+  });
+
+  it('collected entries are treated as existing for de-duplication of later ids', async () => {
+    const { inq, rejections } = scriptedInq([
+      'must_contain', 'dup', 'a', 'any', false, 'output',
+      'must_contain', 'dup', 'unique', 'b', 'any', false, 'output', // 'dup' rejected → 'unique'
+      CODE_EVAL_DONE,
+    ]);
+    const evals = await collectCodeEvals(inq);
+    expect(evals.map((e) => e.id)).toEqual(['dup', 'unique']);
+    expect(rejections.some((r) => /already exists/i.test(String(r.reason)))).toBe(true);
+  });
+});
+
+// Guards against a method being added to CodeCheckMethod without a params-collector
+// branch (the switch would fall through and return undefined).
+describe('coverage of all methods', () => {
+  const perMethodScript: Record<CodeCheckMethod, Array<string | boolean>> = {
+    must_contain: ['k', 'any', false],
+    must_not_contain: ['k', 'any', false],
+    exact_match: ['v', true, true],
+    regex: ['p', ''],
+    must_not_match: ['p', ''],
+    json_schema: ['{"type":"object"}'],
+  };
+
+  for (const method of Object.keys(perMethodScript) as CodeCheckMethod[]) {
+    it(`${method} yields a defined params object`, async () => {
+      const { inq } = scriptedInq(perMethodScript[method]);
+      const params = await collectCodeEvalParams(method, inq);
+      expect(params).toBeTypeOf('object');
+      expect(params).not.toBeNull();
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Surfaces two recently-added config capabilities in the interactive `dt-evals configure` wizard, which previously required hand-editing YAML:

1. **Scope level** — a `select` (agent-span / agent-session) so users can opt into session-level evaluation (grouped by `gen_ai.conversation.id`, falling back to trace id) without editing the file.
2. **Code evals (deterministic evals)** — a looping authoring menu that mirrors the LLM-judge evaluator list. Pick a method, fill in its mandatory fields, choose the span field to check, then return to the menu to add more or finish.

The metric checkbox is relabeled **"LLM-as-judge evaluators"** to distinguish it from the new code-evals section.

## Code evals flow

Menu of the six deterministic methods → per-method fields, each mapping 1:1 to an engine-honored param:

| Method | Fields collected |
|---|---|
| `must_contain` / `must_not_contain` | keywords (CSV), match mode any/all, case-sensitive |
| `exact_match` | expected output, case-sensitive, trim |
| `regex` / `must_not_match` | pattern, optional flags |
| `json_schema` | JSON object (validated on entry) |

Every entry also asks **which span field** to run against (output/input/context), written as `inputs.output` routing. Leaving the id blank discards the check and returns to the method list (**back**). Defaults match the engine's own defaults (`mode=any`, contains case-insensitive, exact-match case-sensitive).

Flag-only mode is unchanged — it preserves existing `scope.level` / metrics via the `existing` spread.

## Verification
- `npm run typecheck` — passes
- `npm run build` — passes (no `lint` script in this package)
- Every wizard option cross-checked against the deterministic engine (`contains.ts`, `exact-match.ts`, `regex.ts`, `json-schema.ts`) and the runner's `buildEvalInput`/`resolveCanonicalField` field routing — no dead options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
